### PR TITLE
fix: Import external HAR

### DIFF
--- a/src/utils/harToProxyData.ts
+++ b/src/utils/harToProxyData.ts
@@ -2,6 +2,7 @@ import { DEFAULT_GROUP_NAME } from '@/constants'
 import { Method, ProxyData, Request, Response } from '@/types'
 import { HarWithOptionalResponse } from '@/types/har'
 import type { Entry } from 'har-format'
+import { safeAtob } from './format'
 
 export function harToProxyData(har: HarWithOptionalResponse): ProxyData[] {
   return har.log.entries.map((entry) => ({
@@ -53,7 +54,7 @@ function parseRequest(request: Entry['request']): Request {
 }
 
 function parseResponse(response: Entry['response']): Response {
-  const content = response.content?.text ? atob(response.content.text) : ''
+  const content = response.content?.text ? safeAtob(response.content.text) : ''
   return {
     statusCode: response.status,
     reason: response.statusText,

--- a/src/utils/harToProxyData.ts
+++ b/src/utils/harToProxyData.ts
@@ -1,8 +1,7 @@
 import { DEFAULT_GROUP_NAME } from '@/constants'
 import { Method, ProxyData, Request, Response } from '@/types'
 import { HarWithOptionalResponse } from '@/types/har'
-import type { Entry } from 'har-format'
-import { safeAtob } from './format'
+import type { Content, Entry } from 'har-format'
 
 export function harToProxyData(har: HarWithOptionalResponse): ProxyData[] {
   return har.log.entries.map((entry) => ({
@@ -54,14 +53,13 @@ function parseRequest(request: Entry['request']): Request {
 }
 
 function parseResponse(response: Entry['response']): Response {
-  const content = response.content?.text ? safeAtob(response.content.text) : ''
   return {
     statusCode: response.status,
     reason: response.statusText,
     httpVersion: response.httpVersion,
     headers: response.headers.map((h) => [h.name, h.value]),
     cookies: response.cookies.map((c) => [c.name, c.value]),
-    content,
+    content: parseContent(response.content),
     contentLength: response.content?.size ?? 0,
     timestampStart: 0,
     path: '',
@@ -70,4 +68,13 @@ function parseResponse(response: Entry['response']): Response {
 
 function isoToUnixTimestamp(isoString: string): number {
   return new Date(isoString).getTime() / 1000
+}
+
+function parseContent(content: Content): string {
+  if (!content.text) return ''
+
+  if (content.encoding === 'base64') {
+    return atob(content.text)
+  }
+  return content.text
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, when trying to import externally recorded HAR, you'll get an error. This is caused by trying to decode a non-base64-encoded response content. Using `safeAtob` will allow us to support both encoded and non-encoded HARs. 


## How to Test

1. Using your browser (I've used Chrome) visit a website with devtools opened, save the HAR from network tab
2. Import HAR into k6 studio

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
