### PR TITLE
fix: allow script name to contain dot character

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -68,7 +68,7 @@ describe('Code generation', () => {
             rules: [],
             allowlist: [],
             includeStaticAssets: false,
-            scriptName: 'my-script',
+            scriptName: 'my-script.js',
           },
         }).replace(/\s/g, '')
       ).toBe(expectedResult.replace(/\s/g, ''))

--- a/src/schemas/exportScript.ts
+++ b/src/schemas/exportScript.ts
@@ -4,7 +4,7 @@ export const ExportScriptDialogSchema = z.object({
   scriptName: z
     .string()
     .min(1, { message: 'Required' })
-    .regex(/^[\w,\s-]+$/, { message: 'Invalid name' }),
+    .regex(/^[\w,.\s-]+$/, { message: 'Invalid name' }),
   overwriteFile: z.boolean().default(false),
 })
 

--- a/src/schemas/generator.ts
+++ b/src/schemas/generator.ts
@@ -11,5 +11,5 @@ export const GeneratorFileDataSchema = z.object({
   rules: TestRuleSchema.array(),
   allowlist: z.string().array(),
   includeStaticAssets: z.boolean(),
-  scriptName: z.string().default('my-script'),
+  scriptName: z.string().default('my-script.js'),
 })

--- a/src/store/generator/slices/script.ts
+++ b/src/store/generator/slices/script.ts
@@ -13,7 +13,7 @@ export type ScriptDataStore = State & Actions
 export const createScriptDataSlice: ImmerStateCreator<ScriptDataStore> = (
   set
 ) => ({
-  scriptName: 'my-script',
+  scriptName: 'my-script.js',
 
   setScriptName: (scriptName: string) =>
     set((state) => {

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -25,7 +25,7 @@ export function createNewGeneratorFile(recordingPath = ''): GeneratorFileData {
     rules: [createEmptyRule('verification')],
     allowlist: [],
     includeStaticAssets: false,
-    scriptName: 'my-script',
+    scriptName: 'my-script.js',
   }
 }
 

--- a/src/views/Generator/ExportScriptDialog/ExportScriptDialog.tsx
+++ b/src/views/Generator/ExportScriptDialog/ExportScriptDialog.tsx
@@ -17,6 +17,7 @@ import {
   useUpdateValueInGeneratorFile,
 } from '../Generator.hooks'
 import { useToast } from '@/store/ui/useToast'
+import { getScriptNameWithExtension } from './ExportScriptDialog.utils'
 
 export function ExportScriptDialog({
   open,
@@ -54,16 +55,16 @@ export function ExportScriptDialog({
 
   const onSubmit = async (data: ExportScriptDialogData) => {
     try {
-      const { scriptName: name, overwriteFile } = data
-      const fileName = `${name}.js`
+      const { scriptName: userInput, overwriteFile } = data
+      const fileName = getScriptNameWithExtension(userInput)
       const fileExists = await scriptExists(fileName)
       if (fileExists && !overwriteFile && !alwaysOverwriteScript) {
         setValue('overwriteFile', true)
         return
       }
 
-      await updateGeneratorFile({ key: 'scriptName', value: name })
-      setScriptName(name)
+      await updateGeneratorFile({ key: 'scriptName', value: fileName })
+      setScriptName(fileName)
       onExport(fileName)
       onOpenChange(false)
     } catch (error) {

--- a/src/views/Generator/ExportScriptDialog/ExportScriptDialog.utils.ts
+++ b/src/views/Generator/ExportScriptDialog/ExportScriptDialog.utils.ts
@@ -1,0 +1,3 @@
+export function getScriptNameWithExtension(scriptName: string) {
+  return scriptName.endsWith('.js') ? scriptName : `${scriptName}.js`
+}

--- a/src/views/Generator/ExportScriptDialog/OverwriteFileWarning.tsx
+++ b/src/views/Generator/ExportScriptDialog/OverwriteFileWarning.tsx
@@ -1,5 +1,6 @@
 import { Code, Flex, Button, AlertDialog } from '@radix-ui/themes'
 import { useFormContext } from 'react-hook-form'
+import { getScriptNameWithExtension } from './ExportScriptDialog.utils'
 
 export function OverwriteFileWarning() {
   const { getValues, setValue } = useFormContext()
@@ -8,11 +9,13 @@ export function OverwriteFileWarning() {
     setValue('overwriteFile', false)
   }
 
+  const scriptName = getScriptNameWithExtension(getValues('scriptName'))
+
   return (
     <>
       <AlertDialog.Description size="2" mb="4">
-        A script named <Code>{getValues('scriptName')}</Code> already exists. Do
-        you want to overwrite it?
+        A script named <Code>{scriptName}</Code> already exists. Do you want to
+        overwrite it?
       </AlertDialog.Description>
 
       <Flex justify="end" gap="2">

--- a/src/views/Generator/ExportScriptDialog/ScriptNameForm.tsx
+++ b/src/views/Generator/ExportScriptDialog/ScriptNameForm.tsx
@@ -34,7 +34,10 @@ export function ScriptNameForm({
 
       <Box>
         <FieldGroup name="scriptName" label="Script name" errors={errors}>
-          <TextField.Root placeholder="my-script" {...register('scriptName')} />
+          <TextField.Root
+            placeholder="my-script.js"
+            {...register('scriptName')}
+          />
         </FieldGroup>
       </Box>
 


### PR DESCRIPTION
As feedback from the test session, we'd like to allow users to input `.` in the script name. With that in mind, this PR makes sure the exported script always contains the `.js` extension.

https://github.com/user-attachments/assets/ce538309-276b-423d-a826-9559c765515e

