### PR TITLE
fix: use equal spacing between generator options buttons

### DIFF
--- a/src/views/Generator/NewRuleMenu.tsx
+++ b/src/views/Generator/NewRuleMenu.tsx
@@ -25,7 +25,7 @@ export function NewRuleMenu(props: ComponentProps<typeof Button>) {
   return (
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
-        <Button variant="ghost" size="1" color="gray" mr="2" {...props}>
+        <Button variant="ghost" size="1" color="gray" {...props}>
           <PlusCircledIcon />
           Add rule
         </Button>

--- a/src/views/Generator/TestRuleContainer/TestRuleContainer.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRuleContainer.tsx
@@ -35,9 +35,11 @@ export function TestRuleContainer() {
         >
           Test rules ({rules.length})
         </Heading>
-        <NewRuleMenu />
-        <TestOptions />
-        <Allowlist />
+        <Flex gap="3">
+          <NewRuleMenu />
+          <TestOptions />
+          <Allowlist />
+        </Flex>
       </Flex>
 
       <SortableRuleList rules={rules} onSwapRules={swapRules} />


### PR DESCRIPTION
Before:

![CleanShot 2024-09-24 at 09 40 38](https://github.com/user-attachments/assets/11b8d921-0f62-43af-8a69-8e11b02b0a40)

After:

![CleanShot 2024-09-24 at 09 40 28](https://github.com/user-attachments/assets/4677dd17-ea8b-4c07-8f92-7b40f7e2a824)
