### PR TITLE
fix: Settings dialog doesn't always fit inside app window

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 import { Box, Button, Dialog, Flex, ScrollArea } from '@radix-ui/themes'
 import { ProxySettings } from './ProxySettings'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -53,13 +54,19 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
-        maxWidth="100%"
-        width="800px"
-        style={{ overflow: 'hidden' }}
+        maxWidth="800px"
+        maxHeight="640px"
+        width="calc(100vw - 100px)"
+        height="calc(100vh - 100px)"
+        css={css`
+          overflow: hidden;
+          display: flex;
+          flex-direction: column;
+        `}
       >
         <Dialog.Title>Settings</Dialog.Title>
         <FormProvider {...formMethods}>
-          <Box style={{ height: 600, paddingBottom: 'var(--space-4)' }}>
+          <Box pb="4" minHeight="0">
             <ScrollArea>
               <RecorderSettings />
               <ProxySettings />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
Before
<img width="912" alt="image" src="https://github.com/user-attachments/assets/153b29ff-5d27-40f9-b7c4-5ad53bf45f0c">
After
<img width="912" alt="image" src="https://github.com/user-attachments/assets/799e438e-423c-4db2-9c41-b5abef804b9b">



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
