### PR TITLE
fix: Show allowlist dialog as modal when action is required

### DIFF
--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -1,15 +1,18 @@
-import { Button } from '@radix-ui/themes'
+import { Button, Dialog, Flex } from '@radix-ui/themes'
 import { useGeneratorStore } from '@/store/generator'
 import { AllowlistDialog } from './AllowlistDialog'
 import { extractUniqueHosts } from '@/store/generator/slices/recording.utils'
 import { GlobeIcon } from '@radix-ui/react-icons'
 import { PopoverDialog } from '@/components/PopoverDialogs'
+import { useState } from 'react'
 
 export function Allowlist() {
   const requests = useGeneratorStore((store) => store.requests)
 
   const allowlist = useGeneratorStore((store) => store.allowlist)
   const setAllowlist = useGeneratorStore((store) => store.setAllowlist)
+
+  const [openAsPopover, setOpenAsPopover] = useState(false)
 
   const showAllowlistDialog = useGeneratorStore(
     (store) => store.showAllowlistDialog
@@ -27,33 +30,89 @@ export function Allowlist() {
 
   const hosts = extractUniqueHosts(requests)
 
+  function handleOpenChange(open: boolean) {
+    if (!open) {
+      setOpenAsPopover(false)
+    }
+
+    setShowAllowlistDialog(open)
+  }
+
+  // Show dialog as popover when triggered from the button
+  const Wrapper = openAsPopover ? PopoverWrapper : DialogWrapper
+
+  const trigger = (
+    <Button
+      size="1"
+      variant="ghost"
+      color="gray"
+      onClick={() => setOpenAsPopover(true)}
+    >
+      <GlobeIcon />
+      Allowed hosts [{allowlist.length}/{hosts.length}]
+    </Button>
+  )
+
   return (
-    <>
-      <PopoverDialog
-        open={showAllowlistDialog}
-        onOpenChange={setShowAllowlistDialog}
-        modal // needed to automatically open when switching recordings
-        trigger={
-          <Button
-            size="1"
-            variant="ghost"
-            color="gray"
-            onClick={() => setShowAllowlistDialog(true)}
-          >
-            <GlobeIcon />
-            Allowed hosts [{allowlist.length}/{hosts.length}]
-          </Button>
-        }
-      >
-        <AllowlistDialog
-          hosts={hosts}
-          allowlist={allowlist}
-          requests={requests}
-          includeStaticAssets={includeStaticAssets}
-          setAllowlist={setAllowlist}
-          setIncludeStaticAssets={setIncludeStaticAssets}
-        />
-      </PopoverDialog>
-    </>
+    <Wrapper
+      trigger={trigger}
+      open={showAllowlistDialog}
+      onOpenChange={handleOpenChange}
+    >
+      <AllowlistDialog
+        hosts={hosts}
+        allowlist={allowlist}
+        requests={requests}
+        includeStaticAssets={includeStaticAssets}
+        setAllowlist={setAllowlist}
+        setIncludeStaticAssets={setIncludeStaticAssets}
+      />
+    </Wrapper>
+  )
+}
+
+interface WrapperProps {
+  trigger: React.ReactNode
+  children: React.ReactNode
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function PopoverWrapper({
+  trigger,
+  children,
+  open,
+  onOpenChange,
+}: WrapperProps) {
+  return (
+    <PopoverDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      trigger={trigger}
+      modal // needed to automatically open when switching recordings
+    >
+      {children}
+    </PopoverDialog>
+  )
+}
+
+function DialogWrapper({
+  trigger,
+  children,
+  open,
+  onOpenChange,
+}: WrapperProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Trigger>{trigger}</Dialog.Trigger>
+      <Dialog.Content width="450px" size="2">
+        {children}
+        <Dialog.Close>
+          <Flex justify="end">
+            <Button>Continue</Button>
+          </Flex>
+        </Dialog.Close>
+      </Dialog.Content>
+    </Dialog.Root>
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We've recently updated allowlist dialog to be displayed as an inline popover to match test options' dialog style. Although this approach is effective, we would like to direct the user's attention towards the allowlist when the user's input is required. This includes when creating a new generator, opening a generator without a set allowlist, or switching between recordings that contain different hosts. With this change, allowlist could be displayed both as popover or modal depending on this condition:

If allowlist is triggered by indirect action (open generator, switch recording) → show as modal.
If allowlist button is clicked inside generator → show as popover.


Could use some feedback whether we should disable "Continue" button when no hosts are selected. Currently, it's not blocking you from continuing without any hosts because neither does the allowlist popover. 

## How to Test

Verify allowlist is displayed as a popover when clicking the allowlist button, and as modal in other cases. 

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
![CleanShot 2024-10-30 at 16 17 31](https://github.com/user-attachments/assets/a00007b5-621c-4f2e-a88b-affa4b3bf6b0)

![CleanShot 2024-10-30 at 16 17 43](https://github.com/user-attachments/assets/d97a8438-3131-45c2-acbe-f0fb51f12ae4)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
