### PR TITLE
fix: Unify dialog style between test options and allowed hosts

### DIFF
--- a/src/components/PopoverDialogs.tsx
+++ b/src/components/PopoverDialogs.tsx
@@ -1,0 +1,26 @@
+import { Popover } from '@radix-ui/themes'
+
+type PopoverDialogProps = Popover.RootProps & {
+  children: React.ReactNode
+  trigger?: React.ReactNode
+}
+export function PopoverDialog({
+  children,
+  trigger,
+  ...rest
+}: PopoverDialogProps) {
+  return (
+    <Popover.Root {...rest}>
+      {trigger && <Popover.Trigger>{trigger}</Popover.Trigger>}
+      <Popover.Content
+        width="400px"
+        size="1"
+        side="bottom"
+        align="end"
+        avoidCollisions
+      >
+        {children}
+      </Popover.Content>
+    </Popover.Root>
+  )
+}

--- a/src/components/WebLogView/Filter.hooks.ts
+++ b/src/components/WebLogView/Filter.hooks.ts
@@ -1,23 +1,24 @@
 import { ProxyData } from '@/types'
 import { isNonStaticAssetResponse } from '@/utils/staticAssets'
 import { useState, useMemo } from 'react'
-import { useLocalStorage } from 'react-use'
 
-export function useFilterRequests(requests: ProxyData[]) {
+export function useFilterRequests({
+  proxyData,
+  includeStaticAssets = true,
+}: {
+  proxyData: ProxyData[]
+  includeStaticAssets?: boolean
+}) {
   const [filter, setFilter] = useState('')
-  const [includeStaticAssets, setIncludeStaticAssets] = useLocalStorage(
-    'includeStaticAssets',
-    false
-  )
 
   const requestWithoutStaticAssets = useMemo(
-    () => requests.filter(isNonStaticAssetResponse),
-    [requests]
+    () => proxyData.filter(isNonStaticAssetResponse),
+    [proxyData]
   )
 
   const filteredRequests = useMemo(() => {
     const assetsFiltered = includeStaticAssets
-      ? requests
+      ? proxyData
       : requestWithoutStaticAssets
     const lowerCaseFilter = filter.toLowerCase().trim()
     if (lowerCaseFilter === '') return assetsFiltered
@@ -29,19 +30,17 @@ export function useFilterRequests(requests: ProxyData[]) {
         data.response?.statusCode.toString().includes(lowerCaseFilter)
       )
     })
-  }, [requests, filter, requestWithoutStaticAssets, includeStaticAssets])
+  }, [proxyData, filter, requestWithoutStaticAssets, includeStaticAssets])
 
   const staticAssetCount = useMemo(
-    () => requests.length - requestWithoutStaticAssets.length,
-    [requests.length, requestWithoutStaticAssets.length]
+    () => proxyData.length - requestWithoutStaticAssets.length,
+    [proxyData.length, requestWithoutStaticAssets.length]
   )
 
   return {
     filter,
     setFilter,
     filteredRequests,
-    includeStaticAssets,
-    setIncludeStaticAssets,
     staticAssetCount,
   }
 }

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -3,6 +3,7 @@ import { useGeneratorStore } from '@/store/generator'
 import { AllowlistDialog } from './AllowlistDialog'
 import { extractUniqueHosts } from '@/store/generator/slices/recording.utils'
 import { GlobeIcon } from '@radix-ui/react-icons'
