### PR TITLE
fix: Use jsonrepair to parse potentially broken json payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "chokidar": "^3.6.0",
         "electron-squirrel-startup": "^1.0.1",
         "immer": "^10.1.1",
+        "jsonrepair": "^3.8.0",
         "lodash-es": "^4.17.21",
         "monaco-editor": "^0.50.0",
         "node-forge": "^1.3.1",
@@ -10287,6 +10288,14 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.8.0.tgz",
+      "integrity": "sha512-89lrxpwp+IEcJ6kwglF0HH3Tl17J08JEpYfXnvvjdp4zV4rjSoGu2NdQHxBs7yTOk3ETjTn9du48pBy8iBqj1w==",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "chokidar": "^3.6.0",
     "electron-squirrel-startup": "^1.0.1",
     "immer": "^10.1.1",
+    "jsonrepair": "^3.8.0",
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.50.0",
     "node-forge": "^1.3.1",

--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -1,6 +1,7 @@
 import { ProxyData } from '@/types'
 import { safeAtob, stringify } from '@/utils/format'
 import { getContentType } from '@/utils/headers'
+import { jsonrepair } from 'jsonrepair'
 
 export function parseParams(data: ProxyData) {
   const hasParams = data.request.query.length || data.request.content
@@ -17,7 +18,9 @@ export function parseParams(data: ProxyData) {
     }
 
     return stringify(
-      JSON.parse(parsePythonByteString(safeAtob(data.request.content ?? '')))
+      JSON.parse(
+        jsonrepair(parsePythonByteString(safeAtob(data.request.content ?? '')))
+      )
     )
   } catch (e) {
     console.error('Failed to parse query parameters', e)


### PR DESCRIPTION
Add jsonrepair to automatically fix JSON issues when parsing potentially broken payload. 