### PR TITLE
fix: restore window from dock on mac os

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ const createWindow = async () => {
     show: false,
     icon,
     title: 'k6 Studio (experimental)',
+    backgroundColor: nativeTheme.themeSource === 'light' ? '#fff' : '#111110',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       devTools: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue on Mac OS where the main window would not be re-created from the Dock after being closed.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

On Mac OS:

- Start k6 studio
- Close k6 studio window (cmd+w)
- Click on k6 studio in the dock
- Check that the window has been re-created
- Check that chokidar still works as expected (by manually removing or creating files in the k6 Studio Recordings/Scripts directory)

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/231

<!-- Thanks for your contribution! 🙏🏼 -->