+import { PopoverDialog } from '@/components/PopoverDialogs'
 
 export function Allowlist() {
   const requests = useGeneratorStore((store) => store.requests)
@@ -26,42 +27,33 @@ export function Allowlist() {
 
   const hosts = extractUniqueHosts(requests)
 
-  const handleSave = ({
-    allowlist,
-    includeStaticAssets,
-  }: {
-    allowlist: string[]
-    includeStaticAssets: boolean
-  }) => {
-    setAllowlist(allowlist)
-    setIncludeStaticAssets(includeStaticAssets)
-  }
-
   return (
     <>
-      {requests.length > 0 && (
-        <Button
-          size="1"
-          variant="ghost"
-          color="gray"
-          onClick={() => setShowAllowlistDialog(true)}
-        >
-          <GlobeIcon />
-          Allowed hosts [{allowlist.length}/{hosts.length}]
-        </Button>
-      )}
-      {/* Radix does not unmount dialog on close, this is need to clear local state */}
-      {showAllowlistDialog && (
+      <PopoverDialog
+        open={showAllowlistDialog}
+        onOpenChange={setShowAllowlistDialog}
+        modal // needed to automatically open when switching recordings
+        trigger={
+          <Button
+            size="1"
+            variant="ghost"
+            color="gray"
+            onClick={() => setShowAllowlistDialog(true)}
+          >
+            <GlobeIcon />
+            Allowed hosts [{allowlist.length}/{hosts.length}]
+          </Button>
+        }
+      >
         <AllowlistDialog
-          open={showAllowlistDialog}
-          onOpenChange={setShowAllowlistDialog}
           hosts={hosts}
           allowlist={allowlist}
-          onSave={handleSave}
           requests={requests}
           includeStaticAssets={includeStaticAssets}
+          setAllowlist={setAllowlist}
+          setIncludeStaticAssets={setIncludeStaticAssets}
         />
-      )}
+      </PopoverDialog>
     </>
   )
 }

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -7,162 +7,150 @@ import {
   Button,
   Checkbox,
   CheckboxGroup,
-  Dialog,
   Flex,
   IconButton,
   ScrollArea,
   TextField,
   Text,
   Tooltip,
+  Card,
+  Callout,
+  Inset,
 } from '@radix-ui/themes'
 import { isEqual } from 'lodash-es'
 import { useMemo, useState } from 'react'
 
 export function AllowlistDialog({
-  open,
-  onOpenChange,
   hosts,
   allowlist,
-  onSave,
   requests,
   includeStaticAssets,
+  setAllowlist,
+  setIncludeStaticAssets,
 }: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
   hosts: string[]
   allowlist: string[]
   includeStaticAssets: boolean
   requests: ProxyData[]
-  onSave: (data: { allowlist: string[]; includeStaticAssets: boolean }) => void
+  setAllowlist: (allowlist: string[]) => void
+  setIncludeStaticAssets: (includeStaticAssets: boolean) => void
 }) {
   const [filter, setFilter] = useState('')
-  const [selectedHosts, setSelectedHosts] = useState(allowlist)
-  const [isStaticAssetsChecked, setIsStaticAssetsChecked] =
-    useState(includeStaticAssets)
 
-  const filteredHosts = hosts.filter((host) => host.includes(filter))
-
-  function handleSelectAll() {
-    setSelectedHosts(filteredHosts)
-  }
-
-  function handleSelectNone() {
-    setSelectedHosts([])
-  }
-
-  function handleSave() {
-    onSave({
-      allowlist: selectedHosts,
-      includeStaticAssets: isStaticAssetsChecked && staticAssetCount > 0,
-    })
-  }
+  const filteredHosts = useMemo(
+    () => hosts.filter((host) => host.includes(filter)),
+    [hosts, filter]
+  )
 
   const staticAssetCount = useMemo(() => {
     const allowedRequests = requests.filter((request) => {
-      return selectedHosts.includes(request.request.host)
+      return allowlist.includes(request.request.host)
     })
 
     return allowedRequests.filter(
       (request) => !isNonStaticAssetResponse(request)
     ).length
-  }, [requests, selectedHosts])
+  }, [requests, allowlist])
+
+  function handleSelectAll() {
+    setAllowlist(filteredHosts)
+  }
+
+  function handleSelectNone() {
+    setAllowlist([])
+  }
+
+  function handleChangeHosts(hosts: string[]) {
+    setAllowlist(hosts)
+  }
+
+  function handleCheckStaticAssets(checked: boolean) {
+    setIncludeStaticAssets(checked && staticAssetCount > 0)
+  }
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
-      <Dialog.Content maxWidth="450px" size="2">
-        <Dialog.Title>Allowed hosts</Dialog.Title>
-        <Dialog.Description size="2" mb="4">
-          Select which hosts you want to include in your test
-        </Dialog.Description>
-
-        <Flex mb="3" justify="between" gap="1">
-          <Flex flexGrow="1" asChild>
-            <TextField.Root
-              placeholder="Filter"
-              size="1"
-              onChange={(e) => setFilter(e.target.value)}
-              value={filter}
-            >
+    <>
+      <Text size="2" as="p" mb="2">
+        Select which hosts you want to include in your test
+      </Text>
+      <Flex mb="3" justify="between" gap="1">
+        <Flex flexGrow="1" asChild>
+          <TextField.Root
+            placeholder="Filter"
+            size="1"
+            onChange={(e) => setFilter(e.target.value)}
+            value={filter}
+          >
+            <TextField.Slot>
+              <MagnifyingGlassIcon height="16" width="16" />
+            </TextField.Slot>
+            {filter !== '' && (
               <TextField.Slot>
-                <MagnifyingGlassIcon height="16" width="16" />
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  onClick={() => setFilter('')}
+                >
+                  <Cross2Icon height="12" width="12" />
+                </IconButton>
               </TextField.Slot>
-              {filter !== '' && (
-                <TextField.Slot>
-                  <IconButton
-                    size="1"
-                    variant="ghost"
-                    onClick={() => setFilter('')}
-                  >
-                    <Cross2Icon height="12" width="12" />
-                  </IconButton>
-                </TextField.Slot>
-              )}
-            </TextField.Root>
-          </Flex>
-          <Flex gap="1">
-            <Button
-              size="1"
-              onClick={handleSelectAll}
-              disabled={isEqual(filteredHosts, selectedHosts)}
-            >
-              Select all
-            </Button>
-            <Button
-              size="1"
-              onClick={handleSelectNone}
-              color="amber"
-              disabled={selectedHosts.length === 0}
-            >
-              Select none
-            </Button>
-          </Flex>
+            )}
+          </TextField.Root>
         </Flex>
