### PR TITLE
fix: Add requests hover state

### DIFF
--- a/src/components/WebLogView/Row.tsx
+++ b/src/components/WebLogView/Row.tsx
@@ -17,7 +17,10 @@ export function Row({ data, isSelected, onSelectRequest }: RowProps) {
     <Table.Row
       onClick={() => onSelectRequest(data)}
       css={{
-        backgroundColor: isSelected ? 'var(--accent-2)' : 'transparent',
+        backgroundColor: isSelected ? 'var(--accent-3)' : 'transparent',
+        '&:hover': {
+          backgroundColor: isSelected ? 'var(--accent-3)' : 'var(--accent-2)',
+        },
       }}
     >
       <Table.Cell


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add hover state on request rows to serve as indicator that rows are clickable.

![CleanShot 2024-10-30 at 14 06 10](https://github.com/user-attachments/assets/7a6ed27f-9331-42ba-9e48-5a1cf0238e55)


## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
