### PR TITLE
fix: preview form data payload in a table

### DIFF
--- a/src/components/WebLogView/RequestDetails/FormPayloadPreview.tsx
+++ b/src/components/WebLogView/RequestDetails/FormPayloadPreview.tsx
@@ -1,0 +1,31 @@
+import { safeJsonParse } from '@/utils/json'
+import { Table } from '@radix-ui/themes'
+
+export function FormPayloadPreview({
+  payloadJsonString,
+}: {
+  payloadJsonString: string
+}) {
+  const contentObject = safeJsonParse<Record<string, string>>(payloadJsonString)
+
+  return (
+    <Table.Root size="1" variant="surface">
+      <Table.Header>
+        <Table.Row>
+          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell>Value</Table.ColumnHeaderCell>
+        </Table.Row>
+      </Table.Header>
+
+      <Table.Body>
+        {contentObject &&
+          Object.entries(contentObject).map(([key, value]) => (
+            <Table.Row key={key}>
+              <Table.Cell>{key}</Table.Cell>
+              <Table.Cell>{value}</Table.Cell>
+            </Table.Row>
+          ))}
+      </Table.Body>
+    </Table.Root>
+  )
+}

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -4,9 +4,12 @@ import { ProxyData } from '@/types'
 
 import { ReadOnlyEditor } from '../../Monaco/ReadOnlyEditor'
 import { parseParams } from './utils'
+import { getContentType } from '@/utils/headers'
+import { FormPayloadPreview } from './FormPayloadPreview'
 
 export function Payload({ data }: { data: ProxyData }) {
   const content = parseParams(data)
+  const contentType = getContentType(data.request?.headers ?? [])
 
   if (!content) {
     return (
@@ -14,6 +17,10 @@ export function Payload({ data }: { data: ProxyData }) {
         Payload not available
       </Flex>
     )
+  }
+
+  if (contentType === 'application/x-www-form-urlencoded') {
+    return <FormPayloadPreview payloadJsonString={content} />
   }
 
   return <ReadOnlyEditor language="javascript" value={content} />

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -68,7 +68,7 @@ export const launchProxy = (
       return
     }
 
-    const proxyData: ProxyData = safeJsonParse(data)
+    const proxyData = safeJsonParse<ProxyData>(data)
     if (proxyData) {
       browserWindow.webContents.send('proxy:data', proxyData)
     }

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -32,7 +32,7 @@ export const setJsonObjectFromPath = (
   value: string
 ) => {
   const jsonObject = safeJsonParse(json)
-  set(jsonObject, path, value)
+  set(jsonObject ?? {}, path, value)
   return JSON.stringify(jsonObject)
 }
 

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,6 +1,6 @@
-export function safeJsonParse(value: string) {
+export function safeJsonParse<T extends object>(value: string) {
   try {
-    return JSON.parse(value)
+    return JSON.parse(value) as T
   } catch (error) {
     console.error('Failed to parse JSON', error)
     return undefined


### PR DESCRIPTION
Reported by Tom: 
> application/x-www-form-urlencoded POST data are being rendered as JSON in the payload tab. Ideally they would appear much like how we render headers i.e. table style

Render `x-www-form-urlencoded` payload as table

Before:

![CleanShot 2024-08-09 at 14 00 05@2x](https://github.com/user-attachments/assets/73323f8a-44f3-45ab-8b13-6a1e9cad297c)

After
![CleanShot 2024-08-09 at 13 48 38@2x](https://github.com/user-attachments/assets/aa87c88f-45df-4a6b-8dd8-0a5506fa44f2)
