### PR TITLE
feat: Add parameterization rule logic

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -4,15 +4,25 @@ import {
   generateRequestSnippets,
   generateVariableDeclarations,
   generateGroupSnippet,
+  generateRequestParams,
 } from './codegen'
-import { CorrelationStateMap, TestRule } from '@/types/rules'
-import { generateSequentialInt } from '@/rules/utils'
-import { ProxyData } from '@/types'
+import { TestRule } from '@/types/rules'
+import { Cookie, Header, ProxyData, Request } from '@/types'
 import { correlationRecording } from '@/test/fixtures/correlationRecording'
 import { checksRecording } from '@/test/fixtures/checksRecording'
 import { ThinkTime } from '@/types/testOptions'
+import { createProxyData, createRequest } from '@/test/factories/proxyData'
+import { jsonRule } from '@/test/fixtures/parameterizationRules'
 
 const fakeDate = new Date('2000-01-01T00:00:00Z')
+
+const thinkTime: ThinkTime = {
+  sleepType: 'iterations',
+  timing: {
+    type: 'fixed',
+    value: 1,
+  },
+}
 
 describe('Code generation', () => {
   beforeAll(() => {
@@ -125,15 +135,6 @@ describe('Code generation', () => {
       ]
 
       const rules: TestRule[] = []
-      const correlationStateMap: CorrelationStateMap = {}
-      const sequentialIdGenerator = generateSequentialInt()
-      const thinkTime: ThinkTime = {
-        sleepType: 'iterations',
-        timing: {
-          type: 'fixed',
-          value: 1,
-        },
-      }
 
       const expectedResult = `
         params = { headers: {}, cookies: {} }
@@ -142,13 +143,7 @@ describe('Code generation', () => {
       `
 
       expect(
-        generateRequestSnippets(
-          recording,
-          rules,
-          correlationStateMap,
-          sequentialIdGenerator,
-          thinkTime
-        ).replace(/\s/g, '')
+        generateRequestSnippets(recording, rules, thinkTime).replace(/\s/g, '')
       ).toBe(expectedResult.replace(/\s/g, ''))
     })
 
@@ -167,15 +162,6 @@ describe('Code generation', () => {
           },
         },
       ]
-      const correlationStateMap: CorrelationStateMap = {}
-      const sequentialIdGenerator = generateSequentialInt()
-      const thinkTime: ThinkTime = {
-        sleepType: 'iterations',
-        timing: {
-          type: 'fixed',
-          value: 1,
-        },
-      }
 
       const expectedResult = `
         params = { headers: {}, cookies: {} }
@@ -198,13 +184,10 @@ describe('Code generation', () => {
       `
 
       expect(
-        generateRequestSnippets(
-          correlationRecording,
-          rules,
-          correlationStateMap,
-          sequentialIdGenerator,
-          thinkTime
-        ).replace(/\s/g, '')
+        generateRequestSnippets(correlationRecording, rules, thinkTime).replace(
+          /\s/g,
+          ''
+        )
       ).toBe(expectedResult.replace(/\s/g, ''))
     })
 
@@ -219,15 +202,6 @@ describe('Code generation', () => {
           },
         },
       ]
-      const correlationStateMap: CorrelationStateMap = {}
-      const sequentialIdGenerator = generateSequentialInt()
-      const thinkTime: ThinkTime = {
-        sleepType: 'iterations',
-        timing: {
-          type: 'fixed',
-          value: 1,
-        },
-      }
 
       const expectedResult = `
         params = { headers: {}, cookies: {} }
@@ -238,13 +212,36 @@ describe('Code generation', () => {
       `
 
       expect(
-        generateRequestSnippets(
-          checksRecording,
-          rules,
-          correlationStateMap,
-          sequentialIdGenerator,
-          thinkTime
-        ).replace(/\s/g, '')
+        generateRequestSnippets(checksRecording, rules, thinkTime).replace(
+          /\s/g,
+          ''
+        )
+      ).toBe(expectedResult.replace(/\s/g, ''))
+    })
+
+    it('should replace paremeterization values', () => {
+      const recording = createProxyData({
+        request: createRequest({
+          method: 'POST',
+          url: 'http://test.k6.io/api/v1/users',
+          content: JSON.stringify({ user_id: '333' }),
+          headers: [['content-type', 'application/json']],
+        }),
+      })
+
+      const rules: TestRule[] = [jsonRule]
+
+      const expectedResult = `
+        params = { headers: { 'content-type': \`application/json\` }, cookies: {} }
+        url = http.url\`http://test.k6.io/api/v1/users\`
+        resp = http.request('POST', url, \`${JSON.stringify({ user_id: 'TEST_ID' })}\`, params)
+      `
+
+      expect(
+        generateRequestSnippets([recording], rules, thinkTime).replace(
+          /\s/g,
+          ''
+        )
       ).toBe(expectedResult.replace(/\s/g, ''))
     })
   })
@@ -265,6 +262,93 @@ describe('Code generation', () => {
           },
         }).replace(/\s/g, '')
       ).toBe(expectedResult.replace(/\s/g, ''))
