### PR TITLE
fix: Inspect requests matched by correlation

### DIFF
--- a/src/components/WebLogView/Details.tsx
+++ b/src/components/WebLogView/Details.tsx
@@ -48,7 +48,7 @@ export function Details({ selectedRequest, onSelectRequest }: DetailsProps) {
                 <RequestDetails data={selectedRequest} />
               </PaneContent>
             </Allotment.Pane>
-            <Allotment.Pane minSize={200}>
+            <Allotment.Pane minSize={200} visible={!!selectedRequest.response}>
               <PaneContent heading="Response">
                 <ResponseDetails data={selectedRequest} />
               </PaneContent>

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -14,7 +14,7 @@ export function Payload({ data }: { data: ProxyData }) {
 
   if (!content) {
     return (
-      <Flex height="100%" justify="center" align="center">
+      <Flex height="200px" justify="center" align="center">
         No payload
       </Flex>
     )

--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -6,7 +6,7 @@ import { jsonrepair } from 'jsonrepair'
 export function parseParams(data: ProxyData) {
   const hasParams = data.request.query.length || data.request.content
 
-  if (data.request.method === 'OPTIONS' || !data.response || !hasParams) {
+  if (data.request.method === 'OPTIONS' || !hasParams) {
     return
   }
 

--- a/src/components/WebLogView/WebLogView.tsx
+++ b/src/components/WebLogView/WebLogView.tsx
@@ -4,6 +4,8 @@ import { Group as GroupType, ProxyData } from '@/types'
 import { Row } from './Row'
 import { Group } from './Group'
 import { Table } from '@/components/Table'
+import { useMemo } from 'react'
+import { useDeepCompareEffect } from 'react-use'
 
 interface WebLogViewProps {
   requests: ProxyData[]
@@ -21,6 +23,20 @@ export function WebLogView({
   onSelectRequest,
   onUpdateGroup,
 }: WebLogViewProps) {
+  const selectedRequest = useMemo(
+    () => requests.find((data) => data.id === selectedRequestId),
+    [requests, selectedRequestId]
+  )
+
+  // Sync selectedRequest when requests change to show updates in correlation preview
+  useDeepCompareEffect(() => {
+    if (!selectedRequest) {
+      return
+    }
+
+    onSelectRequest(selectedRequest)
+  }, [selectedRequest, onSelectRequest])
+
   if (groups !== undefined) {
     const grouped = groups.map((group) => {
       return {

--- a/src/views/Generator/RulePreview/CorrelationPreview.tsx
+++ b/src/views/Generator/RulePreview/CorrelationPreview.tsx
@@ -49,6 +49,7 @@ export function CorrelationPreview({ rule }: { rule: CorrelationRule }) {
                   <WebLogView
                     requests={result.responsesExtracted}
                     onSelectRequest={setSelectedRequest}
+                    selectedRequestId={selectedRequest?.id}
                   />
                 </Box>
                 <Heading size="2" m="2">
@@ -71,7 +72,8 @@ export function CorrelationPreview({ rule }: { rule: CorrelationRule }) {
                       requests={requestsReplacedToProxyData(
                         result.requestsReplaced
                       )}
-                      onSelectRequest={console.log}
+                      onSelectRequest={setSelectedRequest}
+                      selectedRequestId={selectedRequest?.id}
                     />
                   </>
                 )}


### PR DESCRIPTION
Resolves https://github.com/grafana/k6-studio/issues/207

- Click a request in correlation rule preview will open inspector
- Sync `selectedRequest` to show changes when editing correlation rule

![CleanShot 2024-09-25 at 15 43 27](https://github.com/user-attachments/assets/01e1a224-8432-42fa-8add-2ce06a75c836)
