### PR TITLE
fix: eslint warnings in Recorder and useOverflowCheck

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,9 @@
   "ignorePatterns": ["resources/group_snippet.js"],
   "plugins": ["import", "unused-imports", "@tanstack/query"],
   "settings": {
+    "react": {
+      "version": "detect"
+    },
     "import/resolver": {
       "typescript": {}
     }

--- a/src/hooks/useOverflowCheck.ts
+++ b/src/hooks/useOverflowCheck.ts
@@ -14,13 +14,14 @@ export function useOverflowCheck(ref: React.RefObject<HTMLElement>) {
     checkOverflow()
 
     const resizeObserver = new ResizeObserver(checkOverflow)
-    if (ref.current) {
-      resizeObserver.observe(ref.current)
+    const currentRef = ref.current
+    if (currentRef) {
+      resizeObserver.observe(currentRef)
     }
 
     return () => {
-      if (ref.current) {
-        resizeObserver.unobserve(ref.current)
+      if (currentRef) {
+        resizeObserver.unobserve(currentRef)
       }
     }
   }, [ref])

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -165,7 +165,7 @@ export function Recorder() {
         }
       )
     })
-  }, [validateAndSaveHarFile, showToast])
+  }, [validateAndSaveHarFile, showToast, navigate])
 
   return (
     <View


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes eslint warnings in the `Recorder.tsx` component as well as the `useOverflowCheck` hook.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Run `npm run lint`
- Check that no warnings are outputted

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
