### PR TITLE
fix: remove websocket requests from recording

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -17,7 +17,7 @@ import { generateOptions } from './options'
 import { getContentTypeWithCharsetHeader } from '@/utils/headers'
 import { REQUIRED_IMPORTS } from '@/constants/imports'
 import { generateImportStatement } from './imports'
-import { recordingCleanup } from './codegen.utils'
+import { cleanupRecording } from './codegen.utils'
 
 interface GenerateScriptParams {
   recording: GroupedProxyData
@@ -66,7 +66,7 @@ export function generateVUCode(
 
   const groupSnippets = groups
     .map(([groupName, recording]) => {
-      const cleanedRecording = recordingCleanup(recording)
+      const cleanedRecording = cleanupRecording(recording)
       const requestSnippets = generateRequestSnippets(
         cleanedRecording,
         rules,

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -17,7 +17,7 @@ import { generateOptions } from './options'
 import { getContentTypeWithCharsetHeader } from '@/utils/headers'
 import { REQUIRED_IMPORTS } from '@/constants/imports'
 import { generateImportStatement } from './imports'
-import { mergeRedirects } from './codegen.utils'
+import { recordingCleanup } from './codegen.utils'
 
 interface GenerateScriptParams {
   recording: GroupedProxyData
@@ -66,9 +66,9 @@ export function generateVUCode(
 
   const groupSnippets = groups
     .map(([groupName, recording]) => {
-      const mergedRecording = mergeRedirects(recording)
+      const cleanedRecording = recordingCleanup(recording)
       const requestSnippets = generateRequestSnippets(
-        mergedRecording,
+        cleanedRecording,
         rules,
         correlationStateMap,
         sequentialIdGenerator,

--- a/src/codegen/codegen.utils.test.ts
+++ b/src/codegen/codegen.utils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { mergeRedirects, stringify } from './codegen.utils'
+import {
+  mergeRedirects,
+  stringify,
+  removeWebsocketRequests,
+} from './codegen.utils'
 import {
   createRequest,
   createResponse,
@@ -202,6 +206,19 @@ describe('Code generation - utils', () => {
       const recording = [redirect, createProxyData({ id: '2' })]
 
       expect(mergeRedirects(recording)).toEqual(recording)
+    })
+  })
+
+  describe('removeWebsocketRequests', () => {
+    it('remove websocket requests', () => {
+      const websocketRequest = createProxyData({
+        request: createRequest({ headers: [['upgrade', 'websocket']] }),
+      })
+      const normalRequest = createProxyData()
+
+      const recording = [websocketRequest, normalRequest]
+
+      expect(removeWebsocketRequests(recording)).toEqual([{ ...normalRequest }])
     })
   })
 })

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -1,3 +1,4 @@
+import { flow } from 'lodash-es'
 import { ProxyData } from '@/types'
 import { getLocationHeader, getUpgradeHeader } from '@/utils/headers'
 
@@ -116,8 +117,4 @@ export const removeWebsocketRequests = (recording: ProxyData[]) => {
   })
 }
 
-export const cleanupRecording = (recording: ProxyData[]) => {
-  let cleanedRecording = mergeRedirects(recording)
-  cleanedRecording = removeWebsocketRequests(cleanedRecording)
-  return cleanedRecording
-}
+export const cleanupRecording = flow([mergeRedirects, removeWebsocketRequests])

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -116,7 +116,7 @@ export const removeWebsocketRequests = (recording: ProxyData[]) => {
   })
 }
 
-export const recordingCleanup = (recording: ProxyData[]) => {
+export const cleanupRecording = (recording: ProxyData[]) => {
   let cleanedRecording = mergeRedirects(recording)
   cleanedRecording = removeWebsocketRequests(cleanedRecording)
   return cleanedRecording

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -1,5 +1,5 @@
 import { ProxyData } from '@/types'
-import { getLocationHeader } from '@/utils/headers'
+import { getLocationHeader, getUpgradeHeader } from '@/utils/headers'
 
 // TODO: find a well-maintained library for this
 export function stringify(value: unknown): string {
@@ -108,4 +108,16 @@ export function mergeRedirects(recording: ProxyData[]) {
   }
 
   return result
+}
+
+export const removeWebsocketRequests = (recording: ProxyData[]) => {
+  return recording.filter((data) => {
+    return getUpgradeHeader(data.request.headers) !== 'websocket'
+  })
+}
+
+export const recordingCleanup = (recording: ProxyData[]) => {
+  let cleanedRecording = mergeRedirects(recording)
+  cleanedRecording = removeWebsocketRequests(cleanedRecording)
+  return cleanedRecording
 }

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -49,3 +49,7 @@ export function upsertHeader(
 export function getLocationHeader(headers: Header[]) {
   return getHeaderValues(headers, 'location')[0]
 }
+
+export function getUpgradeHeader(headers: Header[]) {
+  return getHeaderValues(headers, 'upgrade')[0]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
Websocket requests are now removed from the generated script file to avoid issues due to websockets not yet supported

## How to Test

<!--- Please describe in detail how you tested your changes -->
Record a website with websockets, try to validate it and see no issue related to the protocol and the request missing for the `101` switching protocol.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Fix: #241 

<!-- Thanks for your contribution! 🙏🏼 -->
