### PR TITLE
fix: apply correlation between groups

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -61,7 +61,7 @@ export function generateVUCode(
     thinkTime
   )
 
-  // Group requests after appying rules to correlate requests between different groups
+  // Group requests after applying rules to correlate requests between different groups
   const groups = Object.entries(groupBy(requestSnippets, (item) => item.group))
 
   const groupSnippets = groups

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -1,4 +1,4 @@
-import { GroupedProxyData, ProxyData, RequestSnippetSchema } from '@/types'
+import { ProxyData, RequestSnippetSchema } from '@/types'
 import { TestRule } from '@/types/rules'
 import { applyRules } from '@/rules/rules'
 import { GeneratorFileData } from '@/types/generator'
@@ -10,9 +10,10 @@ import { getContentTypeWithCharsetHeader } from '@/utils/headers'
 import { REQUIRED_IMPORTS } from '@/constants/imports'
 import { generateImportStatement } from './imports'
 import { cleanupRecording } from './codegen.utils'
+import { groupBy } from 'lodash-es'
 
 interface GenerateScriptParams {
-  recording: GroupedProxyData
+  recording: ProxyData[]
   generator: GeneratorFileData
 }
 
@@ -48,24 +49,30 @@ export function generateVariableDeclarations(variables: Variable[]): string {
 }
 
 export function generateVUCode(
-  recording: GroupedProxyData,
+  recording: ProxyData[],
   rules: TestRule[],
   thinkTime: ThinkTime
 ): string {
-  const groups = Object.entries(recording)
+  const cleanedRecording = cleanupRecording(recording)
+
+  const requestSnippets = generateRequestSnippets(
+    cleanedRecording,
+    rules,
+    thinkTime
+  )
+
+  // Group requests after appying rules to correlate requests between different groups
+  const groups = Object.entries(groupBy(requestSnippets, (item) => item.group))
 
   const groupSnippets = groups
-    .map(([groupName, recording]) => {
-      const cleanedRecording = cleanupRecording(recording)
-      const requestSnippets = generateRequestSnippets(
-        cleanedRecording,
-        rules,
-        thinkTime
-      )
+    .map(([groupName, requestSnippetSchemas]) => {
+      const requestSnippet = requestSnippetSchemas
+        .map(({ snippet }) => snippet)
+        .join('\n')
 
-      return generateGroupSnippet(groupName, requestSnippets, thinkTime)
+      return generateGroupSnippet(groupName, requestSnippet, thinkTime)
     })
-    .join(`\n`)
+    .join('\n')
 
   return [
     `
@@ -81,19 +88,34 @@ export function generateVUCode(
   ].join('\n')
 }
 
+type GenerateRequestSnippetReturnValue = Array<{
+  snippet: string
+  group?: string
+}>
+
 export function generateRequestSnippets(
   recording: ProxyData[],
   rules: TestRule[],
   thinkTime: ThinkTime
-): string {
+): GenerateRequestSnippetReturnValue {
   const { requestSnippetSchemas } = applyRules(recording, rules)
-  return requestSnippetSchemas.reduce((acc, requestSnippetSchema) => {
-    const requestSnippet = generateSingleRequestSnippet(requestSnippetSchema)
+  return requestSnippetSchemas.reduce<GenerateRequestSnippetReturnValue>(
+    (acc, requestSnippetSchema) => {
+      const requestSnippet = generateSingleRequestSnippet(requestSnippetSchema)
 
-    return `${acc}
-      ${requestSnippet}
-      ${thinkTime.sleepType === 'requests' ? `${generateSleep(thinkTime.timing)}` : ''}`
-  }, '')
+      return [
+        ...acc,
+        {
+          group: requestSnippetSchema.data.group,
+          snippet: `
+            ${requestSnippet}
+            ${thinkTime.sleepType === 'requests' ? `${generateSleep(thinkTime.timing)}` : ''}
+          `,
+        },
+      ]
+    },
+    []
+  )
 }
 
 export function generateGroupSnippet(

--- a/src/codegen/codegen.utils.ts
+++ b/src/codegen/codegen.utils.ts
@@ -117,4 +117,6 @@ export const removeWebsocketRequests = (recording: ProxyData[]) => {
   })
 }
 
-export const cleanupRecording = flow([mergeRedirects, removeWebsocketRequests])
+export function cleanupRecording(recording: ProxyData[]) {
+  return flow(removeWebsocketRequests, mergeRedirects)(recording)
+}

--- a/src/hooks/useScriptPreview.ts
+++ b/src/hooks/useScriptPreview.ts
@@ -7,7 +7,6 @@ import {
   useGeneratorStore,
   GeneratorStore,
 } from '@/store/generator'
-import { groupProxyData } from '@/utils/groups'
 import { generateScriptPreview } from '@/views/Generator/Generator.utils'
 
 export function useScriptPreview() {
@@ -21,9 +20,8 @@ export function useScriptPreview() {
         setError(undefined)
         const generator = selectGeneratorData(state)
         const requests = selectFilteredRequests(state)
-        const groupedRequests = groupProxyData(requests)
 
-        const script = await generateScriptPreview(generator, groupedRequests)
+        const script = await generateScriptPreview(generator, requests)
         setPreview(script)
       } catch (e) {
         console.error(e)

--- a/src/test/fixtures/correlationRecording.ts
+++ b/src/test/fixtures/correlationRecording.ts
@@ -3,6 +3,7 @@ import { ProxyData } from '@/types'
 export const correlationRecording: ProxyData[] = [
   {
     id: '1',
+    group: 'one',
     request: {
       method: 'POST',
       url: 'http://test.k6.io/api/v1/foo',
@@ -36,6 +37,7 @@ export const correlationRecording: ProxyData[] = [
 
   {
     id: '2',
+    group: 'one',
     request: {
       method: 'POST',
       url: 'http://test.k6.io/api/v1/login?project_id=555',
@@ -65,6 +67,7 @@ export const correlationRecording: ProxyData[] = [
   },
   {
     id: '3',
+    group: 'two',
     request: {
       method: 'GET',
       url: 'http://test.k6.io/api/v1/users/333',
@@ -83,6 +86,7 @@ export const correlationRecording: ProxyData[] = [
   },
   {
     id: '4',
+    group: 'two',
     request: {
       method: 'POST',
       url: 'http://test.k6.io/api/v1/users',

--- a/src/views/Generator/Generator.utils.ts
+++ b/src/views/Generator/Generator.utils.ts
@@ -1,5 +1,4 @@
 import { generateScript } from '@/codegen'
-import { groupProxyData } from '@/utils/groups'
 import {
   selectFilteredRequests,
   selectGeneratorData,
@@ -8,12 +7,12 @@ import {
 import { GeneratorFileData } from '@/types/generator'
 import { GeneratorFileDataSchema } from '@/schemas/generator'
 import { harToProxyData } from '@/utils/harToProxyData'
-import { GroupedProxyData } from '@/types'
+import { ProxyData } from '@/types'
 import { prettify } from '@/utils/prettify'
 
 export async function generateScriptPreview(
   generator: GeneratorFileData,
-  recording: GroupedProxyData
+  recording: ProxyData[]
 ) {
   const script = generateScript({
     generator,
@@ -31,10 +30,7 @@ export async function exportScript(fileName: string) {
   const generator = selectGeneratorData(useGeneratorStore.getState())
   const filteredRequests = selectFilteredRequests(useGeneratorStore.getState())
 
-  const script = await generateScriptPreview(
-    generator,
-    groupProxyData(filteredRequests)
-  )
+  const script = await generateScriptPreview(generator, filteredRequests)
 
   saveScript(script, fileName)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug where correlation rules wouldn't be applied correctly between groups. Also, I've added grouped recording to the unit test to reproduce the regression. 

## How to Test
[Archive.zip](https://github.com/user-attachments/files/17517390/Archive.zip)

Download attached recording and generator, verify:
- Correlation value is extracted only once
- Correlated value is applied to post body
- Group are added correctly

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)



<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
