### PR TITLE
feat: Group request URL with http.url

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -35,6 +35,7 @@ describe('Code generation', () => {
         let resp
         let match
         let regex
+        let url
         sleep(1)
       }
       `
@@ -128,7 +129,8 @@ describe('Code generation', () => {
 
       const expectedResult = `
         params = { headers: {}, cookies: {} }
-        resp = http.request('GET', \`/api/v1/users\`, null, params)
+        url = http.url\`/api/v1/users\`
+        resp = http.request('GET', url, null, params)
       `
 
       expect(
@@ -169,17 +171,21 @@ describe('Code generation', () => {
 
       const expectedResult = `
         params = { headers: {}, cookies: {} }
-        resp = http.request('POST', \`http://test.k6.io/api/v1/foo\`, null, params)
+        url = http.url\`http://test.k6.io/api/v1/foo\`
+        resp = http.request('POST', url, null, params)
 
         params = { headers: {}, cookies: {} }
-        resp = http.request('POST', \`http://test.k6.io/api/v1/login\`, null, params)
+        url = http.url\`http://test.k6.io/api/v1/login\`
+        resp = http.request('POST', url, null, params)
         let correl_0 = resp.json().user_id
 
         params = { headers: {}, cookies: {} }
-        resp = http.request('GET', \`http://test.k6.io/api/v1/users/\${correl_0}\`, null, params)
+        url = http.url\`http://test.k6.io/api/v1/users/\${correl_0}\`
+        resp = http.request('GET', url, null, params)
 
         params = { headers: {}, cookies: {} }
-        resp = http.request('POST', \`http://test.k6.io/api/v1/users\`, \`${JSON.stringify({ user_id: '${correl_0}' })}\`, params)
+        url = http.url\`http://test.k6.io/api/v1/users\`
+        resp = http.request('POST', url, \`${JSON.stringify({ user_id: '${correl_0}' })}\`, params)
 
       `
 

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -75,6 +75,7 @@ export function generateVUCode(
     let resp
     let match
     let regex
+    let url
     `,
     groupSnippets,
     thinkTime.sleepType === 'iterations' ? generateSleep(thinkTime.timing) : '',
@@ -147,7 +148,8 @@ export function generateSingleRequestSnippet(
   const params = `params = ${generateRequestParams(request)}`
 
   const main = `
-    resp = http.request(${method}, ${url}, ${content}, params)
+    url = http.url${url}
+    resp = http.request(${method}, url, ${content}, params)
   `
 
   return [params, ...before, main, ...after].join('\n')


### PR DESCRIPTION
This PR ensures all requests generated in the script are grouped with the [http.url](https://grafana.com/docs/k6/latest/javascript-api/k6-http/url/#returns) method.

Ticket: https://github.com/grafana/k6-cloud/issues/2528

## What to test

- In k6 studio, create a correlation rule
- Preview or export the script
- Check that all URLs, including the correlation is wrapped in the `http.url` method