### PR TITLE
fix: remove spaces from json raw

### DIFF
--- a/src/components/WebLogView/ResponseDetails/Content.tsx
+++ b/src/components/WebLogView/ResponseDetails/Content.tsx
@@ -14,6 +14,8 @@ export function Content({ data }: { data: ProxyData }) {
   const contentType = getContentType(data.response?.headers ?? [])
   const format = toFormat(contentType)
   const content = parseContent(format, data)
+  const rawFormat = format === 'json' ? 'json-raw' : format
+  const rawContent = parseContent(rawFormat, data)
 
   if (!contentType || !content || !format) {
     return (
@@ -53,7 +55,7 @@ export function Content({ data }: { data: ProxyData }) {
       <ScrollArea style={{ height: '100%' }}>
         <Box px="4" height="100%">
           {selectedTab === 'preview' && <Preview {...contentProps} />}
-          {selectedTab === 'raw' && <Raw {...contentProps} />}
+          {selectedTab === 'raw' && <Raw content={rawContent ?? ''} />}
           {selectedTab === 'content' && <OriginalContent {...contentProps} />}
         </Box>
       </ScrollArea>

--- a/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
+++ b/src/components/WebLogView/ResponseDetails/ResponseDetails.utils.ts
@@ -50,6 +50,8 @@ export function parseContent(format: string | undefined, data: ProxyData) {
     switch (format) {
       case 'json':
         return stringify(JSON.parse(safeAtob(content)))
+      case 'json-raw':
+        return stringify(JSON.parse(safeAtob(content)), 0)
       case 'css':
       case 'html':
       case 'javascript':

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -23,8 +23,8 @@ export function safeBtoa(content: string) {
   }
 }
 
-export function stringify(obj: object) {
-  return JSON.stringify(obj, null, 2)
+export function stringify(obj: object, space: number = 2) {
+  return JSON.stringify(obj, null, space)
 }
 
 export function isBase64(str: string) {


### PR DESCRIPTION
This PR removes spaces between attributes of a JSON that was being displayed in the raw version.

Before:

```json
{ "key": "value", "array": [ 1, 2, 3, 4 ] }
```

After:

```json
{"key":"value","array":[1,2,3,4]}
```

- Inspect a JSON response
- Check that the Raw tab doesn't contain spaces between properties for JSON content
- Check that no functional changes affect the Raw tab for other content types such as HTML 

<img width="576" alt="image" src="https://github.com/user-attachments/assets/c70c762a-a1a0-445d-825b-a69764a8cfab">
