### PR TITLE
fix: Ensure content is base64 encoded for media

### DIFF
--- a/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
+++ b/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
@@ -1,5 +1,5 @@
 import { ProxyData } from '@/types'
-import { safeAtob, stringify } from '@/utils/format'
+import { isBase64, safeAtob, safeBtoa, stringify } from '@/utils/format'
 
 export function toFormat(contentType: string | undefined) {
   if (!contentType) {
@@ -59,7 +59,7 @@ export function parseContent(format: string | undefined, data: ProxyData) {
       case 'font':
       case 'image':
       case 'video':
-        return content
+        return !isBase64(content) ? safeBtoa(content) : content
       default:
         return
     }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -15,6 +15,22 @@ export function safeAtob(content: string) {
   }
 }
 
+export function safeBtoa(content: string) {
+  try {
+    return btoa(content)
+  } catch {
+    return content
+  }
+}
+
 export function stringify(obj: object) {
   return JSON.stringify(obj, null, 2)
+}
+
+export function isBase64(str: string) {
+  try {
+    return btoa(atob(str)) === str
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
Why
`Validator` content is base64 encoded but `Generator` content is not. We need to make sure the `WebLogView` handles the formatting for media content.

How to test
Media content should preview correctly on the Generation and Validation view