### PR TITLE
fix: remove unneeded headers

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -174,8 +174,15 @@ function generateSleep(timing: ThinkTime['timing']): string {
 }
 
 function generateRequestParams(request: ProxyData['request']): string {
+  const headersToExclude = [
+    'Cookie',
+    'User-Agent',
+    'Host',
+    'Content-Length',
+    'Content-Type',
+  ]
   const headers = request.headers
-    .filter(([name]) => name !== 'Cookie')
+    .filter(([name]) => !headersToExclude.includes(name))
     .map(([name, value]) => `'${name}': \`${value}\``)
     .join(',')
   return `


### PR DESCRIPTION
These headers are auto-populated by k6 so we don't need to include them