### PR TITLE
fix: Window title not updating after selecting an external script

### DIFF
--- a/src/views/Validator/Validator.tsx
+++ b/src/views/Validator/Validator.tsx
@@ -36,7 +36,8 @@ export function Validator() {
       (await window.studio.script.showScriptSelectDialog()) || {}
     setScriptPath(path)
     setScript(content)
-  }, [])
+    navigate(getRoutePath('validator', { path: encodeURIComponent(path) }))
+  }, [navigate])
 
   useEffect(() => {
     if (!paramScriptPath) {


### PR DESCRIPTION
This PR fixes the window title not being updated after an external script is selected.

Ticket: https://github.com/grafana/k6-cloud/issues/2671

## What to test

- From the home screen, select "Validate script"
- Open the context menu on the top right corner, and click "Select script"
- Check that the window title now shows the script name


https://github.com/user-attachments/assets/cb25fa4c-1ec4-4ff0-af94-a692f86f85c6



