### PR TITLE
feat: Display a message when recording used by generator is missing

### DIFF
--- a/src/components/EmptyMessage.tsx
+++ b/src/components/EmptyMessage.tsx
@@ -3,13 +3,11 @@ import { Flex, Text } from '@radix-ui/themes'
 import { ReactNode } from 'react'
 import grotIllustration from '@/assets/grot.svg'
 
-interface NoRequestsMessageProps {
-  message?: ReactNode
+interface EmptyMessageProps {
+  message: ReactNode
 }
 
-export function NoRequestsMessage({
-  message = 'Your requests will appear here.',
-}: NoRequestsMessageProps) {
+export function EmptyMessage({ message }: EmptyMessageProps) {
   return (
     <Flex direction="column" align="center" gap="4" pt="8">
       <img

--- a/src/views/Generator/GeneratorSidebar/RequestList.tsx
+++ b/src/views/Generator/GeneratorSidebar/RequestList.tsx
@@ -11,6 +11,9 @@ import { Filter } from '@/components/WebLogView/Filter'
 import { useFilterRequests } from '@/components/WebLogView/Filter.hooks'
 import { RecordingSelector } from '../RecordingSelector'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
+import { useStudioUIStore } from '@/store/ui'
+import { useGeneratorStore } from '@/store/generator'
+import { EmptyMessage } from '@/components/EmptyMessage'
 
 interface RequestListProps {
   requests: ProxyData[]
@@ -21,6 +24,13 @@ export function RequestList({ requests }: RequestListProps) {
   const { filter, setFilter, filteredRequests } = useFilterRequests(requests)
 
   const groups = useProxyDataGroups(requests)
+
+  const recordings = useStudioUIStore((state) => state.recordings)
+  const recordingPath = useGeneratorStore((state) => state.recordingPath)
+
+  const recording = recordings.find((recording) => recording === recordingPath)
+
+  const isRecordingMissing = recording === undefined && recordingPath !== ''
 
   // Preserve the selected request when modifying rules
   useShallowCompareEffect(() => {
@@ -40,23 +50,32 @@ export function RequestList({ requests }: RequestListProps) {
         <Allotment vertical defaultSizes={[1, 2]}>
           <Allotment.Pane minSize={200}>
             <ScrollArea scrollbars="vertical">
-              <Filter
-                filter={filter}
-                setFilter={setFilter}
-                css={{
-                  borderRadius: 0,
-                  outlineOffset: '-2px',
-                  boxShadow: 'none',
-                  borderTop: '1px solid var(--gray-a5)',
-                }}
-                size="2"
-              />
-              <WebLogView
-                requests={filteredRequests}
-                selectedRequestId={selectedRequest?.id}
-                onSelectRequest={setSelectedRequest}
-                groups={groups}
-              />
+              {isRecordingMissing && (
+                <Flex direction="column" justify="center" align="center">
+                  <EmptyMessage message="The selected recording is missing" />
+                </Flex>
+              )}
+              {!isRecordingMissing && (
+                <>
+                  <Filter
+                    filter={filter}
+                    setFilter={setFilter}
+                    css={{
+                      borderRadius: 0,
+                      outlineOffset: '-2px',
+                      boxShadow: 'none',
+                      borderTop: '1px solid var(--gray-a5)',
+                    }}
+                    size="2"
+                  />
+                  <WebLogView
+                    requests={filteredRequests}
+                    selectedRequestId={selectedRequest?.id}
+                    onSelectRequest={setSelectedRequest}
+                    groups={groups}
+                  />
+                </>
+              )}
             </ScrollArea>
           </Allotment.Pane>
           <Allotment.Pane minSize={300} visible={selectedRequest !== null}>

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -10,10 +10,15 @@ import { useToast } from '@/store/ui/useToast'
 import log from 'electron-log/renderer'
 
 export function RecordingSelector() {
-  const recordingPath = useGeneratorStore((store) => store.recordingPath)
-  const setRecording = useGeneratorStore((store) => store.setRecording)
   const recordings = useStudioUIStore((store) => store.recordings)
+  const recordingPath = useGeneratorStore((store) => store.recordingPath)
+
+  const setRecording = useGeneratorStore((store) => store.setRecording)
   const showToast = useToast()
+
+  const selectedRecording = recordings.find(
+    (recording) => recording === recordingPath
+  )
 
   const handleOpen = async (filePath: string) => {
     try {
@@ -57,11 +62,17 @@ export function RecordingSelector() {
             id="recording-selector"
             placeholder="Select recording"
             css={css`
+              min-width: 200px;
               max-width: 200px;
             `}
           />
         </Tooltip>
         <Select.Content position="popper">
+          {selectedRecording === undefined && recordingPath !== '' && (
+            <Select.Item value={recordingPath} disabled>
+              {getFileNameWithoutExtension(recordingPath)}
+            </Select.Item>
+          )}
           {recordings.map((harFileName) => (
             <Select.Item value={harFileName} key={harFileName}>
               {getFileNameWithoutExtension(harFileName)}

--- a/src/views/Generator/ValidatorDialog.tsx
+++ b/src/views/Generator/ValidatorDialog.tsx
@@ -6,7 +6,7 @@ import { useListenProxyData } from '@/hooks/useListenProxyData'
 import { useRunLogs } from '@/hooks/useRunLogs'
 import { ValidatorContent } from '@/views/Validator/ValidatorContent'
 import { useRunChecks } from '@/hooks/useRunChecks'
-import { NoRequestsMessage } from '@/components/NoRequestsMessage'
+import { EmptyMessage } from '@/components/EmptyMessage'
 
 interface ValidatorDialogProps {
   script: string
@@ -102,7 +102,7 @@ export function ValidatorDialog({
               logs={logs}
               checks={checks}
               noDataElement={
-                <NoRequestsMessage message="Requests will appear here" />
+                <EmptyMessage message="Requests will appear here" />
               }
               isRunning={isRunning}
             />

--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -17,7 +17,7 @@ import { harToProxyData } from '@/utils/harToProxyData'
 import { getRoutePath } from '@/routeMap'
 import { Details } from '@/components/WebLogView/Details'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
-import { NoRequestsMessage } from '@/components/NoRequestsMessage'
+import { EmptyMessage } from '@/components/EmptyMessage'
 
 export function RecordingPreviewer() {
   const [proxyData, setProxyData] = useState<ProxyData[]>([])
@@ -119,9 +119,7 @@ export function RecordingPreviewer() {
           <RequestsSection
             groups={groups}
             proxyData={proxyData}
-            noDataElement={
-              <NoRequestsMessage message="The recording is empty" />
-            }
+            noDataElement={<EmptyMessage message="The recording is empty" />}
             selectedRequestId={selectedRequest?.id}
             onSelectRequest={setSelectedRequest}
           />

--- a/src/views/Validator/Validator.tsx
+++ b/src/views/Validator/Validator.tsx
@@ -12,7 +12,7 @@ import { useToast } from '@/store/ui/useToast'
 import { useRunChecks } from '@/hooks/useRunChecks'
 import { getFileNameWithoutExtension } from '@/utils/file'
 import { ValidatorEmptyState } from './ValidatorEmptyState'
-import { NoRequestsMessage } from '@/components/NoRequestsMessage'
+import { EmptyMessage } from '@/components/EmptyMessage'
 
 export function Validator() {
   const [isLoading, setIsLoading] = useState(false)
@@ -133,7 +133,7 @@ export function Validator() {
         logs={logs}
         checks={checks}
         noDataElement={
-          <NoRequestsMessage
+          <EmptyMessage
             message={
               <ValidatorEmptyState
                 isRunning={isRunning}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When opening a generator whose selected recording has been deleted the user is greeted with an alert saying that the recording is missing. But the request list is just empty, the dropdown has no item selected, placeholder text is not shown and the request filter is still visible.

This PR does the following:

1. Shows the missing recording as the currently selected recording.
2. Shows the missing recording as an disabled item in the dropdown.
3. Adds a new state that is displayed instead of the request list.

## How to Test

1. Create a test generator.
4. Assign a recording to it.
5. Save the generator.
6. Delete the recording.
7. Open the generator again.

Instead of the request list you should be seeing a message saying that the recording is missing. The missing item should still be selected in the dropdown, but it should be disabled.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/b95fc509-a7f1-4302-82f4-ced25140b02f)

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