+    })
+  })
+
+  describe('generateRequestParams', () => {
+    const generateRequest = (
+      headers: Header[],
+      cookies: Cookie[] = [['security', 'none']]
+    ): Request => {
+      return {
+        method: 'POST',
+        url: 'http://test.k6.io/api/v1/foo',
+        headers,
+        cookies: cookies,
+        query: [],
+        scheme: 'http',
+        host: 'localhost:3000',
+        content: '',
+        path: '/api/v1/foo',
+        timestampStart: 0,
+        timestampEnd: 0,
+        contentLength: 0,
+        httpVersion: '1.1',
+      }
+    }
+
+    it('generate request params', () => {
+      const headers: Header[] = [['content-type', 'application/json']]
+      const request = generateRequest(headers)
+
+      const expectedResult = `
+    {
+      headers: {
+        'content-type': \`application/json\`
+      },
+      cookies: {
+
+      }
+    }
+  `
+      expect(generateRequestParams(request).replace(/\s/g, '')).toBe(
+        expectedResult.replace(/\s/g, '')
+      )
+    })
+
+    it('generate request params with cookie header', () => {
+      const headers: Header[] = [
+        ['content-type', 'application/json'],
+        ['Cookie', 'hello=world'],
+      ]
+      const request = generateRequest(headers)
+
+      const expectedResult = `
+    {
+      headers: {
+        'content-type': \`application/json\`
+      },
+      cookies: {
+
+      }
+    }
+  `
+      expect(generateRequestParams(request).replace(/\s/g, '')).toBe(
+        expectedResult.replace(/\s/g, '')
+      )
+    })
+
+    it('generate request params with cookies with correlation', () => {
+      const headers: Header[] = [
+        ['content-type', 'application/json'],
+        ['Cookie', "security=${correlation_vars['correlation_0']}"],
+      ]
+      const cookies: Cookie[] = [
+        ['security', "${correlation_vars['correlation_0']}"],
+      ]
+      const request = generateRequest(headers, cookies)
+
+      const expectedResult = `
+    {
+      headers: {
+        'content-type': \`application/json\`
+      },
+      cookies: {
+        'security': {value: \`\${correlation_vars['correlation_0']}\`, replace: true}
+      }
+    }
+  `
+      expect(generateRequestParams(request)).toBe(expectedResult)
     })
   })
 })

