### PR TITLE
feat: Add parameterization custom code logic

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -10,7 +10,7 @@ import { getContentTypeWithCharsetHeader } from '@/utils/headers'
 import { REQUIRED_IMPORTS } from '@/constants/imports'
 import { generateImportStatement } from './imports'
 import { cleanupRecording } from './codegen.utils'
-import { groupBy } from 'lodash-es'
+import { groupProxyData } from '@/utils/groups'
 
 interface GenerateScriptParams {
   recording: ProxyData[]
@@ -62,7 +62,7 @@ export function generateVUCode(
   )
 
   // Group requests after applying rules to correlate requests between different groups
-  const groups = Object.entries(groupBy(requestSnippets, (item) => item.group))
+  const groups = Object.entries(groupProxyData(requestSnippets))
 
   const groupSnippets = groups
     .map(([groupName, requestSnippetSchemas]) => {

--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -7,7 +7,7 @@ import {
   CorrelationState,
   CorrelationRuleInstance,
 } from '@/types/rules'
-import { cloneDeep, escapeRegExp, isEqual } from 'lodash-es'
+import { cloneDeep, escapeRegExp } from 'lodash-es'
 import {
   canonicalHeaderKey,
   matchFilter,
@@ -68,21 +68,25 @@ function applyRule({
     // we populate uniqueId since it doesn't have to be regenerated
     // this will be passed to the tryCorrelationExtraction function
 
-    snippetSchemaReturnValue.data.request = replaceCorrelatedValues({
+    const replacedRequest = replaceCorrelatedValues({
       rule,
       extractedValue: state.extractedValue,
       uniqueId: state.generatedUniqueId ?? 0,
       request: requestSnippetSchema.data.request,
     })
 
+    if (replacedRequest) {
+      snippetSchemaReturnValue.data.request = replacedRequest
+    }
+
     // Keep track of modified requests to display in preview
-    if (!isEqual(requestSnippetSchema, snippetSchemaReturnValue)) {
+    if (replacedRequest) {
       setState({
         requestsReplaced: [
           ...state.requestsReplaced,
           {
             original: requestSnippetSchema.data.request,
-            replaced: snippetSchemaReturnValue.data.request,
+            replaced: replacedRequest,
           },
         ],
       })

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -18,7 +18,7 @@ export function replaceRequestValues({
   selector: Selector
   request: Request
   value: string
-}) {
+}): Request | undefined {
   switch (selector.type) {
     case 'begin-end':
       return replaceBeginEnd(selector, request, value)
@@ -170,7 +170,7 @@ export const replaceBeginEndBody = (
     selector.begin,
     selector.end
   )
-  if (!valueToReplace) return request
+  if (!valueToReplace) return
 
   const content = replaceContent(request.content, valueToReplace, variableName)
   return { ...request, content }
@@ -193,7 +193,7 @@ export const replaceBeginEndHeaders = (
     }
   }
 
-  return request
+  return
 }
 
 export const replaceBeginEndUrl = (
@@ -206,7 +206,7 @@ export const replaceBeginEndUrl = (
     selector.begin,
     selector.end
   )
-  if (!valueToReplace) return request
+  if (!valueToReplace) return
 
   const url = replaceUrl(request.url, valueToReplace, variableName)
   const path = replaceUrl(request.path, valueToReplace, variableName)
@@ -219,7 +219,7 @@ export const replaceRegexBody = (
   variableName: string
 ) => {
   const valueToReplace = matchRegex(request.content ?? '', selector.regex)
-  if (!valueToReplace) return request
+  if (!valueToReplace) return
 
   const content = replaceContent(request.content, valueToReplace, variableName)
   return { ...request, content }
@@ -242,7 +242,7 @@ export const replaceRegexHeaders = (
     }
   }
 
-  return request
+  return
 }
 
 export const replaceRegexUrl = (
@@ -251,7 +251,7 @@ export const replaceRegexUrl = (
   variableName: string
 ) => {
   const valueToReplace = matchRegex(request.url, selector.regex)
-  if (!valueToReplace) return request
+  if (!valueToReplace) return
 
   const url = replaceUrl(request.url, valueToReplace, variableName)
   return { ...request, url }
@@ -263,13 +263,13 @@ export const replaceJsonBody = (
   value: string
 ) => {
   if (!isJsonReqResp(request) || !request.content) {
-    return request
+    return
   }
 
   // since we are using lodash and its `set` function creates missing paths we will first check that the path really
   // exists before setting it
   const valueToReplace = getJsonObjectFromPath(request.content, selector.path)
-  if (!valueToReplace) return request
+  if (!valueToReplace) return
 
   const content = setJsonObjectFromPath(request.content, selector.path, value)
   return { ...request, content }
@@ -389,12 +389,11 @@ if (import.meta.vitest) {
         selector,
         generateRequest('<div>hello</div>'),
         '${correl_0}'
-      ).content
+      )?.content
     ).toBe('<div>${correl_0}</div>')
     expect(
       replaceBeginEndBody(selector, generateRequest('<a>hello</a>'), 'correl_0')
-        .content
-    ).toBe('<a>hello</a>')
+    ).toBeUndefined()
   })
 
   it('replace begin end headers', () => {
@@ -412,11 +411,11 @@ if (import.meta.vitest) {
       end: 'world',
     }
     expect(
-      replaceBeginEndHeaders(selectorMatch, request, '${correl_0}').headers[0]
+      replaceBeginEndHeaders(selectorMatch, request, '${correl_0}')?.headers[0]
     ).toStrictEqual(['content-type', 'application${correl_0}json'])
     expect(
-      replaceBeginEndHeaders(selectorNotMatch, request, 'correl_0').headers[0]
-    ).toStrictEqual(['content-type', 'application/json'])
+      replaceBeginEndHeaders(selectorNotMatch, request, 'correl_0')
+    ).toBeUndefined()
   })
 
   it('replace begin end url', () => {
@@ -435,12 +434,12 @@ if (import.meta.vitest) {
     }
     const match = replaceBeginEndUrl(selectorMatch, request, '${correl_0}')
 
-    expect(match.url).toBe('http://test.k6.io/${correl_0}/v1/foo')
-    expect(match.path).toBe('/${correl_0}/v1/foo')
+    expect(match?.url).toBe('http://test.k6.io/${correl_0}/v1/foo')
+    expect(match?.path).toBe('/${correl_0}/v1/foo')
 
-    expect(replaceBeginEndUrl(selectorNotMatch, request, 'correl_0').url).toBe(
-      'http://test.k6.io/api/v1/foo'
-    )
+    expect(
+      replaceBeginEndUrl(selectorNotMatch, request, 'correl_0')
+    ).toBeUndefined()
   })
 
   it('replace regex body', () => {
@@ -454,12 +453,11 @@ if (import.meta.vitest) {
         selector,
         generateRequest('<div>hello</div>'),
         '${correl_0}'
-      ).content
+      )?.content
     ).toBe('<div>${correl_0}</div>')
     expect(
       replaceRegexBody(selector, generateRequest('<a>hello</a>'), 'correl_0')
-        .content
-    ).toBe('<a>hello</a>')
+    ).toBeUndefined()
   })
 
   it('replace regex headers', () => {
@@ -475,11 +473,11 @@ if (import.meta.vitest) {
       regex: 'hello(.*?)world',
     }
     expect(
-      replaceRegexHeaders(selectorMatch, request, '${correl_0}').headers[0]
+      replaceRegexHeaders(selectorMatch, request, '${correl_0}')?.headers[0]
     ).toStrictEqual(['content-type', 'application${correl_0}json'])
     expect(
-      replaceRegexHeaders(selectorNotMatch, request, 'correl_0').headers[0]
-    ).toStrictEqual(['content-type', 'application/json'])
+      replaceRegexHeaders(selectorNotMatch, request, 'correl_0')
+    ).toBeUndefined()
   })
 
   it('replace regex url', () => {
@@ -494,12 +492,12 @@ if (import.meta.vitest) {
       from: 'url',
       regex: 'supercali(.*?)fragilisti',
     }
-    expect(replaceRegexUrl(selectorMatch, request, '${correl_0}').url).toBe(
+    expect(replaceRegexUrl(selectorMatch, request, '${correl_0}')?.url).toBe(
       'http://test.k6.io/${correl_0}/v1/foo'
     )
-    expect(replaceRegexUrl(selectorNotMatch, request, 'correl_0').url).toBe(
-      'http://test.k6.io/api/v1/foo'
-    )
+    expect(
+      replaceRegexUrl(selectorNotMatch, request, 'correl_0')
+    ).toBeUndefined()
   })
 
   it('replace json body', () => {
@@ -523,21 +521,21 @@ if (import.meta.vitest) {
         selectorMatch,
         generateRequest('{"hello":"world"}'),
         '${correl_0}'
-      ).content
+      )?.content
     ).toBe('{"hello":"${correl_0}"}')
     expect(
       replaceJsonBody(
         selectorNotMatch,
         generateRequest('{"hello":"world"}'),
         '${correl_0}'
-      ).content
-    ).toBe('{"hello":"world"}')
+      )
+    ).toBeUndefined()
     expect(
       replaceJsonBody(
         selectorMatchArray,
         generateRequest('[{"hello":"world"}]'),
         '${correl_0}'
-      ).content
+      )?.content
     ).toBe('[{"hello":"${correl_0}"}]')
   })
 }

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -12,9 +12,7 @@ export const ArrayValueSchema = z.object({
 
 export const CustomCodeValueSchema = z.object({
   type: z.literal('customCode'),
-  getValue: z
-    .function()
-    .returns(z.union([z.string(), z.number(), z.null(), z.void()])),
+  code: z.string(),
 })
 
 export const RecordedValueSchema = z.object({

--- a/src/test/fixtures/parameterizationRules.ts
+++ b/src/test/fixtures/parameterizationRules.ts
@@ -1,6 +1,6 @@
 import { ParameterizationRule } from '@/types/rules'
 
-export const jsonRule: ParameterizationRule = {
+export const jsonRule = {
   type: 'parameterization',
   id: '1',
   filter: { path: '' },
@@ -13,9 +13,9 @@ export const jsonRule: ParameterizationRule = {
     type: 'string',
     value: 'TEST_ID',
   },
-}
+} satisfies ParameterizationRule
 
-export const urlRule: ParameterizationRule = {
+export const urlRule = {
   type: 'parameterization',
   id: '2',
   filter: { path: '' },
@@ -29,9 +29,9 @@ export const urlRule: ParameterizationRule = {
     type: 'string',
     value: 'TEST_ID',
   },
-}
+} satisfies ParameterizationRule
 
-export const headerRule: ParameterizationRule = {
+export const headerRule = {
   type: 'parameterization',
   id: '3',
   filter: { path: '' },
@@ -44,4 +44,39 @@ export const headerRule: ParameterizationRule = {
     type: 'string',
     value: 'TEST_TOKEN',
   },
-}
+} satisfies ParameterizationRule
+
+export const customCodeReplaceProjectId = {
+  type: 'parameterization',
+  id: '4',
+  filter: { path: '' },
+  selector: {
+    type: 'regex',
+    from: 'url',
+    regex: 'project_id=(\\d+)',
+  },
+  value: {
+    type: 'customCode',
+    code: `
+      const randomInteger = Math.floor(Math.random() * 100000);
+      return randomInteger;
+    `,
+  },
+} satisfies ParameterizationRule
+
+export const customCodeReplaceCsrf = {
+  type: 'parameterization',
+  id: '4',
+  filter: { path: '' },
+  selector: {
+    type: 'regex',
+    from: 'url',
+    regex: 'csrf=(\\d+)',
+  },
+  value: {
+    type: 'customCode',
+    code: `
+      return '123456'
+    `,
+  },
+} satisfies ParameterizationRule

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -50,6 +50,8 @@ export interface ParameterizationState {
     original: Request
     replaced: Request
   }[]
+  uniqueId: number
+  snippedInjected: boolean
 }
 
 export type ParameterizationRuleInstance =

--- a/src/utils/groups.ts
+++ b/src/utils/groups.ts
@@ -1,7 +1,6 @@
 import { DEFAULT_GROUP_NAME } from '@/constants'
-import { ProxyData } from '@/types'
 import { groupBy } from 'lodash-es'
 
-export function groupProxyData(requests: ProxyData[]) {
+export function groupProxyData<T extends { group?: string }>(requests: T[]) {
   return groupBy(requests, (item) => item.group || DEFAULT_GROUP_NAME)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add logic to support parameterization rule custom code value. The snippet will be wrapped in a function `getCorrelationValueN`. This is different to custom code rule where the snippet is dropped into script without wrapping it, but I went with this approach as it more versatile and helps avoid variable name collision. Also, in the future this could be extended to pass request details to the custom code function to allow more customization, e.g.,: `getCorrelationValue0(params, headers, body)`.

The UI for adding custom code parameterization will be added in a separate PR. 

## How to Test

<!--- Please describe in detail how you tested your changes -->
- Manually add parameterization rule with custom code
- Verify snippet is added to script
- Verify snippet is referenced in request
- Verify snippet function is added only once when referenced in multiple requests

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
![CleanShot 2024-10-28 at 11 01 43](https://github.com/user-attachments/assets/f7cf5037-2adf-443b-954d-04a43874b716)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
