### PR TITLE
fix: Groups can be added with the same name

### DIFF
--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -26,7 +26,7 @@ import TextSpinner from '@/components/TextSpinner/TextSpinner'
 
 export function Recorder() {
   const [selectedRequest, setSelectedRequest] = useState<ProxyData | null>(null)
-  const [group, setGroup] = useState<string>('Default')
+  const [group, setGroup] = useState('Default')
   const { proxyData, resetProxyData } = useListenProxyData(group)
   const [recorderState, setRecorderState] = useState<RecorderState>('idle')
   const showToast = useToast()
@@ -162,7 +162,11 @@ export function Recorder() {
         <Allotment.Pane minSize={200}>
           <Flex direction="column" height="100%">
             <Flex justify="between" wrap="wrap" gap="2" p="2" flexShrink="0">
-              <GroupForm onChange={setGroup} value={group} />
+              <GroupForm
+                currentGroup={group}
+                proxyData={proxyData}
+                onChange={setGroup}
+              />
 
               <DebugControls />
             </Flex>


### PR DESCRIPTION
This PR fixes an issue where you could add multiple groups with the same name. This really messed up the recording because we use group requests by the name, meaning that later requests could appear before earlier request. 

The bug can be seen in this video:

https://github.com/user-attachments/assets/bf70d8ff-81d7-4633-9f05-aaa075ec85eb

We now check to see if the given name is already in use and disallow the user from adding the group if the name is already taken.

## How to test

1. Start a recording
2. Try to add group without name
3. Add group with new name
4. Try to add group with already existing name