### PR TITLE
fix: improve generated js for correlation

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -177,15 +177,15 @@ describe('Code generation', () => {
         params = { headers: {}, cookies: {} }
         url = http.url\`http://test.k6.io/api/v1/login\`
         resp = http.request('POST', url, null, params)
-        correlation_vars[0] = resp.json().user_id
+        correlation_vars['correlation_0'] = resp.json().user_id
 
         params = { headers: {}, cookies: {} }
-        url = http.url\`http://test.k6.io/api/v1/users/\${correlation_vars[0]}\`
+        url = http.url\`http://test.k6.io/api/v1/users/\${correlation_vars['correlation_0']}\`
         resp = http.request('GET', url, null, params)
 
         params = { headers: {}, cookies: {} }
         url = http.url\`http://test.k6.io/api/v1/users\`
-        resp = http.request('POST', url, \`${JSON.stringify({ user_id: '${correlation_vars[0]}' })}\`, params)
+        resp = http.request('POST', url, \`${JSON.stringify({ user_id: "${correlation_vars['correlation_0']}" })}\`, params)
 
       `
 

--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -209,7 +209,7 @@ const extractCorrelationRegex = (
 
 const getCorrelationVariableSnippet = (uniqueId: number) => {
   return `if (match) {
-      correlation_vars[${uniqueId}] = match[1]
+      correlation_vars['correlation_${uniqueId}'] = match[1]
     }`
 }
 
@@ -459,7 +459,7 @@ const extractCorrelationJsonBody = (
     : `.${selector.path}`
 
   const correlationExtractionSnippet = `
-correlation_vars[${generatedUniqueId}] = resp.json()${json_path}`
+correlation_vars['correlation_${generatedUniqueId}'] = resp.json()${json_path}`
   return {
     extractedValue,
     correlationExtractionSnippet,
@@ -517,7 +517,7 @@ if (import.meta.vitest) {
     }
 
     const correlationExtractionSnippet = `
-correlation_vars[1] = resp.json().user_id`
+correlation_vars['correlation_1'] = resp.json().user_id`
     const expectedResult = {
       extractedValue: '444',
       correlationExtractionSnippet,
@@ -544,7 +544,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.begin}(.*?)${selector.end}')
     match = resp.body.match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: 'bob',
@@ -577,7 +577,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.begin}(.*?)${selector.end}')
     match = resp.headers["${canonicalHeaderKey('Content-type')}"].match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: '/',
@@ -610,7 +610,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.begin}(.*?)${selector.end}')
     match = resp.url.match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: 'v1',
@@ -637,7 +637,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.regex}')
     match = resp.body.match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: 'bob',
@@ -664,7 +664,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.regex}')
     match = resp.headers["${canonicalHeaderKey('Content-type')}"].match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: '/',
@@ -696,7 +696,7 @@ correlation_vars[1] = resp.json().user_id`
     regex = new RegExp('${selector.regex}')
     match = resp.url.match(regex)
     if (match) {
-      correlation_vars[1] = match[1]
+      correlation_vars['correlation_1'] = match[1]
     }`
     const expectedResult = {
       extractedValue: 'v1',

--- a/src/rules/correlation.utils.ts
+++ b/src/rules/correlation.utils.ts
@@ -31,7 +31,7 @@ export function replaceCorrelatedValues({
     return replaceTextMatches(
       request,
       extractedValue,
-      `correlation_vars[${uniqueId}]`
+      `correlation_vars['correlation_${uniqueId}']`
     )
   }
 
@@ -40,19 +40,19 @@ export function replaceCorrelatedValues({
       return replaceBeginEnd(
         rule.replacer.selector,
         request,
-        `correlation_vars[${uniqueId}]`
+        `correlation_vars['correlation_${uniqueId}']`
       )
     case 'regex':
       return replaceRegex(
         rule.replacer.selector,
         request,
-        `correlation_vars[${uniqueId}]`
+        `correlation_vars['correlation_${uniqueId}']`
       )
     case 'json':
       return replaceJsonBody(
         rule.replacer.selector,
         request,
-        `correlation_vars[${uniqueId}]`
+        `correlation_vars['correlation_${uniqueId}']`
       )
     default:
       return exhaustive(rule.replacer.selector)


### PR DESCRIPTION
Make the js code generator for correlation idiomatic.

`correlation_vars[0]` -> `correlation_vars['correlation_0']`