### PR TITLE
fix: test variables failing with objects

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -46,7 +46,7 @@ export function generateVariableDeclarations(variables: Variable[]): string {
 
   const variables_lines = variables
     .filter(({ name }) => name)
-    .map(({ name, value }) => `"${name}": "${value}",`)
+    .map(({ name, value }) => `"${name}": ${JSON.stringify(value)},`)
     .join('\n')
 
   return `const VARS = {\n${variables_lines}\n}\n`


### PR DESCRIPTION
Make use of `JSON.stringify()` to escape characters and create a valid string from any input