### PR TITLE
fix: Handle plaintext correctly

### DIFF
--- a/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
+++ b/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
@@ -33,7 +33,7 @@ export function toFormat(contentType: string | undefined) {
     case 'text/html':
       return 'html'
     case 'text/plain':
-      return 'plain'
+      return 'plaintext'
     default:
       return
   }
@@ -53,13 +53,13 @@ export function parseContent(format: string | undefined, data: ProxyData) {
       case 'css':
       case 'html':
       case 'javascript':
-      case 'plain':
-        return safeAtob(content)
+      case 'plaintext':
+        return isBase64(content) ? safeAtob(content) : content
       case 'audio':
       case 'font':
       case 'image':
       case 'video':
-        return !isBase64(content) ? safeBtoa(content) : content
+        return isBase64(content) ? content : safeBtoa(content)
       default:
         return
     }


### PR DESCRIPTION
This PR fixes how we handle `plaintext`

<img width="1419" alt="Screenshot 2024-07-30 at 16 36 45" src="https://github.com/user-attachments/assets/92019cf8-ce6c-4c42-8377-f730b1907b32">