+        <Flex gap="1">
+          <Button
+            size="1"
+            onClick={handleSelectAll}
+            disabled={isEqual(filteredHosts, allowlist)}
+          >
+            Select all
+          </Button>
+          <Button
+            size="1"
+            onClick={handleSelectNone}
+            color="amber"
+            disabled={allowlist.length === 0}
+          >
+            Select none
+          </Button>
+        </Flex>
+      </Flex>
 
-        <Box height="210px" asChild pr="3" mb="4">
-          <ScrollArea>
-            <CheckboxGroup.Root
-              value={selectedHosts}
-              onValueChange={(e) => setSelectedHosts(e)}
-            >
-              {filteredHosts.map((host) => (
-                <CheckboxGroup.Item value={host} key={host}>
-                  {host}
-                </CheckboxGroup.Item>
-              ))}
-            </CheckboxGroup.Root>
-          </ScrollArea>
-        </Box>
-
-        <Flex justify="between" align="center">
-          <Label>
-            <Checkbox
-              onCheckedChange={() =>
-                setIsStaticAssetsChecked((value) => !value)
-              }
-              checked={isStaticAssetsChecked}
-              disabled={staticAssetCount === 0}
-            />
-            <Tooltip content="Static assets are excluded from your test by default.">
-              <Text size="2">Include static assets ({staticAssetCount})</Text>
-            </Tooltip>
-          </Label>
-          <Flex gap="3" justify="end">
-            <Dialog.Close>
-              <Button variant="soft" color="gray">
-                Cancel
-              </Button>
-            </Dialog.Close>
-            <Dialog.Close>
-              <Button
-                disabled={selectedHosts.length === 0}
-                onClick={handleSave}
+      <Card size="1" mb="2">
+        <Inset css={{ height: '210px' }}>
+          <ScrollArea scrollbars="vertical" type="always">
+            <Flex p="2" pr="4" asChild overflow="hidden">
+              <CheckboxGroup.Root
+                size="2"
+                value={allowlist}
+                onValueChange={handleChangeHosts}
               >
