### PR TITLE
fix: Can't clear filter in recording preview when there are no matches

### DIFF
--- a/src/views/Recorder/RequestsSection.tsx
+++ b/src/views/Recorder/RequestsSection.tsx
@@ -44,7 +44,12 @@ export function RequestsSection({
   const groupedProxyData = groupProxyData(filteredRequests)
   const ref = useAutoScroll(groupedProxyData, autoScroll)
 
-  if (filteredRequests.length === 0 && noDataElement) {
+  const showNoDataState =
+    filter === '' &&
+    filteredRequests.length === 0 &&
+    noDataElement !== undefined
+
+  if (showNoDataState) {
     return noDataElement
   }
 
@@ -82,7 +87,6 @@ export function RequestsSection({
           </Box>
         </Flex>
       </Flex>
-
       <ScrollArea scrollbars="both">
         <div ref={ref} css={{ minWidth: '500px' }}>
           <WebLogView


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://github.com/user-attachments/assets/e746b529-b62d-4651-8a9b-9273aae68688

When filtering requests in the recording preview, the no data state is shown if there are no matches. This hides the filter input and makes it impossible to reset the filter without closing the recording and opening it again.

## How to Test

1. Open a recording.
2. Focus the filter input
3. Smash your palm on the keyboard a few times

The filtering should behave the same way as when filtering during recording: the list should just be empty.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/I



ssue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
