### PR TITLE
fix: Show create group button after clearing recording

### DIFF
--- a/src/components/WebLogView/WebLogView.tsx
+++ b/src/components/WebLogView/WebLogView.tsx
@@ -4,14 +4,12 @@ import { Group as GroupType, ProxyData } from '@/types'
 import { Row } from './Row'
 import { Group } from './Group'
 import { Table } from '@/components/Table'
-import { NoRequestsMessage } from '../NoRequestsMessage'
 
 interface WebLogViewProps {
   requests: ProxyData[]
   groups?: GroupType[]
   activeGroup?: string
   selectedRequestId?: string
-  noRequestsMessage?: string
   onSelectRequest: (data: ProxyData | null) => void
   onUpdateGroup?: (group: GroupType) => void
 }
@@ -22,12 +20,7 @@ export function WebLogView({
   selectedRequestId,
   onSelectRequest,
   onUpdateGroup,
-  noRequestsMessage,
 }: WebLogViewProps) {
-  if (requests.length === 0) {
-    return <NoRequestsMessage noRequestsMessage={noRequestsMessage} />
-  }
-
   if (groups !== undefined) {
     const grouped = groups.map((group) => {
       return {

--- a/src/views/Generator/GeneratorSidebar/RequestList.tsx
+++ b/src/views/Generator/GeneratorSidebar/RequestList.tsx
@@ -51,7 +51,6 @@ export function RequestList({ requests }: RequestListProps) {
                 requests={filteredRequests}
                 selectedRequestId={selectedRequest?.id}
                 onSelectRequest={setSelectedRequest}
-                noRequestsMessage="No requests matched the filter."
               />
             </ScrollArea>
           </Allotment.Pane>

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -217,7 +217,7 @@ export function Recorder() {
                 resetProxyData={handleResetRecording}
               />
             </div>
-            {recorderState === 'recording' && proxyData.length > 0 && (
+            {recorderState === 'recording' && (
               <Box width="200px" p="2">
                 <Button
                   size="2"

--- a/src/views/Recorder/RequestsSection.tsx
+++ b/src/views/Recorder/RequestsSection.tsx
@@ -95,9 +95,6 @@ export function RequestsSection({
             selectedRequestId={selectedRequestId}
             onSelectRequest={onSelectRequest}
             onUpdateGroup={onUpdateGroup}
-            noRequestsMessage={
-              filter !== '' ? 'No requests matched the filter.' : undefined
-            }
           />
         </div>
       </ScrollArea>


### PR DESCRIPTION
I've removed the NoRequestsMessage from weblog view because it doesn't work well with groups after clearing recording - you can't see group are you creating. The empty table should be a clear indicator that there are no requests or non matched the filter, but let me know if you think otherwise. 

Before:

![CleanShot 2024-09-23 at 11 04 24](https://github.com/user-attachments/assets/2d921f47-7e9d-4299-9a36-bf250226bcae)

After:

![CleanShot 2024-09-23 at 11 07 25](https://github.com/user-attachments/assets/66453700-9b6f-485b-a094-40a05e5d7995)