--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -1,10 +1,11 @@
 import { ProxyData, RequestSnippetSchema, Response, Request } from '@/types'
 import {
-  CorrelationStateMap,
   CorrelationRule,
   BeginEndSelector,
   RegexSelector,
   JsonSelector,
+  CorrelationState,
+  CorrelationRuleInstance,
 } from '@/types/rules'
 import { cloneDeep, escapeRegExp, isEqual } from 'lodash-es'
 import {
@@ -17,79 +18,98 @@ import { exhaustive } from '@/utils/typescript'
 import { replaceCorrelatedValues } from './correlation.utils'
 import { matchBeginEnd, matchRegex, getJsonObjectFromPath } from './shared'
 
-export function applyCorrelationRule(
-  requestSnippetSchema: RequestSnippetSchema,
-  rule: CorrelationRule,
-  correlationStateMap: CorrelationStateMap,
-  sequentialIdGenerator: Generator<number>
-): RequestSnippetSchema {
-  // this is the modified schema that we return to the accumulator
-  const snippetSchemaReturnValue = cloneDeep(requestSnippetSchema)
+export function createCorrelationRuleInstance(
+  rule: CorrelationRule
+): CorrelationRuleInstance {
+  const sequentialIdGenerator = generateSequentialInt()
 
-  // if we have an extracted value we try to apply it to the request
-  // note: this comes before the extractor to avoid applying an extracted value on the same request/response pair
-  const correlationState = correlationStateMap[rule.id]
-  let uniqueId: number | undefined
-
-  if (correlationState?.extractedValue) {
-    const { extractedValue } = correlationState
-    // we populate uniqueId since it doesn't have to be regenerated
-    // this will be passed to the tryCorrelationExtraction function
-    uniqueId = correlationState.generatedUniqueId
-
-    snippetSchemaReturnValue.data.request = replaceCorrelatedValues({
-      rule,
-      extractedValue,
-      uniqueId: uniqueId ?? 0,
-      request: requestSnippetSchema.data.request,
-    })
-
-    // Keep track of modified requests to display in preview
-    if (!isEqual(requestSnippetSchema, snippetSchemaReturnValue)) {
-      correlationState.requestsReplaced.push([
-        requestSnippetSchema.data.request,
-        snippetSchemaReturnValue.data.request,
-      ])
-    }
+  const state: CorrelationState = {
+    extractedValue: undefined,
+    count: 0,
+    responsesExtracted: [],
+    requestsReplaced: [],
+    generatedUniqueId: undefined,
+    sequentialIdGenerator,
   }
 
-  // Skip extraction if filter doesn't match
-  if (!matchFilter(requestSnippetSchema, rule)) {
-    return snippetSchemaReturnValue
-  }
+  return {
+    rule,
+    state,
+    type: rule.type,
+    apply: (
+      requestSnippetSchema: RequestSnippetSchema
+    ): RequestSnippetSchema => {
+      // this is the modified schema that we return to the accumulator
+      const snippetSchemaReturnValue = cloneDeep(requestSnippetSchema)
 
-  // try to extract the value
-  const { extractedValue, correlationExtractionSnippet, generatedUniqueId } =
-    tryCorrelationExtraction(
-      rule,
-      requestSnippetSchema.data,
-      uniqueId,
-      sequentialIdGenerator
-    )
+      // if we have an extracted value we try to apply it to the request
+      // note: this comes before the extractor to avoid applying an extracted value on the same request/response pair
+      let uniqueId: number | undefined
 
-  if (extractedValue && correlationExtractionSnippet) {
-    if (correlationState) {
-      // we only increment the count and we keep the first extracted value
-      correlationState.count += 1
-      // note: if the correlation extracts from URL we will need to showcase the request
-      correlationState.responsesExtracted.push(requestSnippetSchema.data)
-    } else {
-      correlationStateMap[rule.id] = {
+      if (state.extractedValue) {
+        // we populate uniqueId since it doesn't have to be regenerated
+        // this will be passed to the tryCorrelationExtraction function
+        uniqueId = state.generatedUniqueId
+
+        snippetSchemaReturnValue.data.request = replaceCorrelatedValues({
+          rule,
+          extractedValue: state.extractedValue,
+          uniqueId: uniqueId ?? 0,
+          request: requestSnippetSchema.data.request,
+        })
+
+        // Keep track of modified requests to display in preview
+        if (!isEqual(requestSnippetSchema, snippetSchemaReturnValue)) {
+          state.requestsReplaced = [
+            ...state.requestsReplaced,
+            {
+              original: requestSnippetSchema.data.request,
+              replaced: snippetSchemaReturnValue.data.request,
+            },
+          ]
+        }
+      }
+
+      // Skip extraction if filter doesn't match
+      if (!matchFilter(requestSnippetSchema, rule)) {
+        return snippetSchemaReturnValue
+      }
+
+      // try to extract the value
+      const {
         extractedValue,
-        count: 1,
-        responsesExtracted: [requestSnippetSchema.data],
-        requestsReplaced: [],
         generatedUniqueId,
+        correlationExtractionSnippet,
+      } = tryCorrelationExtraction(
+        rule,
+        requestSnippetSchema.data,
+        uniqueId,
+        sequentialIdGenerator
+      )
+
+      if (extractedValue && correlationExtractionSnippet) {
+        // Keep first extracted value
+
+        state.extractedValue ??= extractedValue
+        state.generatedUniqueId = generatedUniqueId
+        state.responsesExtracted = [
+          ...state.responsesExtracted,
+          requestSnippetSchema.data,
+        ]
+        state.count += 1
+
+        return {
+          ...snippetSchemaReturnValue,
+          after: [
+            ...requestSnippetSchema['after'],
+            correlationExtractionSnippet,
+          ], // ! we know that we have the values because we are in the if condition but might need better types
+        }
       }
 
-      return {
-        ...requestSnippetSchema,
-        after: [...requestSnippetSchema['after'], correlationExtractionSnippet], // ! we know that we have the values because we are in the if condition but might need better types
-      }
-    }
+      return snippetSchemaReturnValue
+    },
   }
-
-  return snippetSchemaReturnValue
 }
 
 const noCorrelationResult = {

--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -103,7 +103,7 @@ export function createCorrelationRuleInstance(
           after: [
             ...requestSnippetSchema['after'],
             correlationExtractionSnippet,
-          ], // ! we know that we have the values because we are in the if condition but might need better types
+          ],
         }
       }
 

--- a/src/rules/correlation.utils.ts
+++ b/src/rules/correlation.utils.ts
@@ -6,7 +6,6 @@ export function replaceCorrelatedValues({
   rule,
   extractedValue,
   uniqueId,
-
   request,
 }: {
   rule: CorrelationRule

--- a/src/rules/customCode.ts
+++ b/src/rules/customCode.ts
@@ -1,19 +1,24 @@
 import { RequestSnippetSchema } from '@/types'
-import { CustomCodeRule } from '@/types/rules'
+import { CustomCodeRule, CustomCodeRuleInstance } from '@/types/rules'
 import { matchFilter } from './utils'
 
-export function applyCustomCodeRule(
-  requestSnippetSchema: RequestSnippetSchema,
+export function createCustomCodeRuleInstance(
   rule: CustomCodeRule
-): RequestSnippetSchema {
-  if (!matchFilter(requestSnippetSchema, rule)) {
-    return requestSnippetSchema
-  }
-
-  const block = rule.placement === 'before' ? 'before' : 'after'
-
+): CustomCodeRuleInstance {
   return {
-    ...requestSnippetSchema,
-    [block]: [...requestSnippetSchema[block], rule.snippet],
+    rule,
+    type: rule.type,
+    apply: (requestSnippetSchema: RequestSnippetSchema) => {
+      if (!matchFilter(requestSnippetSchema, rule)) {
+        return requestSnippetSchema
+      }
+
+      const block = rule.placement === 'before' ? 'before' : 'after'
+
+      return {
+        ...requestSnippetSchema,
+        [block]: [...requestSnippetSchema[block], rule.snippet],
+      }
+    },
   }
 }

--- a/src/rules/parameterization.test.ts
+++ b/src/rules/parameterization.test.ts
@@ -107,7 +107,29 @@ describe('applyParameterization', () => {
     expect(updatedRequest.data.request.content).toBe('{"user_id":"123"}')
   })
 
-  it('saves replaced requests')
+  it('saves replaced requests', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          headers: [['content-Type', 'application/json']],
+          content: JSON.stringify({ user_id: '123' }),
+        }),
+      })
+    )
+
+    const ruleInstance = createParameterizationRuleInstance(jsonRule)
+
+    ruleInstance.apply(requestSnippet)
+
+    expect(ruleInstance.state.requestsReplaced[0]?.original).toStrictEqual(
+      requestSnippet.data.request
+    )
+
+    expect(ruleInstance.state.requestsReplaced[0]?.replaced).toStrictEqual({
+      ...requestSnippet.data.request,
+      content: '{"user_id":"TEST_ID"}',
+    })
+  })
   it('supports custom code')
   it('supports array variables')
 })

