### PR TITLE
feat: persist application logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ To do that, modify the `hosts` file on your system, for example, `127.0.0.1 myap
 ### "Proxy failed to start" error
 If you're on a Mac, make sure you're not running the k6 Studio application from the Downloads folder. If that's the case, close the app, move the application file to the Applications folder, and start the app again.
 
+### Application logs
+
+Application logs are saved in the following directory:
+
+- on Mac: `~/Library/Logs/k6 Studio/k6-studio.log`
+- on Windows: `%USERPROFILE%\AppData\Roaming\k6 Studio\logs\k6-studio.log`
+
+When opening an issue, please include a tail of your log file.
+
 ---
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@vitejs/plugin-react": "^4.3.1",
         "allotment": "^1.20.2",
         "chokidar": "^3.6.0",
+        "electron-log": "^5.2.0",
         "electron-squirrel-startup": "^1.0.1",
         "find-process": "^1.4.7",
         "immer": "^10.1.1",
@@ -7156,6 +7157,15 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.2.0.tgz",
+      "integrity": "sha512-VjLkvaLmbP3AOGOh5Fob9M8bFU0mmeSAb5G2EoTBx+kQLf2XA/0byzjsVGBTHhikbT+m1AB27NEQUv9wX9nM8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-squirrel-startup": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@vitejs/plugin-react": "^4.3.1",
     "allotment": "^1.20.2",
     "chokidar": "^3.6.0",
+    "electron-log": "^5.2.0",
     "electron-squirrel-startup": "^1.0.1",
     "find-process": "^1.4.7",
     "immer": "^10.1.1",

--- a/src/components/Layout/ActivityBar/ActivityBar.tsx
+++ b/src/components/Layout/ActivityBar/ActivityBar.tsx
@@ -7,6 +7,7 @@ import { ThemeSwitcher } from '@/components/ThemeSwitcher'
 import { VersionLabel } from './VersionLabel'
 import { HomeIcon } from '@/components/icons'
 import { NavIconButton } from './NavIconButton'
+import { ApplicationLogButton } from './ApplicationLogButton'
 
 export function ActivityBar() {
   return (
@@ -40,6 +41,7 @@ export function ActivityBar() {
 
         <Flex direction="column" align="center" gap="3" mt="auto">
           <ThemeSwitcher />
+          <ApplicationLogButton />
           <VersionLabel />
         </Flex>
       </Box>

--- a/src/components/Layout/ActivityBar/ApplicationLogButton.tsx
+++ b/src/components/Layout/ActivityBar/ApplicationLogButton.tsx
@@ -1,0 +1,21 @@
+import { ActivityLogIcon } from '@radix-ui/react-icons'
+import { Tooltip, IconButton } from '@radix-ui/themes'
+
+export function ApplicationLogButton() {
+  const handleClick = () => {
+    window.studio.app.openApplicationLog()
+  }
+
+  return (
+    <Tooltip content="Application Logs" side="right">
+      <IconButton
+        are-label="Application Logs"
+        color="gray"
+        variant="ghost"
+        onClick={handleClick}
+      >
+        <ActivityLogIcon />
+      </IconButton>
+    </Tooltip>
+  )
+}

--- a/src/hooks/useCreateGenerator.test.ts
+++ b/src/hooks/useCreateGenerator.test.ts
@@ -24,6 +24,11 @@ vi.mock('@/routeMap', () => ({
 vi.mock('@/store/ui/useToast', () => ({
   useToast: vi.fn(),
 }))
+vi.mock('electron-log/renderer', () => ({
+  default: {
+    error: vi.fn(),
+  },
+}))
 
 describe('useCreateGenerator', () => {
   const navigate = vi.fn()

--- a/src/hooks/useCreateGenerator.ts
+++ b/src/hooks/useCreateGenerator.ts
@@ -5,6 +5,7 @@ import { generateFileNameWithTimestamp } from '@/utils/file'
 import { createNewGeneratorFile } from '@/utils/generator'
 import { getRoutePath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
+import log from 'electron-log/renderer'
 
 export function useCreateGenerator() {
   const navigate = useNavigate()
@@ -26,6 +27,7 @@ export function useCreateGenerator() {
         status: 'error',
         title: 'Failed to create generator',
       })
+      log.error(error)
     }
   }, [navigate, showToast])
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 import { App } from './App'
+import log from 'electron-log/renderer'
+
+log.errorHandler.startCatching()
 
 const root = createRoot(document.getElementById('root')!)
 root.render(<App />)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,6 @@
 import log from 'electron-log/main'
+import { spawn } from 'node:child_process'
+import path from 'node:path'
 
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
@@ -17,4 +19,11 @@ export function initializeLogger() {
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'
   }
+}
+
+export function openLogFolder() {
+  const logFile = log.transports.file.getFile().path
+  const logPath = path.dirname(logFile)
+  const executable = process.platform === 'darwin' ? 'open' : 'explorer'
+  spawn(executable, [logPath])
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,15 +4,15 @@ import path from 'node:path'
 
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
-  // @see https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
+  // https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
   log.initialize()
 
   // log electron core events
-  // @see https://github.com/megahertz/electron-log/blob/master/docs/events.md
+  // https://github.com/megahertz/electron-log/blob/master/docs/events.md
   log.eventLogger.startLogging()
 
   // log uncaught exceptions
-  // @see https://github.com/megahertz/electron-log/blob/master/docs/errors.md
+  // https://github.com/megahertz/electron-log/blob/master/docs/errors.md
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,6 +24,8 @@ export function initializeLogger() {
 export function openLogFolder() {
   const logFile = log.transports.file.getFile().path
   const logPath = path.dirname(logFile)
+
+  // supports only Mac and Windows at this time
   const executable = process.platform === 'darwin' ? 'open' : 'explorer'
   spawn(executable, [logPath])
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,20 @@
+import log from 'electron-log/main'
+
+export function initializeLogger() {
+  // allow logs to be triggered from the renderer process
+  // @see https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
+  log.initialize()
+
+  // log electron core events
+  // @see https://github.com/megahertz/electron-log/blob/master/docs/events.md
+  log.eventLogger.startLogging()
+
+  // log uncaught exceptions
+  // @see https://github.com/megahertz/electron-log/blob/master/docs/errors.md
+  log.errorHandler.startCatching()
+
+  log.transports.file.fileName = 'k6-studio.log'
+  if (process.env.NODE_ENV === 'development') {
+    log.transports.file.fileName = 'k6-studio-dev.log'
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -511,8 +511,8 @@ ipcMain.handle('browser:open:external:link', (_, url: string) => {
   shell.openExternal(url)
 })
 
-ipcMain.handle('application:open-log', () => {
-  console.info('application:open-log event received')
+ipcMain.handle('app:open-log', () => {
+  console.info('app:open-log event received')
   openLogFolder()
 })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,8 @@ import { HarFile } from './types/har'
 import { GeneratorFile } from './types/generator'
 import kill from 'tree-kill'
 import find from 'find-process'
+import { initializeLogger } from './logger'
+import log from 'electron-log/main'
 
 // handle auto updates
 if (process.env.NODE_ENV !== 'development') {
@@ -66,6 +68,8 @@ let splashscreenWindow: BrowserWindow
 if (require('electron-squirrel-startup')) {
   app.quit()
 }
+
+initializeLogger()
 
 const createSplashWindow = async () => {
   splashscreenWindow = new BrowserWindow({
@@ -338,9 +342,10 @@ ipcMain.handle(
       })
     } catch (error) {
       sendToast(browserWindow.webContents, {
-        title: 'There was an error exporting the script',
+        title: 'Failed to export the script',
         status: 'error',
       })
+      log.error(error)
     }
   }
 )
@@ -476,6 +481,7 @@ ipcMain.handle(
 
       await rename(oldPath, newPath)
     } catch (e) {
+      log.error(e)
       browserWindow &&
         sendToast(browserWindow.webContents, {
           title: 'Failed to rename file',

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ import { HarFile } from './types/har'
 import { GeneratorFile } from './types/generator'
 import kill from 'tree-kill'
 import find from 'find-process'
-import { initializeLogger } from './logger'
+import { initializeLogger, openLogFolder } from './logger'
 import log from 'electron-log/main'
 
 // handle auto updates
@@ -509,6 +509,11 @@ ipcMain.on('splashscreen:close', (event) => {
 ipcMain.handle('browser:open:external:link', (_, url: string) => {
   console.info('browser:open:external:link event received')
   shell.openExternal(url)
+})
+
+ipcMain.handle('application:open-log', () => {
+  console.info('application:open-log event received')
+  openLogFolder()
 })
 
 const browserWindowFromEvent = (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -142,6 +142,9 @@ const app = {
   closeSplashscreen: () => {
     ipcRenderer.send('splashscreen:close')
   },
+  openApplicationLog: () => {
+    ipcRenderer.invoke('application:open-log')
+  },
 } as const
 
 const studio = {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -143,7 +143,7 @@ const app = {
     ipcRenderer.send('splashscreen:close')
   },
   openApplicationLog: () => {
-    ipcRenderer.invoke('application:open-log')
+    ipcRenderer.invoke('app:open-log')
   },
 } as const
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,6 +7,7 @@ import { readFile } from 'fs/promises'
 import { ProxyData } from './types'
 import readline from 'readline/promises'
 import { safeJsonParse } from './utils/json'
+import log from 'electron-log/main'
 
 export type ProxyProcess = ChildProcessWithoutNullStreams
 
@@ -75,6 +76,7 @@ export const launchProxy = (
 
   proxy.stderr.on('data', (data) => {
     console.error(`stderr: ${data}`)
+    log.error(data.toString())
   })
 
   proxy.on('close', (code) => {

--- a/src/views/Generator/ExportScriptDialog/ExportScriptDialog.tsx
+++ b/src/views/Generator/ExportScriptDialog/ExportScriptDialog.tsx
@@ -18,6 +18,7 @@ import {
 } from '../Generator.hooks'
 import { useToast } from '@/store/ui/useToast'
 import { getScriptNameWithExtension } from './ExportScriptDialog.utils'
+import log from 'electron-log/renderer'
 
 export function ExportScriptDialog({
   open,
@@ -72,6 +73,7 @@ export function ExportScriptDialog({
         status: 'error',
         title: 'Failed to update script name',
       })
+      log.error(error)
     }
   }
 

--- a/src/views/Generator/Generator.hooks.ts
+++ b/src/views/Generator/Generator.hooks.ts
@@ -11,6 +11,7 @@ import { selectGeneratorData, useGeneratorStore } from '@/store/generator'
 import { GeneratorFileData } from '@/types/generator'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { queryClient } from '@/utils/query'
+import log from 'electron-log/renderer'
 
 export function useGeneratorParams() {
   const { fileName } = useParams()
@@ -69,6 +70,7 @@ export function useSaveGeneratorFile(fileName: string) {
         status: 'error',
         description: error.message,
       })
+      log.error(error)
     },
   })
 }

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -24,6 +24,7 @@ import { getRoutePath } from '@/routeMap'
 import { UnsavedChangesDialog } from './UnsavedChangesDialog'
 import { RuleEditor } from './RuleEditor'
 import { getFileNameWithoutExtension } from '@/utils/file'
+import log from 'electron-log/renderer'
 
 export function Generator() {
   const selectedRule = useGeneratorStore(selectSelectedRule)
@@ -69,7 +70,7 @@ export function Generator() {
         title: 'Failed to load generator',
         status: 'error',
       })
-
+      log.error(generatorError)
       navigate(getRoutePath('home'), { replace: true })
     }
   }, [generatorError, showToast, navigate])
@@ -81,6 +82,7 @@ export function Generator() {
         status: 'error',
         description: 'Select another recording in the sidebar',
       })
+      log.error(harError)
     }
   }, [harError, showToast])
 

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -7,6 +7,7 @@ import { harToProxyData } from '@/utils/harToProxyData'
 import { useStudioUIStore } from '@/store/ui'
 import { getFileNameWithoutExtension } from '@/utils/file'
 import { useToast } from '@/store/ui/useToast'
+import log from 'electron-log/renderer'
 
 export function RecordingSelector() {
   const recordingPath = useGeneratorStore((store) => store.recordingPath)
@@ -25,6 +26,7 @@ export function RecordingSelector() {
         title: 'Failed to open recording',
         status: 'error',
       })
+      log.error(error)
     }
   }
 
@@ -40,6 +42,7 @@ export function RecordingSelector() {
         title: 'Failed to import recording',
         status: 'error',
       })
+      log.error(error)
     }
   }
 

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -22,6 +22,7 @@ import { useToast } from '@/store/ui/useToast'
 import TextSpinner from '@/components/TextSpinner/TextSpinner'
 import { DEFAULT_GROUP_NAME } from '@/constants'
 import { ButtonWithTooltip } from '@/components/ButtonWithTooltip'
+import log from 'electron-log/renderer'
 
 const INITIAL_GROUPS: Group[] = [
   {
@@ -63,12 +64,13 @@ export function Recorder() {
       await startRecording()
 
       setRecorderState('recording')
-    } catch {
+    } catch (error) {
       setRecorderState('idle')
       showToast({
-        title: 'There was an error starting the recording',
+        title: 'Failed to start recording',
         status: 'error',
       })
+      log.error(error)
     }
   }, [resetProxyData, showToast])
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

This PR introduces changes needed to capture caught and uncaught exceptions to a log file. This will enable us to troubleshoot issues more efficiently.

Here's an example of a log file being generated by the Studio. This includes errors raised by the proxy, IpcMain call and unhandle exceptions.

```log
[2024-10-07 12:06:39.823] [error] mitmproxy/certs.py:112: CryptographyDeprecationWarning: Properties that return a naïve datetime object have been deprecated. Please switch to not_valid_after_utc.

