### PR TITLE
fix: Requests falsely treated as static assets

### DIFF
--- a/src/components/WebLogView/Row.tsx
+++ b/src/components/WebLogView/Row.tsx
@@ -4,7 +4,6 @@ import { ProxyData } from '@/types'
 
 import { MethodBadge } from '../MethodBadge'
 import { ResponseStatusBadge } from '../ResponseStatusBadge'
-import { removeHostFromUrl, removeProtocolFromUrl } from './WebLogView.utils'
 import { TableCellWithTooltip } from '../TableCellWithTooltip'
 
 interface RowProps {
@@ -14,10 +13,6 @@ interface RowProps {
 }
 
 export function Row({ data, isSelected, onSelectRequest }: RowProps) {
-  const pathAndQuery = removeHostFromUrl(
-    removeProtocolFromUrl(data.request.url)
-  )
-
   return (
     <Table.Row
       onClick={() => onSelectRequest(data)}
@@ -48,7 +43,7 @@ export function Row({ data, isSelected, onSelectRequest }: RowProps) {
         <ResponseStatusBadge status={data.response?.statusCode} />
       </Table.Cell>
       <TableCellWithTooltip>{data.request.host}</TableCellWithTooltip>
-      <TableCellWithTooltip>/{pathAndQuery}</TableCellWithTooltip>
+      <TableCellWithTooltip>{data.request.path}</TableCellWithTooltip>
     </Table.Row>
   )
 }

--- a/src/utils/harToProxyData.ts
+++ b/src/utils/harToProxyData.ts
@@ -47,7 +47,7 @@ function parseRequest(request: Entry['request']): Request {
     timestampEnd: 0,
     scheme: url.protocol.replace(':', ''),
     host: url.hostname,
-    path: url.pathname,
+    path: url.pathname + url.search,
     contentLength: content.length,
   }
 }

--- a/src/utils/staticAssets.ts
+++ b/src/utils/staticAssets.ts
@@ -3,14 +3,15 @@ import { getContentType } from './headers'
 
 export function isNonStaticAssetResponse(data: ProxyData) {
   const contentType = getContentType(data?.response?.headers ?? [])
+  const pathWithoutQuery = data.request.path.split('?')[0] ?? '/'
 
   if (!contentType) {
-    return !isURLStaticAsset(data.request.path)
+    return !isURLStaticAsset(pathWithoutQuery)
   }
 
   return (
     NON_STATIC_ASSET_MIME_TYPES.includes(contentType) &&
-    !isURLStaticAsset(data.request.path)
+    !isURLStaticAsset(pathWithoutQuery)
   )
 }
 


### PR DESCRIPTION
This PR fixes 2 issues:

1. Inconsistency of URL path between data from proxy and loaded har file: proxy would return path including query params, while `harToProxyData` returned path only. 
2. The `isNonStaticAssetResponse` not striping query params from path and falsely treating URLs as static assets, for example: test.k6.io/home?foo=bar.js


How to test:

- Use the attached har file to verify the request to `https://test.k6.io/?foo=bar.js` is no longer treated as a static asset.
- Create a generator and verify it's not treated as static assets in Validator either

[2024-09-25_06-32-30.har.zip](https://github.com/user-attachments/files/17126179/2024-09-25_06-32-30.har.zip)