--- a/src/rules/parameterization.test.ts
+++ b/src/rules/parameterization.test.ts
@@ -1,0 +1,121 @@
+import { createProxyData, createRequest } from '@/test/factories/proxyData'
+import { ParameterizationRule } from '@/types/rules'
+import { describe, expect, it } from 'vitest'
+import { createParameterizationRuleInstance } from './parameterization'
+import { ProxyData } from '@/types'
+import {
+  headerRule,
+  jsonRule,
+  urlRule,
+} from '@/test/fixtures/parameterizationRules'
+
+describe('applyParameterization', () => {
+  it('replaces string value', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          headers: [['content-Type', 'application/json']],
+          content: JSON.stringify({ user_id: '123' }),
+        }),
+      })
+    )
+
+    const updatedRequest =
+      createParameterizationRuleInstance(jsonRule).apply(requestSnippet)
+
+    expect(updatedRequest.data.request.content).toBe('{"user_id":"TEST_ID"}')
+  })
+
+  it('replaces value in URL', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          url: 'http://example.com/api/v1/users?user_id=123&foo=bar',
+        }),
+      })
+    )
+
+    const updatedRequest =
+      createParameterizationRuleInstance(urlRule).apply(requestSnippet)
+
+    expect(updatedRequest.data.request.url).toBe(
+      'http://example.com/api/v1/users?user_id=TEST_ID&foo=bar'
+    )
+  })
+
+  it('replaces value in headers', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          headers: [['authorization', 'token 123']],
+        }),
+      })
+    )
+    const updatedRequest =
+      createParameterizationRuleInstance(headerRule).apply(requestSnippet)
+
+    expect(updatedRequest.data.request.headers).toStrictEqual([
+      ['authorization', 'token TEST_TOKEN'],
+    ])
+  })
+
+  it('replaces variable', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          headers: [['content-Type', 'application/json']],
+          content: JSON.stringify({ user_id: '123' }),
+        }),
+      })
+    )
+
+    const variableRule: ParameterizationRule = {
+      ...jsonRule,
+      value: {
+        type: 'variable',
+        variableName: 'test_variable',
+      },
+    }
+
+    const updatedRequest =
+      createParameterizationRuleInstance(variableRule).apply(requestSnippet)
+
+    expect(updatedRequest.data.request.content).toBe(
+      '{"user_id":"${VARS[\'test_variable\']}"}'
+    )
+  })
+
+  it('does not apply rule if filter does not match', () => {
+    const requestSnippet = createRequestSnippet(
+      createProxyData({
+        request: createRequest({
+          headers: [['content-Type', 'application/json']],
+          content: JSON.stringify({ user_id: '123' }),
+          url: 'http://example.com/api/v1/',
+        }),
+      })
+    )
+
+    const notMatchingRule = {
+      ...jsonRule,
+      filter: { path: '/api/v1/users/123' },
+    }
+
+    const updatedRequest =
+      createParameterizationRuleInstance(notMatchingRule).apply(requestSnippet)
+
+    expect(updatedRequest.data.request.content).toBe('{"user_id":"123"}')
+  })
+
+  it('saves replaced requests')
+  it('supports custom code')
+  it('supports array variables')
+})
+
+function createRequestSnippet(proxyData: ProxyData) {
+  return {
+    data: proxyData,
+    before: [],
+    after: [],
+  }
+}

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -1,0 +1,73 @@
+import { RequestSnippetSchema } from '@/types'
+import {
+  ParameterizationRule,
+  ParameterizationRuleInstance,
+  ParameterizationState,
+} from '@/types/rules'
+import { exhaustive } from '@/utils/typescript'
+import { replaceRequestValues } from './shared'
+import { matchFilter } from './utils'
+import { isEqual } from 'lodash-es'
+
+export function createParameterizationRuleInstance(
+  rule: ParameterizationRule
+): ParameterizationRuleInstance {
+  const state: ParameterizationState = {
+    requestsReplaced: [],
+  }
+
+  return {
+    state,
+    rule,
+    type: rule.type,
+    apply: (requestSnippet: RequestSnippetSchema) => {
+      if (!matchFilter(requestSnippet, rule)) {
+        return requestSnippet
+      }
+
+      const updatedRequestSnippet = {
+        ...requestSnippet,
+        data: {
+          ...requestSnippet.data,
+          request: replaceRequestValues({
+            selector: rule.selector,
+            request: requestSnippet.data.request,
+            value: getRuleValue(rule),
+          }),
+        },
+      }
+
+      // Save the original and updated request snippets for preview
+      if (!isEqual(requestSnippet, updatedRequestSnippet)) {
+        state.requestsReplaced = [
+          ...state.requestsReplaced,
+          {
+            original: requestSnippet.data.request,
+            replaced: updatedRequestSnippet.data.request,
+          },
+        ]
+      }
+
+      return updatedRequestSnippet
+    },
+  }
+}
+
+function getRuleValue(rule: ParameterizationRule) {
+  const { value } = rule
+
+  switch (value.type) {
+    case 'string':
+      return value.value
+
+    case 'variable':
+      return `\${VARS['${value.variableName}']}`
+
+    case 'array':
+    case 'customCode':
+      throw new Error('Not implemented')
+
+    default:
+      return exhaustive(value)
+  }
+}

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -41,22 +41,3 @@ export function createRuleInstance<T extends TestRule>(rule: T) {
       return exhaustive(rule)
   }
 }
-
-// TODO: need to make this return exact instance of passed rule
-export function previewRuleChanges<T extends TestRule>({
-  rules,
-  rule,
-  recording,
-}: {
-  rules: T[]
-  rule: T
-  recording: ProxyData[]
-}) {
-  const preceedingRules = rules.slice(0, rules.indexOf(rule))
-  const { requestSnippetSchemas } = applyRules(recording, preceedingRules)
-
-  const ruleInstance = createRuleInstance(rule)
-  requestSnippetSchemas.forEach(ruleInstance.apply)
-
-  return ruleInstance
-}

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -1,19 +1,17 @@
-import { RuleInstance, TestRule } from '@/types/rules'
+import { TestRule } from '@/types/rules'
 import { exhaustive } from '../utils/typescript'
 import { createCustomCodeRuleInstance } from './customCode'
 import { createCorrelationRuleInstance } from './correlation'
 import { createVerificationRuleInstance } from './verification'
 import { createParameterizationRuleInstance } from './parameterization'
 import { ProxyData, RequestSnippetSchema } from '@/types'
+import { generateSequentialInt } from './utils'
 
