### PR TITLE
fix: scripts and generators not showing up in sidebar when created on Windows

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -114,7 +114,7 @@ const createWindow = async () => {
 
 app.whenReady().then(async () => {
   const mainWindow = await createWindow()
-  setupProjectStructure()
+  await setupProjectStructure()
 
   watcher = watch([RECORDINGS_PATH, GENERATORS_PATH, SCRIPTS_PATH], {
     ignoreInitial: true,


### PR DESCRIPTION
During a test session on Windows, we noticed that scripts were not showing up in the sidebar after being exported.

This happens because of a race condition between creating the project directories (`Scripts`, `Generators`, `Recordings`) and starting watching them with `chokidar` before they exist.

https://github.com/grafana/k6-studio/blob/e92765e0c4a9fdf67b782fd7c6b4fa430c3de56c/src/main.ts#L117-L119

A similar issue was reported https://github.com/paulmillr/chokidar/issues/346

Fixing the race condition addressed the issue.

## How to test

- Stop any running instances of k6 studio
- Delete the `Documents/k6-studio` directory
- Start an instance of k6 studio
- Check that files show up in the sidebar as they get created

## Before 

Generator and scripts don't show up in the sidebar after first launch

https://github.com/user-attachments/assets/a78b809b-9dc2-4952-93a7-14546e5b6bec

## After 

Files show up in the sidebar as they get created after first launch

https://github.com/user-attachments/assets/6f54559a-f379-4ae2-98d4-a5106a828168