### PR TITLE
fix: disable window reloading in prod build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import {
   selectUpstreamCertificate,
 } from './settings'
 import { ProxyStatus } from './types'
+import { configureApplicationMenu } from './menu'
 
 // handle auto updates
 if (process.env.NODE_ENV !== 'development') {
@@ -163,7 +164,10 @@ const createWindow = async () => {
     mainWindow.webContents.openDevTools({ mode: 'detach' })
   }
 
-  mainWindow.once('ready-to-show', () => configureWatcher(mainWindow))
+  mainWindow.once('ready-to-show', () => {
+    configureApplicationMenu()
+    configureWatcher(mainWindow)
+  })
   proxyEmitter.on('status:change', (statusName: ProxyStatus) => {
     proxyStatus = statusName
     mainWindow.webContents.send('proxy:status:change', statusName)

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -11,7 +11,6 @@ const template: Electron.MenuItemConstructorOptions[] = [
   { role: 'fileMenu' },
   { role: 'editMenu' },
   {
-    // { role: 'viewMenu' }
     label: 'View',
     submenu: [
       ...getDevToolsMenu(),

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,0 +1,49 @@
+import { Menu, shell } from 'electron'
+
+const isDevEnv = process.env.NODE_ENV === 'development'
+
+// Custom application menu
+// https://www.electronjs.org/docs/latest/api/menu
+const template: Electron.MenuItemConstructorOptions[] = [
+  { role: 'appMenu' },
+  { role: 'fileMenu' },
+  { role: 'editMenu' },
+  {
+    // { role: 'viewMenu' }
+    label: 'View',
+    submenu: [
+      ...(isDevEnv
+        ? ([
+            { role: 'reload' },
+            { role: 'forceReload' },
+            { role: 'toggleDevTools' },
+          ] as Electron.MenuItemConstructorOptions[])
+        : []),
+      { type: 'separator' },
+      { role: 'resetZoom' },
+      { role: 'zoomIn' },
+      { role: 'zoomOut' },
+      { type: 'separator' },
+      { role: 'togglefullscreen' },
+    ],
+  },
+  { role: 'windowMenu' },
+  {
+    role: 'help',
+    submenu: [
+      {
+        label: 'Report an issue',
+        click: async () => {
+          await shell.openExternal(
+            'https://github.com/grafana/k6-studio/issues'
+          )
+        },
+      },
+    ],
+  },
+]
+
+export function configureApplicationMenu() {
+  const menu = Menu.buildFromTemplate(template)
+  Menu.setApplicationMenu(menu)
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,24 +1,20 @@
 import { Menu, shell } from 'electron'
+import { getPlatform } from './utils/electron'
 
 const isDevEnv = process.env.NODE_ENV === 'development'
+const isMac = getPlatform() === 'mac'
 
 // Custom application menu
 // https://www.electronjs.org/docs/latest/api/menu
 const template: Electron.MenuItemConstructorOptions[] = [
-  { role: 'appMenu' },
+  ...getAppMenu(),
   { role: 'fileMenu' },
   { role: 'editMenu' },
   {
     // { role: 'viewMenu' }
     label: 'View',
     submenu: [
-      ...(isDevEnv
-        ? ([
-            { role: 'reload' },
-            { role: 'forceReload' },
-            { role: 'toggleDevTools' },
-          ] as Electron.MenuItemConstructorOptions[])
-        : []),
+      ...getDevToolsMenu(),
       { type: 'separator' },
       { role: 'resetZoom' },
       { role: 'zoomIn' },
@@ -42,6 +38,16 @@ const template: Electron.MenuItemConstructorOptions[] = [
     ],
   },
 ]
+
+function getAppMenu(): Electron.MenuItemConstructorOptions[] {
+  return isMac ? [{ role: 'appMenu' }] : []
+}
+
+function getDevToolsMenu(): Electron.MenuItemConstructorOptions[] {
+  return isDevEnv
+    ? [{ role: 'reload' }, { role: 'forceReload' }, { role: 'toggleDevTools' }]
+    : []
+}
 
 export function configureApplicationMenu() {
   const menu = Menu.buildFromTemplate(template)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes some properties from the application menu as long as their key bindings, including:

- Reload: `CMD + R`
- Force reload: `CMD + Shift + R`
- Toggle developer tools: `CMD + Option + I`

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- change the `NODE_ENV` variable in your localhost and check that `CMD + R` and other shortcuts mentioned above no longer work
- check that the "app menu" is not present on a Windows build

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

 Resolves https://github.com/grafana/k6-studio/issues/274 

<!-- Thanks for your contribution! 🙏🏼 -->
