### PR TITLE
fix: Replacer filter not applied

### DIFF
--- a/src/rules/correlation.utils.ts
+++ b/src/rules/correlation.utils.ts
@@ -15,7 +15,7 @@ export function replaceCorrelatedValues({
 }) {
   const varName = `\${correlation_vars['correlation_${uniqueId}']}`
   // Default behaviour replaces all occurences of the string
-  if (!rule.replacer) {
+  if (!rule.replacer?.selector) {
     return replaceTextMatches(request, extractedValue, varName)
   }
 

--- a/src/rules/customCode.ts
+++ b/src/rules/customCode.ts
@@ -9,7 +9,7 @@ export function createCustomCodeRuleInstance(
     rule,
     type: rule.type,
     apply: (requestSnippetSchema: RequestSnippetSchema) => {
-      if (!matchFilter(requestSnippetSchema, rule)) {
+      if (!matchFilter(requestSnippetSchema, rule.filter)) {
         return requestSnippetSchema
       }
 

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -21,7 +21,7 @@ export function createParameterizationRuleInstance(
     rule,
     type: rule.type,
     apply: (requestSnippet: RequestSnippetSchema) => {
-      if (!matchFilter(requestSnippet, rule)) {
+      if (!matchFilter(requestSnippet, rule.filter)) {
         return requestSnippet
       }
 

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -1,6 +1,5 @@
-import { TestRule } from '@/types/rules'
+import { Filter } from '@/types/rules'
 import { RequestSnippetSchema, Response, Request } from '@/types'
-import { exhaustive } from '@/utils/typescript'
 import { getHeaderValues } from '@/utils/headers'
 import { escapeRegExp } from 'lodash-es'
 
@@ -29,26 +28,10 @@ export function* generateSequentialInt(): Generator<number> {
 
 export function matchFilter(
   { data: { request } }: RequestSnippetSchema,
-  rule: TestRule
+  filter: Filter
 ) {
   try {
-    switch (rule.type) {
-      case 'correlation': {
-        const {
-          extractor: { filter },
-        } = rule
-
-        return new RegExp(escapeRegExp(filter.path)).test(request.url)
-      }
-      case 'customCode':
-      case 'parameterization':
-      case 'verification': {
-        const { filter } = rule
-        return new RegExp(escapeRegExp(filter.path)).test(request.url)
-      }
-      default:
-        return exhaustive(rule)
-    }
+    return new RegExp(escapeRegExp(filter.path)).test(request.url)
   } catch (e) {
     console.error(e)
     return false

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -88,7 +88,7 @@ export const CorrelationExtractorSchema = z.object({
 
 export const CorrelationReplacerSchema = z.object({
   filter: FilterSchema,
-  selector: SelectorSchema,
+  selector: SelectorSchema.optional(),
 })
 
 export const RuleBaseSchema = z.object({

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -15,6 +15,9 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
             end: '',
           },
         },
+        replacer: {
+          filter: { path: '' },
+        },
       }
     case 'customCode':
       return {

--- a/src/views/Generator/RuleEditor/CorrelationEditor.tsx
+++ b/src/views/Generator/RuleEditor/CorrelationEditor.tsx
@@ -10,13 +10,17 @@ export function CorrelationEditor() {
   const { setValue, watch } = useFormContext<TestRule>()
   const replacer = watch('replacer')
 
-  const toggleCustomReplacer = () => {
-    if (replacer) {
-      setValue('replacer', undefined)
+  const isCustomReplacerSelector = !!replacer?.selector
+
+  const toggleCustomReplacerSelector = () => {
+    if (isCustomReplacerSelector) {
+      setValue('replacer.selector', undefined)
     } else {
-      setValue('replacer', {
-        filter: { path: '' },
-        selector: { from: 'body', type: 'begin-end', begin: '', end: '' },
+      setValue('replacer.selector', {
+        from: 'body',
+        type: 'begin-end',
+        begin: '',
+        end: '',
       })
     }
   }
@@ -34,34 +38,34 @@ export function CorrelationEditor() {
         <SelectorField field="extractor.selector" />
       </Box>
       <Box>
-        <Label mb="2">
-          <Heading size="2" weight="medium">
-            Replacer
-          </Heading>
-          <Switch
-            onCheckedChange={toggleCustomReplacer}
-            checked={!!replacer}
-            size="1"
-          />
-        </Label>
+        <Heading size="2" weight="medium" mb="2">
+          Replacer
+        </Heading>
         <Text size="2" as="p" mb="2" color="gray">
           Replace matched values with the extracted value.{' '}
         </Text>
 
-        {!replacer && (
-          <Text size="2" as="p" mb="2" color="gray">
-            By default, the correlation rule will replace all occurrences of the
-            extracted value in the requests. Enable this option to fine tune
-            your selection.
-          </Text>
-        )}
+        <>
+          <FilterField field="replacer.filter" />
+          <Label mb="2">
+            <Text size="2">Customize selector</Text>
 
-        {replacer && (
-          <>
-            <FilterField field="replacer.filter" />
-            <SelectorField field="replacer.selector" />
-          </>
-        )}
+            <Switch
+              onCheckedChange={toggleCustomReplacerSelector}
+              checked={isCustomReplacerSelector}
+              size="1"
+            />
+          </Label>
+
+          {!isCustomReplacerSelector && (
+            <Text size="2" as="p" mb="2" color="gray">
+              By default, the correlation rule will replace all occurrences of
+              the extracted value in the requests. Enable this option to fine
+              tune your selection.
+            </Text>
+          )}
+          <SelectorField field="replacer.selector" />
+        </>
       </Box>
     </Grid>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes correlation replacer filter, previously it wasn't applied. 
- Make correlation replacer selector optional, allowing users to filter by request path without having to define custom selector.


## How to Test
- Test correlation without replacer filter
- Test correlation with replacer filter
- Test correlation with custom replacer selector

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![CleanShot 2024-10-28 at 15 06 35](https://github.com/user-attachments/assets/86e8f602-1b12-4442-a54a-f17d1e77b67e)

![CleanShot 2024-10-28 at 15 06 48](https://github.com/user-attachments/assets/d741d1ec-2f08-4d05-aad9-fd76c1c2f221)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
