### PR TITLE
fix: Keep inspector open when editing rule

### DIFF
--- a/src/views/Generator/GeneratorSidebar/RequestList.tsx
+++ b/src/views/Generator/GeneratorSidebar/RequestList.tsx
@@ -1,10 +1,11 @@
 import { ScrollArea } from '@radix-ui/themes'
 import { Allotment } from 'allotment'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { WebLogView } from '@/components/WebLogView'
 import { ProxyData } from '@/types'
 import { Details } from '@/components/WebLogView/Details'
+import { useShallowCompareEffect } from 'react-use'
 
 interface RequestListProps {
   requests: ProxyData[]
@@ -13,7 +14,8 @@ interface RequestListProps {
 export function RequestList({ requests }: RequestListProps) {
   const [selectedRequest, setSelectedRequest] = useState<ProxyData | null>(null)
 
-  useEffect(() => {
+  // Preserve the selected request when modifiying rules
+  useShallowCompareEffect(() => {
     setSelectedRequest(null)
   }, [requests])
 


### PR DESCRIPTION
This fixes a bug where request inspector would close when editing a rule.

1. Open generator
2. Create a rule
3. Click on a request to open inspector
4. Edit rule property (filer, selectors)
5. Verify inspector is still open