-export function applyRules(
-  recording: ProxyData[],
-  rules: TestRule[]
-): {
-  requestSnippetSchemas: RequestSnippetSchema[]
-  ruleInstances: RuleInstance[]
-} {
-  const ruleInstances = rules.map(createRuleInstance)
+export function applyRules(recording: ProxyData[], rules: TestRule[]) {
+  const idGenerator = generateSequentialInt()
+  const ruleInstances = rules.map((rule) =>
+    createRuleInstance(rule, idGenerator)
+  )
 
   const requestSnippetSchemas = recording.map((data) =>
     ruleInstances.reduce<RequestSnippetSchema>((acc, rule) => rule.apply(acc), {
@@ -26,10 +24,13 @@ export function applyRules(
   return { requestSnippetSchemas, ruleInstances }
 }
 
-export function createRuleInstance<T extends TestRule>(rule: T) {
+export function createRuleInstance<T extends TestRule>(
+  rule: T,
+  idGenerator: Generator<number>
+) {
   switch (rule.type) {
     case 'correlation':
-      return createCorrelationRuleInstance(rule)
+      return createCorrelationRuleInstance(rule, idGenerator)
     case 'parameterization':
       return createParameterizationRuleInstance(rule)
     case 'verification':

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -1,31 +1,62 @@
-/* eslint-disable  @typescript-eslint/no-non-null-assertion */
-import { RequestSnippetSchema } from '@/types'
-import { CorrelationStateMap, TestRule } from '@/types/rules'
+import { RuleInstance, TestRule } from '@/types/rules'
 import { exhaustive } from '../utils/typescript'
-import { applyCustomCodeRule } from './customCode'
-import { applyCorrelationRule } from './correlation'
-import { applyVerificationRule } from './verification'
+import { createCustomCodeRuleInstance } from './customCode'
+import { createCorrelationRuleInstance } from './correlation'
+import { createVerificationRuleInstance } from './verification'
+import { createParameterizationRuleInstance } from './parameterization'
+import { ProxyData, RequestSnippetSchema } from '@/types'
 
-export function applyRule(
-  requestSnippetSchema: RequestSnippetSchema,
-  rule: TestRule,
-  correlationStateMap: CorrelationStateMap,
-  sequentialIdGenerator: Generator<number>
-): RequestSnippetSchema {
+export function applyRules(
+  recording: ProxyData[],
+  rules: TestRule[]
+): {
+  requestSnippetSchemas: RequestSnippetSchema[]
+  ruleInstances: RuleInstance[]
+} {
+  const ruleInstances = rules.map(createRuleInstance)
+
+  const requestSnippetSchemas = recording.map((data) =>
+    ruleInstances.reduce<RequestSnippetSchema>((acc, rule) => rule.apply(acc), {
+      data,
+      before: [],
+      after: [],
+    })
+  )
+
+  return { requestSnippetSchemas, ruleInstances }
+}
+
+export function createRuleInstance<T extends TestRule>(rule: T) {
   switch (rule.type) {
-    case 'customCode':
-      return applyCustomCodeRule(requestSnippetSchema, rule)
     case 'correlation':
-      return applyCorrelationRule(
-        requestSnippetSchema,
-        rule,
-        correlationStateMap,
-        sequentialIdGenerator
-      )
+      return createCorrelationRuleInstance(rule)
     case 'parameterization':
+      return createParameterizationRuleInstance(rule)
     case 'verification':
-      return applyVerificationRule(requestSnippetSchema)
+      return createVerificationRuleInstance(rule)
+    case 'customCode':
+      return createCustomCodeRuleInstance(rule)
+
     default:
       return exhaustive(rule)
   }
+}
+
+// TODO: need to make this return exact instance of passed rule
+export function previewRuleChanges<T extends TestRule>({
+  rules,
+  rule,
+  recording,
+}: {
+  rules: T[]
+  rule: T
+  recording: ProxyData[]
+}) {
+  const preceedingRules = rules.slice(0, rules.indexOf(rule))
+  const { requestSnippetSchemas } = applyRules(recording, preceedingRules)
+
+  const ruleInstance = createRuleInstance(rule)
+  requestSnippetSchemas.forEach(ruleInstance.apply)
+
+  return ruleInstance
 }

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -1,8 +1,98 @@
 import { escapeRegExp, get, set } from 'lodash-es'
 import { safeJsonParse } from '@/utils/json'
 import { Header, Request, Cookie } from '@/types'
-import { BeginEndSelector, JsonSelector, RegexSelector } from '@/types/rules'
+import {
+  BeginEndSelector,
+  JsonSelector,
+  RegexSelector,
+  Selector,
+} from '@/types/rules'
 import { isJsonReqResp } from './utils'
+import { exhaustive } from '@/utils/typescript'
+
+export function replaceRequestValues({
+  selector,
+  value,
+  request,
+}: {
+  selector: Selector
+  request: Request
+  value: string
+}) {
+  switch (selector.type) {
+    case 'begin-end':
+      return replaceBeginEnd(selector, request, value)
+    case 'regex':
+      return replaceRegex(selector, request, value)
+    case 'json':
+      return replaceJsonBody(selector, request, value)
+    default:
+      return exhaustive(selector)
+  }
+}
+
+const replaceBeginEnd = (
+  selector: BeginEndSelector,
+  request: Request,
+  variableName: string
+) => {
+  switch (selector.from) {
+    case 'body':
+      return replaceBeginEndBody(selector, request, variableName)
+    case 'headers':
+      return replaceBeginEndHeaders(selector, request, variableName)
+    case 'url':
+      return replaceBeginEndUrl(selector, request, variableName)
+    default:
+      return exhaustive(selector.from)
+  }
+}
+
+const replaceRegex = (
+  selector: RegexSelector,
+  request: Request,
+  variableName: string
+) => {
+  switch (selector.from) {
+    case 'body':
+      return replaceRegexBody(selector, request, variableName)
+    case 'headers':
+      return replaceRegexHeaders(selector, request, variableName)
+    case 'url':
+      return replaceRegexUrl(selector, request, variableName)
+    default:
+      return exhaustive(selector.from)
+  }
+}
+
+export function replaceTextMatches(
+  request: Request,
+  extractedValue: string,
+  variableName: string
+): Request {
+  const content = replaceContent(request.content, extractedValue, variableName)
+  const url = replaceUrl(request.url, extractedValue, variableName)
+  const path = request.path.replaceAll(extractedValue, `\${${variableName}}`)
+  const headers: Header[] = replaceHeaders(
+    request.headers,
+    extractedValue,
+    variableName
+  )
+  const cookies: Cookie[] = replaceCookies(
+    request.cookies,
+    extractedValue,
+    variableName
+  )
+
+  return {
+    ...request,
+    content,
+    url,
+    path,
+    headers,
+    cookies,
+  }
+}
 
 export const matchBeginEnd = (value: string, begin: string, end: string) => {
   // matches only the first occurrence
@@ -39,26 +129,22 @@ export const setJsonObjectFromPath = (
 export const replaceContent = (
   content: string | null,
   value: string,
-  variableName: string
+  newValue: string
 ) => {
-  return content?.replaceAll(value, `\${${variableName}}`) ?? null
+  return content?.replaceAll(value, newValue) ?? null
 }
 
-export const replaceUrl = (
-  url: string,
-  value: string,
-  variableName: string
-) => {
-  return url.replaceAll(value, `\${${variableName}}`)
+export const replaceUrl = (url: string, value: string, newValue: string) => {
+  return url.replaceAll(value, newValue)
 }
 
 export const replaceHeaders = (
   headers: Header[],
   value: string,
-  variableName: string
+  newValue: string
 ): Header[] => {
   return headers.map(([key, headerValue]) => {
-    const replacedValue = headerValue.replaceAll(value, `\${${variableName}}`)
+    const replacedValue = headerValue.replaceAll(value, newValue)
     return [key, replacedValue]
   })
 }
@@ -66,10 +152,10 @@ export const replaceHeaders = (
 export const replaceCookies = (
   cookies: Cookie[],
   value: string,
-  variableName: string
+  newValue: string
 ): Cookie[] => {
   return cookies.map(([key, cookieValue]) => {
-    const replacedValue = cookieValue.replaceAll(value, `\${${variableName}}`)
+    const replacedValue = cookieValue.replaceAll(value, newValue)
     return [key, replacedValue]
   })
 }
@@ -123,7 +209,8 @@ export const replaceBeginEndUrl = (
   if (!valueToReplace) return request
 
   const url = replaceUrl(request.url, valueToReplace, variableName)
-  return { ...request, url }
+  const path = replaceUrl(request.path, valueToReplace, variableName)
+  return { ...request, url, path }
 }
 
 export const replaceRegexBody = (
@@ -173,7 +260,7 @@ export const replaceRegexUrl = (
 export const replaceJsonBody = (
   selector: JsonSelector,
   request: Request,
-  variableName: string
+  value: string
 ) => {
   if (!isJsonReqResp(request) || !request.content) {
     return request
@@ -184,11 +271,7 @@ export const replaceJsonBody = (
   const valueToReplace = getJsonObjectFromPath(request.content, selector.path)
   if (!valueToReplace) return request
 
-  const content = setJsonObjectFromPath(
-    request.content,
-    selector.path,
-    `\${${variableName}}`
-  )
+  const content = setJsonObjectFromPath(request.content, selector.path, value)
   return { ...request, content }
 }
 
@@ -256,7 +339,7 @@ if (import.meta.vitest) {
 
   it('replace content', () => {
     const request = generateRequest('<div>hello</div>')
-    expect(replaceContent(request.content, 'hello', 'correl_0')).toBe(
+    expect(replaceContent(request.content, 'hello', '${correl_0}')).toBe(
       '<div>${correl_0}</div>'
     )
     expect(replaceContent(request.content, 'world', 'correl_0')).toBe(
@@ -267,16 +350,16 @@ if (import.meta.vitest) {
   it('replace headers', () => {
     const request = generateRequest('')
     expect(
-      replaceHeaders(request.headers, 'application', 'correl_0')[0]
+      replaceHeaders(request.headers, 'application', '${correl_0}')[0]
     ).toStrictEqual(['content-type', '${correl_0}/json'])
     expect(
-      replaceHeaders(request.headers, 'protobuf', 'correl_0')[0]
+      replaceHeaders(request.headers, 'protobuf', '${correl_0}')[0]
     ).toStrictEqual(['content-type', 'application/json'])
   })
 
   it('replace url', () => {
     const request = generateRequest('')
-    expect(replaceUrl(request.url, 'api', 'correl_0')).toBe(
+    expect(replaceUrl(request.url, 'api', '${correl_0}')).toBe(
       'http://test.k6.io/${correl_0}/v1/foo'
     )
     expect(replaceUrl(request.url, 'jumanji', 'correl_0')).toBe(
@@ -286,10 +369,9 @@ if (import.meta.vitest) {
 
   it('replace cookies', () => {
     const request = generateRequest('')
-    expect(replaceCookies(request.cookies, 'on', 'correl_0')[0]).toStrictEqual([
-      'security',
-      'n${correl_0}e',
-    ])
+    expect(
+      replaceCookies(request.cookies, 'on', '${correl_0}')[0]
+    ).toStrictEqual(['security', 'n${correl_0}e'])
     expect(
       replaceCookies(request.cookies, 'notincookie', 'correl_0')[0]
     ).toStrictEqual(['security', 'none'])
@@ -306,7 +388,7 @@ if (import.meta.vitest) {
       replaceBeginEndBody(
         selector,
         generateRequest('<div>hello</div>'),
-        'correl_0'
+        '${correl_0}'
       ).content
     ).toBe('<div>${correl_0}</div>')
     expect(
@@ -330,7 +412,7 @@ if (import.meta.vitest) {
       end: 'world',
     }
     expect(
-      replaceBeginEndHeaders(selectorMatch, request, 'correl_0').headers[0]
+      replaceBeginEndHeaders(selectorMatch, request, '${correl_0}').headers[0]
     ).toStrictEqual(['content-type', 'application${correl_0}json'])
     expect(
       replaceBeginEndHeaders(selectorNotMatch, request, 'correl_0').headers[0]
@@ -351,9 +433,11 @@ if (import.meta.vitest) {
       begin: 'supercali',
       end: 'fragilisti',
     }
-    expect(replaceBeginEndUrl(selectorMatch, request, 'correl_0').url).toBe(
-      'http://test.k6.io/${correl_0}/v1/foo'
-    )
+    const match = replaceBeginEndUrl(selectorMatch, request, '${correl_0}')
+
+    expect(match.url).toBe('http://test.k6.io/${correl_0}/v1/foo')
+    expect(match.path).toBe('/${correl_0}/v1/foo')
+
     expect(replaceBeginEndUrl(selectorNotMatch, request, 'correl_0').url).toBe(
       'http://test.k6.io/api/v1/foo'
     )
@@ -369,7 +453,7 @@ if (import.meta.vitest) {
       replaceRegexBody(
         selector,
         generateRequest('<div>hello</div>'),
-        'correl_0'
+        '${correl_0}'
       ).content
     ).toBe('<div>${correl_0}</div>')
     expect(
@@ -391,7 +475,7 @@ if (import.meta.vitest) {
       regex: 'hello(.*?)world',
     }
     expect(
-      replaceRegexHeaders(selectorMatch, request, 'correl_0').headers[0]
+      replaceRegexHeaders(selectorMatch, request, '${correl_0}').headers[0]
     ).toStrictEqual(['content-type', 'application${correl_0}json'])
     expect(
       replaceRegexHeaders(selectorNotMatch, request, 'correl_0').headers[0]
@@ -410,7 +494,7 @@ if (import.meta.vitest) {
       from: 'url',
       regex: 'supercali(.*?)fragilisti',
     }
-    expect(replaceRegexUrl(selectorMatch, request, 'correl_0').url).toBe(
+    expect(replaceRegexUrl(selectorMatch, request, '${correl_0}').url).toBe(
       'http://test.k6.io/${correl_0}/v1/foo'
     )
     expect(replaceRegexUrl(selectorNotMatch, request, 'correl_0').url).toBe(
@@ -438,21 +522,21 @@ if (import.meta.vitest) {
       replaceJsonBody(
         selectorMatch,
         generateRequest('{"hello":"world"}'),
-        'correl_0'
+        '${correl_0}'
       ).content
     ).toBe('{"hello":"${correl_0}"}')
     expect(
       replaceJsonBody(
         selectorNotMatch,
         generateRequest('{"hello":"world"}'),
-        'correl_0'
+        '${correl_0}'
       ).content
     ).toBe('{"hello":"world"}')
     expect(
       replaceJsonBody(
         selectorMatchArray,
         generateRequest('[{"hello":"world"}]'),
-        'correl_0'
+        '${correl_0}'
       ).content
     ).toBe('[{"hello":"${correl_0}"}]')
   })

--- a/src/rules/verification.ts
+++ b/src/rules/verification.ts
@@ -1,21 +1,28 @@
 import { RequestSnippetSchema } from '@/types'
+import { VerificationRule, VerificationRuleInstance } from '@/types/rules'
 
-export function applyVerificationRule(
-  requestSnippetSchema: RequestSnippetSchema
-): RequestSnippetSchema {
-  const response = requestSnippetSchema.data.response
+export function createVerificationRuleInstance(
+  rule: VerificationRule
+): VerificationRuleInstance {
+  return {
+    rule,
+    type: rule.type,
+    apply: (requestSnippetSchema: RequestSnippetSchema) => {
+      const response = requestSnippetSchema.data.response
 
-  if (!response) {
-    return requestSnippetSchema
-  }
+      if (!response) {
+        return requestSnippetSchema
+      }
 
-  const verificationSnippet = `
+      const verificationSnippet = `
 check(resp, {
     'status matches ${response.statusCode}': (r) => r.status === ${response.statusCode},
   })
 `
-  return {
-    ...requestSnippetSchema,
-    after: [...requestSnippetSchema['after'], verificationSnippet],
+      return {
+        ...requestSnippetSchema,
+        after: [...requestSnippetSchema['after'], verificationSnippet],
+      }
+    },
   }
 }

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -21,6 +21,11 @@ export const RecordedValueSchema = z.object({
   type: z.literal('recordedValue'),
 })
 
+export const StringValueSchema = z.object({
+  type: z.literal('string'),
+  value: z.string(),
+})
+
 export const FilterSchema = z.object({
   path: z.string(),
 })
@@ -73,7 +78,8 @@ export const VerificationRuleSelectorSchema = z.discriminatedUnion('type', [
   BeginEndSelectorSchema,
   RegexSelectorSchema,
   JsonSelectorSchema,
-  StatusCodeSelectorSchema,
+  // TODO: verify if save to disable
+  // StatusCodeSelectorSchema,
 ])
 
 export const CorrelationExtractorSchema = z.object({
@@ -99,6 +105,7 @@ export const ParameterizationRuleSchema = RuleBaseSchema.extend({
     VariableValueSchema,
     ArrayValueSchema,
     CustomCodeValueSchema,
+    StringValueSchema,
   ]),
 })
 

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -78,8 +78,6 @@ export const VerificationRuleSelectorSchema = z.discriminatedUnion('type', [
   BeginEndSelectorSchema,
   RegexSelectorSchema,
   JsonSelectorSchema,
-  // TODO: verify if save to disable
-  // StatusCodeSelectorSchema,
 ])
 
 export const CorrelationExtractorSchema = z.object({

--- a/src/test/fixtures/correlationRecording.ts
+++ b/src/test/fixtures/correlationRecording.ts
@@ -23,7 +23,10 @@ export const correlationRecording: ProxyData[] = [
       path: '/api/v1/foo',
       reason: 'OK',
       httpVersion: '1.1',
-      headers: [['Content-Type', 'application/json']],
+      headers: [
+        ['Content-Type', 'application/json'],
+        ['project', 'project_id=555'],
+      ],
       cookies: [],
       content: JSON.stringify({ user_id: '444' }),
       contentLength: 0,
@@ -35,7 +38,7 @@ export const correlationRecording: ProxyData[] = [
     id: '2',
     request: {
       method: 'POST',
-      url: 'http://test.k6.io/api/v1/login',
+      url: 'http://test.k6.io/api/v1/login?project_id=555',
       headers: [],
       cookies: [],
       query: [],

--- a/src/test/fixtures/parameterizationRules.ts
+++ b/src/test/fixtures/parameterizationRules.ts
@@ -36,10 +36,9 @@ export const headerRule: ParameterizationRule = {
   id: '3',
   filter: { path: '' },
   selector: {
-    type: 'begin-end',
+    type: 'regex',
     from: 'headers',
-    begin: 'token ',
-    end: '$',
+    regex: 'token (.+)$',
   },
   value: {
     type: 'string',

--- a/src/test/fixtures/parameterizationRules.ts
+++ b/src/test/fixtures/parameterizationRules.ts
@@ -1,0 +1,48 @@
+import { ParameterizationRule } from '@/types/rules'
+
+export const jsonRule: ParameterizationRule = {
+  type: 'parameterization',
+  id: '1',
+  filter: { path: '' },
+  selector: {
+    type: 'json',
+    from: 'body',
+    path: 'user_id',
+  },
+  value: {
+    type: 'string',
+    value: 'TEST_ID',
+  },
+}
+
+export const urlRule: ParameterizationRule = {
+  type: 'parameterization',
+  id: '2',
+  filter: { path: '' },
+  selector: {
+    type: 'begin-end',
+    from: 'url',
+    begin: 'user_id=',
+    end: '&',
+  },
+  value: {
+    type: 'string',
+    value: 'TEST_ID',
+  },
+}
+
+export const headerRule: ParameterizationRule = {
+  type: 'parameterization',
+  id: '3',
+  filter: { path: '' },
+  selector: {
+    type: 'begin-end',
+    from: 'headers',
+    begin: 'token ',
+    end: '$',
+  },
+  value: {
+    type: 'string',
+    value: 'TEST_TOKEN',
+  },
+}

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -32,7 +32,6 @@ export interface CorrelationState {
     replaced: Request
   }[]
   generatedUniqueId: number | undefined
-  sequentialIdGenerator: Generator<number>
 }
 
 export interface BaseRuleInstance<T extends TestRule> {

--- a/src/utils/prettify.ts
+++ b/src/utils/prettify.ts
@@ -1,0 +1,11 @@
+import { format } from 'prettier/standalone'
+import * as prettierPluginBabel from 'prettier/plugins/babel'
+// eslint-disable-next-line import/namespace
+import * as prettierPluginEStree from 'prettier/plugins/estree'
+
+export function prettify(code: string) {
+  return format(code, {
+    parser: 'babel',
+    plugins: [prettierPluginBabel, prettierPluginEStree],
+  })
+}

--- a/src/views/Generator/Generator.utils.ts
+++ b/src/views/Generator/Generator.utils.ts
@@ -1,8 +1,4 @@
 import { generateScript } from '@/codegen'
-import { format } from 'prettier/standalone'
-import * as prettierPluginBabel from 'prettier/plugins/babel'
-// eslint-disable-next-line import/namespace
-import * as prettierPluginEStree from 'prettier/plugins/estree'
 import { groupProxyData } from '@/utils/groups'
 import {
   selectFilteredRequests,
@@ -13,6 +9,7 @@ import { GeneratorFileData } from '@/types/generator'
 import { GeneratorFileDataSchema } from '@/schemas/generator'
 import { harToProxyData } from '@/utils/harToProxyData'
 import { GroupedProxyData } from '@/types'
+import { prettify } from '@/utils/prettify'
 
 export async function generateScriptPreview(
   generator: GeneratorFileData,
@@ -22,12 +19,8 @@ export async function generateScriptPreview(
     generator,
     recording,
   })
-  const prettifiedScript = await format(script, {
-    parser: 'babel',
-    plugins: [prettierPluginBabel, prettierPluginEStree],
-  })
 
-  return prettifiedScript
+  return prettify(script)
 }
 
 export function saveScript(script: string, fileName: string) {

--- a/src/views/Generator/RulePreview/CorrelationPreview.tsx
+++ b/src/views/Generator/RulePreview/CorrelationPreview.tsx
@@ -104,7 +104,6 @@ export function CorrelationPreview({ rule }: { rule: CorrelationRule }) {
 export function requestsReplacedToProxyData(
   requests: { replaced: Request }[]
 ): ProxyData[] {
-  console.log('request', requests)
   return requests.map(({ replaced }, i) => ({
     request: replaced,
     id: i.toString(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This is the first PR of parameterization rule implementation, includes rule logic, unit tests, and a refactor of how we currently apply rules.

### Refactor rule application:
Some rules need to have a state to keep track of extracted value, requests matched and sequential variable IDs. Currently, it was done by using `correlationState` object, which was passed as argument when applying rules. Parameterization rule required a state to keep track of replaced requests and, while similar to correlation state, it didn't require all its properties. 

To address this, I've introduced Rule instances with the following structure:

```ts
export interface RuleInstance {
  apply: (request: RequestSnippetSchema) => RequestSnippetSchema
  rule: TestRule
  state: CorrelationState | ParameterizationState | other 
}
```

This allowed to encapsulate state inside rule instance, reduce coupling because consumers applying rules no longer need to know about rule's state. 



## How to Test

1. Verify correlation and other existing rules still works as expected. 
2. The parameterization rule could be tested by manually adding rules to the generator, but it will be easier to do in the follow PR which adds UI

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
