### PR TITLE
fix: Remove base64 conversion

### DIFF
--- a/src/utils/harToProxyData.ts
+++ b/src/utils/harToProxyData.ts
@@ -38,7 +38,8 @@ function parseRequest(request: Entry['request']): Request {
 }
 
 function parseResponse(response: Entry['response']): Response {
-  const content = response.content?.text ? atob(response.content.text) : ''
+  const content = response.content?.text ?? ''
+
   return {
     statusCode: response.status,
     reason: response.statusText,


### PR DESCRIPTION
## Why
Removing general base64 conversion to be consistent across the application.

## How to test
Response preview should now work on the Generation and Validation view

## Notes
Alternatively we keep this and re-base64 media content