-                Save
-              </Button>
-            </Dialog.Close>
-          </Flex>
-        </Flex>
-      </Dialog.Content>
-    </Dialog.Root>
+                {filteredHosts.map((host) => (
+                  <Text as="label" size="2" key={host}>
+                    <Flex gap="2">
+                      <CheckboxGroup.Item value={host} />{' '}
+                      <Text truncate>{host}</Text>
+                    </Flex>
+                  </Text>
+                ))}
+              </CheckboxGroup.Root>
+            </Flex>
+          </ScrollArea>
+        </Inset>
+      </Card>
+
+      <Flex justify="between" align="center">
+        <Label>
+          <Checkbox
+            onCheckedChange={handleCheckStaticAssets}
+            checked={includeStaticAssets}
+            disabled={staticAssetCount === 0}
+          />
+          <Tooltip content="Static assets are excluded from your test by default.">
+            <Text size="2">Include static assets ({staticAssetCount})</Text>
+          </Tooltip>
+        </Label>
+      </Flex>
+    </>
   )
 }

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -3,7 +3,6 @@ import { ProxyData } from '@/types'
 import { isNonStaticAssetResponse } from '@/utils/staticAssets'
 import { Cross2Icon, MagnifyingGlassIcon } from '@radix-ui/react-icons'
 import {
-  Box,
   Button,
   Checkbox,
   CheckboxGroup,
@@ -14,7 +13,6 @@ import {
   Text,
   Tooltip,
   Card,
-  Callout,
   Inset,
 } from '@radix-ui/themes'
 import { isEqual } from 'lodash-es'

--- a/src/views/Generator/GeneratorSidebar/RequestList.tsx
+++ b/src/views/Generator/GeneratorSidebar/RequestList.tsx
@@ -21,7 +21,9 @@ interface RequestListProps {
 
 export function RequestList({ requests }: RequestListProps) {
   const [selectedRequest, setSelectedRequest] = useState<ProxyData | null>(null)
-  const { filter, setFilter, filteredRequests } = useFilterRequests(requests)
+  const { filter, setFilter, filteredRequests } = useFilterRequests({
+    proxyData: requests,
+  })
 
   const groups = useProxyDataGroups(requests)
 

--- a/src/views/Generator/TestOptions/TestOptions.tsx
+++ b/src/views/Generator/TestOptions/TestOptions.tsx
@@ -1,5 +1,5 @@
 import { GearIcon } from '@radix-ui/react-icons'
-import { Button, ScrollArea, Tabs } from '@radix-ui/themes'
+import { Box, Button, Inset, ScrollArea, Tabs } from '@radix-ui/themes'
 import { css } from '@emotion/react'
 
 import { LoadProfile } from './LoadProfile'
@@ -17,33 +17,37 @@ export function TestOptions() {
         </Button>
       }
     >
-      <Tabs.Root defaultValue="loadProfile">
-        <Tabs.List
-          css={css`
-            margin-bottom: var(--space-3);
-          `}
-        >
-          <Tabs.Trigger value="loadProfile">Load profile</Tabs.Trigger>
-          <Tabs.Trigger value="thinkTime">Think time</Tabs.Trigger>
-          <Tabs.Trigger value="testData">Test data</Tabs.Trigger>
-        </Tabs.List>
-        <ScrollArea
-          scrollbars="vertical"
-          css={css`
-            max-height: 60vh;
-          `}
-        >
-          <Tabs.Content value="loadProfile">
-            <LoadProfile />
-          </Tabs.Content>
-          <Tabs.Content value="thinkTime">
-            <ThinkTime />
-          </Tabs.Content>
-          <Tabs.Content value="testData">
-            <VariablesEditor />
-          </Tabs.Content>
-        </ScrollArea>
-      </Tabs.Root>
+      <Inset>
+        <Tabs.Root defaultValue="loadProfile">
+          <Tabs.List
+            css={css`
+              margin-bottom: var(--space-3);
+            `}
+          >
+            <Tabs.Trigger value="loadProfile">Load profile</Tabs.Trigger>
+            <Tabs.Trigger value="thinkTime">Think time</Tabs.Trigger>
+            <Tabs.Trigger value="testData">Test data</Tabs.Trigger>
+          </Tabs.List>
+          <ScrollArea
+            scrollbars="vertical"
+            css={css`
+              max-height: 60vh;
+            `}
+          >
+            <Box p="3" pt="0" css={{ '.rt-TabsContent': { outline: 'none' } }}>
+              <Tabs.Content value="loadProfile">
+                <LoadProfile />
+              </Tabs.Content>
+              <Tabs.Content value="thinkTime">
+                <ThinkTime />
+              </Tabs.Content>
+              <Tabs.Content value="testData">
+                <VariablesEditor />
+              </Tabs.Content>
+            </Box>
+          </ScrollArea>
+        </Tabs.Root>
+      </Inset>
     </PopoverDialog>
   )
 }

--- a/src/views/Generator/TestOptions/TestOptions.tsx
+++ b/src/views/Generator/TestOptions/TestOptions.tsx
@@ -1,55 +1,49 @@
 import { GearIcon } from '@radix-ui/react-icons'
-import { Button, Popover, ScrollArea, Tabs } from '@radix-ui/themes'
+import { Button, ScrollArea, Tabs } from '@radix-ui/themes'
 import { css } from '@emotion/react'
 
 import { LoadProfile } from './LoadProfile'
 import { ThinkTime } from './ThinkTime'
 import { VariablesEditor } from './VariablesEditor'
+import { PopoverDialog } from '@/components/PopoverDialogs'
 
 export function TestOptions() {
   return (
-    <Popover.Root>
-      <Popover.Trigger>
+    <PopoverDialog
+      trigger={
         <Button variant="ghost" size="1" color="gray">
           <GearIcon />
           Test options
         </Button>
-      </Popover.Trigger>
-      <Popover.Content
-        width="400px"
-        size="1"
-        side="bottom"
-        align="end"
-        avoidCollisions
-      >
-        <Tabs.Root defaultValue="loadProfile">
-          <Tabs.List
-            css={css`
-              margin-bottom: var(--space-3);
-            `}
-          >
-            <Tabs.Trigger value="loadProfile">Load profile</Tabs.Trigger>
-            <Tabs.Trigger value="thinkTime">Think time</Tabs.Trigger>
-            <Tabs.Trigger value="testData">Test data</Tabs.Trigger>
-          </Tabs.List>
-          <ScrollArea
-            scrollbars="vertical"
-            css={css`
-              max-height: 60vh;
-            `}
-          >
-            <Tabs.Content value="loadProfile">
-              <LoadProfile />
-            </Tabs.Content>
-            <Tabs.Content value="thinkTime">
-              <ThinkTime />
-            </Tabs.Content>
-            <Tabs.Content value="testData">
-              <VariablesEditor />
-            </Tabs.Content>
-          </ScrollArea>
-        </Tabs.Root>
-      </Popover.Content>
-    </Popover.Root>
+      }
+    >
+      <Tabs.Root defaultValue="loadProfile">
+        <Tabs.List
+          css={css`
+            margin-bottom: var(--space-3);
+          `}
+        >
+          <Tabs.Trigger value="loadProfile">Load profile</Tabs.Trigger>
+          <Tabs.Trigger value="thinkTime">Think time</Tabs.Trigger>
+          <Tabs.Trigger value="testData">Test data</Tabs.Trigger>
+        </Tabs.List>
+        <ScrollArea
+          scrollbars="vertical"
+          css={css`
+            max-height: 60vh;
+          `}
+        >
+          <Tabs.Content value="loadProfile">
+            <LoadProfile />
+          </Tabs.Content>
+          <Tabs.Content value="thinkTime">
+            <ThinkTime />
+          </Tabs.Content>
+          <Tabs.Content value="testData">
+            <VariablesEditor />
+          </Tabs.Content>
+        </ScrollArea>
+      </Tabs.Root>
+    </PopoverDialog>
   )
 }

--- a/src/views/Recorder/RequestsSection.tsx
+++ b/src/views/Recorder/RequestsSection.tsx
@@ -9,6 +9,7 @@ import { ReactNode } from 'react'
 import { ClearRequestsButton } from './ClearRequestsButton'
 import { Filter } from '@/components/WebLogView/Filter'
 import { useFilterRequests } from '@/components/WebLogView/Filter.hooks'
+import { useLocalStorage } from 'react-use'
 
 interface RequestsSectionProps {
   proxyData: ProxyData[]
@@ -33,14 +34,14 @@ export function RequestsSection({
   onUpdateGroup,
   resetProxyData,
 }: RequestsSectionProps) {
-  const {
-    filter,
-    setFilter,
-    includeStaticAssets,
-    setIncludeStaticAssets,
-    staticAssetCount,
-    filteredRequests,
-  } = useFilterRequests(proxyData)
+  const [includeStaticAssets, setIncludeStaticAssets] = useLocalStorage(
+    'includeStaticAssets',
+    false
+  )
+
+  const { filter, setFilter, staticAssetCount, filteredRequests } =
+    useFilterRequests({ proxyData, includeStaticAssets })
+
   const groupedProxyData = groupProxyData(filteredRequests)
   const ref = useAutoScroll(groupedProxyData, autoScroll)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Use popover style dialog for allow list to match the style of test options. It also removes "save" and "discard" buttons from the allow list dialog to match other forms. The changes are reflected immediately without closing dialog. 

## How to Test

- Verify dialog is automatically opened for new recordings
- Verify dialog is opened when switching to recording with additional hosts or different hosts
- Try to add/remove hosts, switch static assets

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
![CleanShot 2024-10-29 at 15 28 21](https://github.com/user-attachments/assets/5b14d5e3-1d20-4651-8667-cf212822ab5c)

![CleanShot 2024-10-29 at 15 28 25](https://github.com/user-attachments/assets/23b25c31-74d2-4607-83f8-dc420e7f965f)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
