### PR TITLE
feat: remember window size and position

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -628,8 +628,7 @@ function showWindow(browserWindow: BrowserWindow) {
 }
 
 function trackWindowState(browserWindow: BrowserWindow) {
-  const [width, height] = browserWindow.getSize() as [number, number]
-  const [x, y] = browserWindow.getPosition() as [number, number]
+  const { width, height, x, y } = browserWindow.getBounds()
   const isMaximized = browserWindow.isMaximized()
   appSettings.windowState = {
     width,
@@ -638,7 +637,11 @@ function trackWindowState(browserWindow: BrowserWindow) {
     y,
     isMaximized,
   }
-  saveSettings(appSettings)
+  try {
+    saveSettings(appSettings)
+  } catch (error) {
+    log.error(error)
+  }
 }
 
 function configureWatcher(browserWindow: BrowserWindow) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,10 +121,14 @@ const createWindow = async () => {
   // clean leftover proxies if any, this might happen on windows
   await cleanUpProxies()
 
+  const { width, height, x, y } = appSettings.windowState
+
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    width: 1200,
-    height: 800,
+    x,
+    y,
+    width,
+    height,
     minWidth: 800,
     minHeight: 600,
     show: false,
@@ -162,6 +166,9 @@ const createWindow = async () => {
   mainWindow.on('closed', () =>
     proxyEmitter.removeAllListeners('status:change')
   )
+
+  mainWindow.on('move', () => trackWindowState(mainWindow))
+  mainWindow.on('resize', () => trackWindowState(mainWindow))
 
   return mainWindow
 }
@@ -611,8 +618,27 @@ const launchProxyAndAttachEmitter = async (browserWindow: BrowserWindow) => {
 }
 
 function showWindow(browserWindow: BrowserWindow) {
-  browserWindow.maximize()
+  const { isMaximized } = appSettings.windowState
+  if (isMaximized) {
+    browserWindow.maximize()
+  } else {
+    browserWindow.show()
+  }
   browserWindow.focus()
+}
+
+function trackWindowState(browserWindow: BrowserWindow) {
+  const [width, height] = browserWindow.getSize() as [number, number]
+  const [x, y] = browserWindow.getPosition() as [number, number]
+  const isMaximized = browserWindow.isMaximized()
+  appSettings.windowState = {
+    width,
+    height,
+    x,
+    y,
+    isMaximized,
+  }
+  saveSettings(appSettings)
 }
 
 function configureWatcher(browserWindow: BrowserWindow) {

--- a/src/schemas/appSettings.ts
+++ b/src/schemas/appSettings.ts
@@ -81,8 +81,17 @@ export const RecorderSettingsSchema = z
     }
   })
 
+const WindowStateSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  width: z.number().int(),
+  height: z.number().int(),
+  isMaximized: z.boolean(),
+})
+
 export const AppSettingsSchema = z.object({
   version: z.string(),
   proxy: ProxySettingsSchema,
   recorder: RecorderSettingsSchema,
+  windowState: WindowStateSchema,
 })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,13 @@ const defaultSettings: AppSettings = {
   recorder: {
     detectBrowserPath: true,
   },
+  windowState: {
+    width: 1200,
+    height: 800,
+    x: 0,
+    y: 0,
+    isMaximized: true,
+  },
 }
 
 const fileName =
@@ -42,7 +49,11 @@ export async function getSettings() {
   const fileHandle = await open(filePath, 'r')
   try {
     const settings = await fileHandle?.readFile({ encoding: 'utf-8' })
-    return JSON.parse(settings) as AppSettings
+    const currentSettings = JSON.parse(settings) as AppSettings
+    return {
+      ...defaultSettings,
+      ...currentSettings,
+    }
   } finally {
     await fileHandle?.close()
   }
@@ -54,7 +65,6 @@ export async function getSettings() {
  * @returns The settings that have changed
  */
 export async function saveSettings(newSettings: AppSettings) {
-  console.log(newSettings)
   const currentSettings = await getSettings()
   const diff = getSettingsDiff(currentSettings, newSettings)
   await writeFile(filePath, JSON.stringify(newSettings))

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -49,7 +49,7 @@ export async function getSettings() {
   const fileHandle = await open(filePath, 'r')
   try {
     const settings = await fileHandle?.readFile({ encoding: 'utf-8' })
-    const currentSettings = JSON.parse(settings) as AppSettings
+    const currentSettings = AppSettingsSchema.parse(JSON.parse(settings))
     return {
       ...defaultSettings,
       ...currentSettings,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR persists the window bounds (x, y, width, and height) in the settings file so these options are remembered next time the application restarts.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

- launch the app
- resize the window and move it around the screen
- reopen the app
- check that position and dimensions are remembered

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/238

<!-- Thanks for your contribution! 🙏🏼 -->
