### PR TITLE
fix: prevent infinite error loop on proxy restart

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -577,7 +577,7 @@ async function applySettings(
   browserWindow: BrowserWindow
 ) {
   if (modifiedSettings.proxy) {
-    stopProxyProcess()
+    await stopProxyProcess()
     appSettings.proxy = modifiedSettings.proxy
     proxyEmitter.emit('status:change', 'restarting')
     currentProxyProcess = await launchProxyAndAttachEmitter(browserWindow)
@@ -703,11 +703,15 @@ function getFilePathFromName(name: string) {
   }
 }
 
-const stopProxyProcess = () => {
+const stopProxyProcess = async () => {
   if (currentProxyProcess) {
-    // NOTE: this might not kill the second spawned process on windows
     currentProxyProcess.kill()
     currentProxyProcess = null
+
+    // kill remaining proxies if any, this might happen on windows
+    if (getPlatform() === 'win') {
+      await cleanUpProxies()
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

This PR introduces logic that prevents the proxy from being stuck on an infinite restarting loop. This is known to happen in two occasions:

- When the option to automatically find a port is set to `false` and the currently selected port is busy
- On Windows when there are instances of the proxy still running before new settings can be applied

![proxy-loop-error-windows](https://github.com/user-attachments/assets/e16350c8-8ff8-4252-9a40-50d3794b3d7c)

## How to Test

- Launch an instance of k6 Studio and set the proxy port
- Launch a separate instance of k6 Studio, set the option to automatically find a port to `false` and use the same port as the previous instance.

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![Screenshot 2024-10-24 at 11 38 50 AM](https://github.com/user-attachments/assets/52e26c9c-0474-45e0-8c4a-befda981b451)

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/273

<!-- Thanks for your contribution! 🙏🏼 -->