[2024-10-07 12:06:39.824] [error] /Users/username/www/k6-studio/resources/mac/arm64/k6-studio-proxy: Invalid proxy mode specification: regular@AAA (invalid port: AAA)

[2024-10-07 12:08:10.704] [error] Error: Error invoking remote method 'har:open': Error: ENOENT: no such file or directory, open '/Users/username/Documents/k6-studio/Recordings/2024-10-02_17-21-55.har'

[2024-10-07 12:17:58.722] [error] Unhandled rejection ReferenceError: currentBrowserProcess_NOT_DECLARED is not defined
    at IpcMainImpl.<anonymous> (/Users/username/www/k6-studio/.vite/build/main.js:2391:3)
    at IpcMainImpl.emit (node:events:518:28)
    at WebContents.<anonymous> (node:electron/js2c/browser_init:2:82429)
    at WebContents.emit (node:events:518:28)
```

In addition, a button was included in the UI to allow users to retrieve the log file more easily.

## How to Test

<!--- Please describe in detail how you tested your changes -->
- Manually set the proxy to an invalid port and start the application
- Manually change the recording path of a generator and try to open it
- Throw exceptions in specific parts of the app and raise them from the UI

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/1c2dfe7d-9e78-444e-ad7c-d8cf20f3970e)

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/235

<!-- Thanks for your contribution! 🙏🏼 -->
