### PR TITLE
fix: url parts missing forward slash

### DIFF
--- a/src/components/WebLogView/WebLogView.utils.test.ts
+++ b/src/components/WebLogView/WebLogView.utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  removeHostFromUrl,
+  removeProtocolFromUrl,
+  removeQueryStringFromUrl,
+} from './WebLogView.utils'
+
+describe('WebLogView.utils', () => {
+  it('should remove the host from the URL', () => {
+    const url = 'example.com/path/to/resource'
+    expect(removeHostFromUrl(url)).toBe('path/to/resource')
+  })
+
+  it('should remove the protocol from the URL', () => {
+    const url = 'https://example.com/path/to/resource'
+    expect(removeProtocolFromUrl(url)).toBe('example.com/path/to/resource')
+  })
+
+  it('should remove the query string from the URL', () => {
+    const url = 'https://example.com/path/to/resource?query=string'
+    expect(removeQueryStringFromUrl(url)).toBe(
+      'https://example.com/path/to/resource'
+    )
+  })
+})

--- a/src/components/WebLogView/WebLogView.utils.ts
+++ b/src/components/WebLogView/WebLogView.utils.ts
@@ -12,7 +12,7 @@ export function removeHostFromUrl(url?: string) {
   if (!url) return ''
 
   const [, ...path] = url.split('/')
-  return path
+  return path.join('/')
 }
 
 export function isGroupedProxyData(


### PR DESCRIPTION
This PR fixes the request list where the URL path was missing `/` between paths

Before:

![image](https://github.com/user-attachments/assets/0296e19b-ddeb-4994-b123-bc029aaee55b)


After:

![image](https://github.com/user-attachments/assets/4713a3c7-4ae7-4158-9afd-39d5eec0c01d)
