### PR TITLE
fix: Minor ui bugs

### DIFF
--- a/src/views/Generator/GeneratorSidebar/GeneratorSidebar.tsx
+++ b/src/views/Generator/GeneratorSidebar/GeneratorSidebar.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react'
 import { useEffect, useState } from 'react'
 
-import { Flex, Tabs } from '@radix-ui/themes'
+import { Box, Flex, Tabs } from '@radix-ui/themes'
 import { ScriptPreview } from './ScriptPreview'
 import {
   selectFilteredRequests,
@@ -36,34 +36,36 @@ export function GeneratorSidebar() {
   return (
     <Flex direction="column" height="100%" minHeight="0" asChild>
       <Tabs.Root value={tab} onValueChange={(value) => setTab(value)}>
-        <Tabs.List>
-          <Tabs.Trigger value="requests">
-            Requests ({filteredRequests.length})
-          </Tabs.Trigger>
-          <Tabs.Trigger
-            value="script"
-            disabled={!hasRecording}
-            css={
-              hasError &&
-              css`
-                color: var(--red-9);
-              `
-            }
-          >
-            {hasError && (
-              <CrossCircledIcon
-                css={css`
-                  margin-right: 5px;
-                `}
-                color="var(--red-9)"
-              />
+        <Box flexShrink="0">
+          <Tabs.List>
+            <Tabs.Trigger value="requests">
+              Requests ({filteredRequests.length})
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              value="script"
+              disabled={!hasRecording}
+              css={
+                hasError &&
+                css`
+                  color: var(--red-9);
+                `
+              }
+            >
+              {hasError && (
+                <CrossCircledIcon
+                  css={css`
+                    margin-right: 5px;
+                  `}
+                  color="var(--red-9)"
+                />
+              )}
+              Script
+            </Tabs.Trigger>
+            {hasPreview && (
+              <Tabs.Trigger value="rule-preview">Rule preview</Tabs.Trigger>
             )}
-            Script
-          </Tabs.Trigger>
-          {hasPreview && (
-            <Tabs.Trigger value="rule-preview">Rule preview</Tabs.Trigger>
-          )}
-        </Tabs.List>
+          </Tabs.List>
+        </Box>
         {hasPreview && (
           <Tabs.Content
             value="rule-preview"

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -19,7 +19,13 @@ export function Home() {
   return (
     <Flex direction="column" height="100%">
       <ExperimentalBanner />
-      <Flex direction="column" align="center" justify="center" height="100%">
+      <Flex
+        direction="column"
+        align="center"
+        justify="center"
+        height="100%"
+        p="4"
+      >
         <Heading
           size="8"
           mb="1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. When there's a script error, the generator sidebar tabs can get covered

![CleanShot 2024-10-31 at 15 12 38](https://github.com/user-attachments/assets/c5c5cc5c-e391-4e69-822b-2f517b71108f)

2. Add padding to home screen

![CleanShot 2024-10-31 at 14 58 17](https://github.com/user-attachments/assets/293d3cc4-b34f-4b7a-acc0-4c1be8a6102e)

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
