### PR TITLE
fix: Allowlist showing up when hosts are selected

### DIFF
--- a/src/store/generator/slices/recording.ts
+++ b/src/store/generator/slices/recording.ts
@@ -28,7 +28,6 @@ export const createRecordingSlice: ImmerStateCreator<RecordingSliceStore> = (
   setRecording: (requests: ProxyData[], path: string) =>
     set((state) => {
       state.requests = requests
-      state.allowlist = []
       state.recordingPath = path
     }),
   resetRecording: () =>

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -7,7 +7,7 @@ import { ProxyData } from '@/types'
 import { AllowlistDialog } from './AllowlistDialog'
 import { usePrevious } from 'react-use'
 
-export function Allowlist() {
+export function Allowlist({ isLoading }: { isLoading: boolean }) {
   const requests = useGeneratorStore((store) => store.requests)
   const hasRecording = useGeneratorStore(
     (store) => !!store.recordingPath && store.requests.length > 0
@@ -45,8 +45,8 @@ export function Allowlist() {
       return true
     }
 
-    return newHostsDetected
-  }, [allowlist, hasRecording, newHostsDetected])
+    return !isLoading && newHostsDetected
+  }, [allowlist, hasRecording, newHostsDetected, isLoading])
 
   useEffect(() => {
     if (shouldResetAllowList) {

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -21,7 +21,7 @@ export function Generator() {
       actions={
         <>
           <RecordingSelector />
-          <Allowlist />
+          <Allowlist isLoading={isLoading} />
           <Button onClick={onSave}>Save</Button>
           {hasRecording && (
             <Button onClick={exportScript}>Export script</Button>


### PR DESCRIPTION
Fixes the bug when allowlist dialog was displayed when opening generator with previously saved allowlist.

How to test:

1. Create a new generator from recording
2. Verify allowlist is displayed
3. Select at least one host, save generator file
4. Navigate away from generator
5. Navigate back to generator
6. Verify allowlist was not displayed.