### PR TITLE
fix: replace url and path for url regex matchers

### DIFF
--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -254,7 +254,8 @@ export const replaceRegexUrl = (
   if (!valueToReplace) return
 
   const url = replaceUrl(request.url, valueToReplace, variableName)
-  return { ...request, url }
+  const path = replaceUrl(request.path, valueToReplace, variableName)
+  return { ...request, url, path }
 }
 
 export const replaceJsonBody = (

--- a/src/views/Generator/RulePreview/ParameterizationPreview.tsx
+++ b/src/views/Generator/RulePreview/ParameterizationPreview.tsx
@@ -54,7 +54,7 @@ export function ParameterizationPreview({
             {preview && preview.requestsReplaced.length > 0 && (
               <>
                 <Heading size="2" m="2">
-                  Requests matched
+                  Requests replaced
                 </Heading>
                 <WebLogView
                   requests={requestsReplacedToProxyData(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Show replaced path in parameterization preview

Before:

![CleanShot 2024-10-30 at 10 55 35](https://github.com/user-attachments/assets/b719181a-1772-47f3-93b2-6c40c2553b12)

After:

![CleanShot 2024-10-30 at 10 54 54](https://github.com/user-attachments/assets/921b8807-c770-44e4-a418-9e7b09f3d6da)



## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
