### PR TITLE
fix: don't close rule editor when hitting enter

### DIFF
--- a/src/views/Generator/RuleEditor/RuleEditor.tsx
+++ b/src/views/Generator/RuleEditor/RuleEditor.tsx
@@ -94,6 +94,7 @@ export function RuleEditor({ rule }: RuleEditorProps) {
                 title="close"
                 m="3"
                 onClick={handleClose}
+                type="button"
               >
                 <Cross2Icon />
               </IconButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevent rule editor from closing when hitting enter. 

## How to Test

1. Create or edit an existing rule.
2. Focus an input.
3. Hit enter.
4. Verify rule form is not closed.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
