### PR TITLE
feat: merge redirect chains

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -17,6 +17,7 @@ import { generateOptions } from './options'
 import { getContentTypeWithCharsetHeader } from '@/utils/headers'
 import { REQUIRED_IMPORTS } from '@/constants/imports'
 import { generateImportStatement } from './imports'
+import { mergeRedirects } from './codegen.utils'
 
 interface GenerateScriptParams {
   recording: GroupedProxyData
@@ -65,8 +66,9 @@ export function generateVUCode(
 
   const groupSnippets = groups
     .map(([groupName, recording]) => {
+      const mergedRecording = mergeRedirects(recording)
       const requestSnippets = generateRequestSnippets(
-        recording,
+        mergedRecording,
         rules,
         correlationStateMap,
         sequentialIdGenerator,

--- a/src/codegen/codegen.utils.test.ts
+++ b/src/codegen/codegen.utils.test.ts
@@ -104,7 +104,7 @@ describe('Code generation - utils', () => {
       return createProxyData({ id, request, response })
     }
 
-    it('should return only the first request and last response', () => {
+    it('should resolve redirect chains with absolute URLs', () => {
       const first = createRedirectMock(
         '1',
         'http://first.com',
@@ -120,6 +120,26 @@ describe('Code generation - utils', () => {
         first,
         createRedirectMock('2', 'http://second.com', 'http://third.com'),
         createRedirectMock('3', 'http://third.com', 'http://last.com'),
+        last,
+      ]
+
+      expect(mergeRedirects(recording)).toEqual([
+        { ...first, response: last.response },
+      ])
+    })
+
+    it('should resolve redirect chains with relative path', () => {
+      const first = createRedirectMock('1', 'http://domain.com', '/second')
+      const last = createProxyData({
+        id: '4',
+        request: createRequest({ url: 'http://domain.com/last' }),
+        response: createResponse({ content: "I'm the last one" }),
+      })
+
+      const recording = [
+        first,
+        createRedirectMock('2', 'http://domain.com/second', '/third'),
+        createRedirectMock('3', 'http://domain.com/third', '/last'),
         last,
       ]
 

--- a/src/codegen/codegen.utils.test.ts
+++ b/src/codegen/codegen.utils.test.ts
@@ -148,6 +148,24 @@ describe('Code generation - utils', () => {
       ])
     })
 
+    it('should resolve redirect chains that are out of order', () => {
+      const from = createRedirectMock('1', 'http://a.com', 'http://b.com')
+      const nonRedirect = createProxyData({ id: '2' })
+      const to = createProxyData({
+        id: '3',
+        request: createRequest({ url: 'http://b.com' }),
+        response: createResponse({ content: "I'm the final response" }),
+      })
+
+      // "from" and "to" are not in order
+      const recording = [from, nonRedirect, to]
+
+      expect(mergeRedirects(recording)).toEqual([
+        { ...from, response: to.response },
+        nonRedirect,
+      ])
+    })
+
     it('should not change the request if a redirect is not found', () => {
       const redirect = createRedirectMock(
         '1',

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -1,3 +1,6 @@
+import { ProxyData } from '@/types'
+import { getLocationHeader } from '@/utils/headers'
+
 // TODO: find a well-maintained library for this
 export function stringify(value: unknown): string {
   if (typeof value === 'string') {
@@ -18,4 +21,66 @@ export function stringify(value: unknown): string {
   }
 
   return `${value}`
+}
+
+function isRedirect(response: ProxyData['response']) {
+  if (!response) return false
+  return response.statusCode >= 300 && response.statusCode < 400
+}
+
+function findNextUrl(response: ProxyData['response']) {
+  if (!response || !isRedirect(response)) return undefined
+  return getLocationHeader(response.headers)
+}
+
+export function mergeRedirects(recording: ProxyData[]) {
+  const result = []
+  const processed = new Set()
+
+  for (const item of recording) {
+    const { response, id } = item
+
+    // Skip requests that have been processed
+    if (processed.has(id)) {
+      continue
+    }
+
+    // Requests without response don't need to be merged
+    if (!response) {
+      result.push(item)
+      processed.add(id)
+      continue
+    }
+
+    // Requests that are not redirects don't need to be merged
+    if (!isRedirect(response)) {
+      result.push(item)
+      processed.add(id)
+      continue
+    }
+
+    let finalResponse: ProxyData['response'] = response
+    let nextUrl = findNextUrl(response)
+
+    // Find the final response by following the redirect chain
+    while (nextUrl) {
+      const nextRequest = recording.find((req) => req.request.url === nextUrl)
+      if (nextRequest) {
+        processed.add(nextRequest.id)
+        finalResponse = nextRequest.response
+        nextUrl = findNextUrl(finalResponse)
+      } else {
+        break
+      }
+    }
+
+    result.push({
+      ...item,
+      response: finalResponse,
+    })
+
+    processed.add(id)
+  }
+
+  return result
 }

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -86,7 +86,10 @@ export function mergeRedirects(recording: ProxyData[]) {
 
     // Find the final response by following the redirect chain
     while (nextUrl) {
-      const nextRequest = recording.find((req) => req.request.url === nextUrl)
+      // Find request that corresponds to the next URL in the chain and that haven't been processed yet
+      const nextRequest = recording.find(
+        (req) => req.request.url === nextUrl && !processed.has(req.id)
+      )
       if (nextRequest) {
         processed.add(nextRequest.id)
         finalResponse = nextRequest.response

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -28,7 +28,7 @@ function isRedirect(response: ProxyData['response']) {
   return [301, 302].includes(response.statusCode)
 }
 
-function findNextUrl(response: ProxyData['response']) {
+function getRedirectLocation(response: ProxyData['response']) {
   if (!response || !isRedirect(response)) return undefined
   return getLocationHeader(response.headers)
 }
@@ -60,7 +60,7 @@ export function mergeRedirects(recording: ProxyData[]) {
     }
 
     let finalResponse: ProxyData['response'] = response
-    let nextUrl = findNextUrl(response)
+    let nextUrl = getRedirectLocation(response)
 
     // Find the final response by following the redirect chain
     while (nextUrl) {
@@ -68,7 +68,7 @@ export function mergeRedirects(recording: ProxyData[]) {
       if (nextRequest) {
         processed.add(nextRequest.id)
         finalResponse = nextRequest.response
-        nextUrl = findNextUrl(finalResponse)
+        nextUrl = getRedirectLocation(finalResponse)
       } else {
         break
       }

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -25,7 +25,7 @@ export function stringify(value: unknown): string {
 
 function isRedirect(response: ProxyData['response']) {
   if (!response) return false
-  return response.statusCode >= 300 && response.statusCode < 400
+  return [301, 302].includes(response.statusCode)
 }
 
 function findNextUrl(response: ProxyData['response']) {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -40,3 +40,12 @@ export function upsertHeader(
     [key, value],
   ]
 }
+
+/**
+ * Returns the value of the location header
+ * @example
+ * application/json
+ */
+export function getLocationHeader(headers: Header[]) {
+  return getHeaderValues(headers, 'location')[0]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

Currently, when exporting a script, the Studio generates checks for all requests in a redirect chain. For example, the URL `http://www.k6.io` does 3 redirects.

```sh
$ curl -v -L http://www.k6.io 2>&1 | grep -i "^< location:"
< Location: https://www.k6.io/
< location: http://k6.io/index.html
< Location: https://k6.io/index.html
```

Right now, one check for each request above is generated when exporting the script, which is unexpected behaviour. 

This PR introduces logic responsible for identifying and resolving a redirect chain, ensuring that only the initial request and the check for the final response are present.

Example: Request to `http://www.k6.io` (first request in the chain) checks for the response in `https://k6.io/index.html` (final response in the chain).

## How to Test

<!--- Please describe in detail how you tested your changes -->

- Create a recording and browse to a website that does at least one redirect, such as `http://www.k6.io` (note the HTTP protocol)
- Check the redirect chain in the request list
![image](https://github.com/user-attachments/assets/0eb2b5e5-50e2-4f1a-bd48-08354d705b06)
- Export a script and verify that only one check is present (checking for the HTTP status of the last request in the chain)


## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

 Resolves https://github.com/grafana/k6-studio/issues/206

<!-- Thanks for your contribution! 🙏🏼 -->
