### PR TITLE
feat: organize settings dialog with tabs

### DIFF
--- a/src/components/Form/FileUploadInput.tsx
+++ b/src/components/Form/FileUploadInput.tsx
@@ -8,6 +8,7 @@ type FileUploadInputProps = {
   buttonText: string
   hint?: string
   errors?: FieldErrors
+  disabled?: boolean
   onSelectFile: () => void
 }
 
@@ -17,6 +18,7 @@ export const FileUploadInput = ({
   hint,
   label,
   errors,
+  disabled,
   buttonText,
 }: FileUploadInputProps) => {
   return (
@@ -34,6 +36,7 @@ export const FileUploadInput = ({
           >
             <TextField.Root
               type="text"
+              disabled={disabled}
               onChange={field.onChange}
               name={field.name}
               value={field.value}
@@ -44,6 +47,7 @@ export const FileUploadInput = ({
 
       <Button
         ml="2"
+        disabled={disabled}
         onClick={onSelectFile}
         style={{
           marginTop: 48,

--- a/src/components/Settings/ProxySettings.tsx
+++ b/src/components/Settings/ProxySettings.tsx
@@ -28,7 +28,7 @@ export const ProxySettings = () => {
   const { proxy } = watch()
 
   return (
-    <SettingsSection title="Proxy">
+    <SettingsSection>
       <FieldGroup
         name="proxy.port"
         label="Port number"

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -3,6 +3,7 @@ import { Flex, Text, Checkbox } from '@radix-ui/themes'
 import { Controller, useFormContext } from 'react-hook-form'
 import { SettingsSection } from './SettingsSection'
 import { FileUploadInput } from '../Form'
+import { useEffect } from 'react'
 
 export const RecorderSettings = () => {
   const {
@@ -15,6 +16,13 @@ export const RecorderSettings = () => {
   } = useFormContext<AppSettings>()
 
   const { recorder } = watch()
+
+  useEffect(() => {
+    if (recorder.detectBrowserPath) {
+      setValue('recorder.browserPath', '', { shouldDirty: true })
+      clearErrors('recorder.browserPath')
+    }
+  }, [clearErrors, recorder.detectBrowserPath, setValue])
 
   const handleSelectFile = async () => {
     const result = await window.studio.settings.selectBrowserExecutable()
@@ -43,16 +51,15 @@ export const RecorderSettings = () => {
         />
       </Flex>
 
-      {recorder && !recorder.detectBrowserPath && (
-        <FileUploadInput
-          label="Browser Path"
-          errors={errors}
-          name="recorder.browserPath"
-          onSelectFile={handleSelectFile}
-          buttonText="Select executable"
-          hint="The location of the browser executable (k6 Studio currently supports Chrome)"
-        />
-      )}
+      <FileUploadInput
+        label="Browser Path"
+        errors={errors}
+        name="recorder.browserPath"
+        onSelectFile={handleSelectFile}
+        buttonText="Select executable"
+        hint="The location of the browser executable (k6 Studio currently supports Chrome)"
+        disabled={recorder.detectBrowserPath}
+      />
     </SettingsSection>
   )
 }

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -25,7 +25,7 @@ export const RecorderSettings = () => {
   }
 
   return (
-    <SettingsSection title="Recorder">
+    <SettingsSection>
       <Flex gap="2" mb="4">
         <Controller
           control={control}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -122,7 +122,7 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
               </Tabs.List>
             </Box>
 
-            <Box minHeight="0" maxHeight="480px" flexGrow="1">
+            <Box minHeight="0" maxHeight="460px" mb="4" flexGrow="1">
               <ScrollArea>
                 {tabs.map((tab) => (
                   <Tabs.Content key={tab.value} value={tab.value}>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react'
-import { Button, Dialog, Flex, Tabs } from '@radix-ui/themes'
+import { Box, Button, Dialog, Flex, ScrollArea, Tabs } from '@radix-ui/themes'
 import { ProxySettings } from './ProxySettings'
 import { FormProvider, useForm } from 'react-hook-form'
 import { AppSettingsSchema } from '@/schemas/appSettings'
@@ -99,44 +99,55 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
           <Tabs.Root
             value={selectedTab}
             onValueChange={(value) => setSelectedTab(value)}
+            css={css`
+              height: 100%;
+              display: flex;
+              flex-direction: column;
+            `}
           >
-            <Tabs.List>
-              {tabs.map((tab) => (
-                <Tabs.Trigger key={tab.value} value={tab.value}>
-                  {tab.label}
-                  {errors[tab.value as keyof typeof errors] && (
-                    <ExclamationTriangleIcon
-                      css={css`
-                        margin-left: var(--space-1);
-                      `}
-                    />
-                  )}
-                </Tabs.Trigger>
-              ))}
-            </Tabs.List>
+            <Box flexShrink="0">
+              <Tabs.List>
+                {tabs.map((tab) => (
+                  <Tabs.Trigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                    {errors[tab.value as keyof typeof errors] && (
+                      <ExclamationTriangleIcon
+                        css={css`
+                          margin-left: var(--space-1);
+                        `}
+                      />
+                    )}
+                  </Tabs.Trigger>
+                ))}
+              </Tabs.List>
+            </Box>
 
-            {tabs.map((tab) => (
-              <Tabs.Content key={tab.value} value={tab.value}>
-                <tab.component />
-              </Tabs.Content>
-            ))}
+            <Box minHeight="0" maxHeight="480px" flexGrow="1">
+              <ScrollArea>
+                {tabs.map((tab) => (
+                  <Tabs.Content key={tab.value} value={tab.value}>
+                    <tab.component />
+                  </Tabs.Content>
+                ))}
+              </ScrollArea>
+            </Box>
+
+            <Flex gap="3" justify="end">
+              <Dialog.Close>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.Close>
+              <Dialog.Close>
+                <ButtonWithTooltip
+                  loading={submitting}
+                  disabled={!isDirty}
+                  tooltip={!isDirty ? 'Changes saved' : ''}
+                  onClick={handleSubmit(onSubmit, onInvalid)}
+                >
+                  Save changes
+                </ButtonWithTooltip>
+              </Dialog.Close>
+            </Flex>
           </Tabs.Root>
-
-          <Flex gap="3" justify="end" align="end" flexGrow="1">
-            <Dialog.Close>
-              <Button variant="outline">Cancel</Button>
-            </Dialog.Close>
-            <Dialog.Close>
-              <ButtonWithTooltip
-                loading={submitting}
-                disabled={!isDirty}
-                tooltip={!isDirty ? 'Changes saved' : ''}
-                onClick={handleSubmit(onSubmit, onInvalid)}
-              >
-                Save changes
-              </ButtonWithTooltip>
-            </Dialog.Close>
-          </Flex>
         </FormProvider>
       </Dialog.Content>
     </Dialog.Root>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -56,8 +56,11 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
     try {
       setSubmitting(true)
       const isSuccess = await window.studio.settings.saveSettings(data)
-      isSuccess && reset(data)
-      onOpenChange(false)
+      if (isSuccess) {
+        reset(data)
+        setSettings(data)
+        onOpenChange(false)
+      }
     } catch (error) {
       console.error('Error saving settings', error)
     } finally {
@@ -73,8 +76,13 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
     setSelectedTab(tabsWithError[0] || 'proxy')
   }
 
+  const handleOpenChange = () => {
+    reset(settings)
+    onOpenChange(!open)
+  }
+
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Content
         maxWidth="800px"
         maxHeight="640px"

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -21,7 +21,7 @@ const tabs = [
   { label: 'Proxy', value: 'proxy', component: ProxySettings },
   { label: 'Recorder', value: 'recorder', component: RecorderSettings },
   {
-    label: 'Usage Collection',
+    label: 'Usage collection',
     value: 'usageReport',
     component: UsageReportSettings,
   },

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -57,9 +57,10 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
       setSubmitting(true)
       const isSuccess = await window.studio.settings.saveSettings(data)
       if (isSuccess) {
+        onOpenChange(false)
         reset(data)
         setSettings(data)
-        onOpenChange(false)
+        setSelectedTab('proxy')
       }
     } catch (error) {
       console.error('Error saving settings', error)
@@ -78,6 +79,7 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
 
   const handleOpenChange = () => {
     reset(settings)
+    setSelectedTab('proxy')
     onOpenChange(!open)
   }
 

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, ScrollArea } from '@radix-ui/themes'
+import { Box, Flex } from '@radix-ui/themes'
 
 type SettingsSectionProps = {
   children: React.ReactNode
@@ -6,8 +6,8 @@ type SettingsSectionProps = {
 
 export function SettingsSection({ children }: SettingsSectionProps) {
   return (
-    <Flex gap="2" direction="column" pt="4" height="460px">
-      <ScrollArea>{children}</ScrollArea>
+    <Flex gap="2" direction="column" pt="4">
+      <Box>{children}</Box>
     </Flex>
   )
 }

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -1,27 +1,13 @@
-import { css } from '@emotion/react'
-import { Flex, Heading, Box } from '@radix-ui/themes'
+import { Flex, ScrollArea } from '@radix-ui/themes'
 
 type SettingsSectionProps = {
-  title: string
   children: React.ReactNode
 }
 
-export function SettingsSection({ title, children }: SettingsSectionProps) {
+export function SettingsSection({ children }: SettingsSectionProps) {
   return (
-    <Flex gap="2" direction="column" p="1">
-      <Heading
-        size="2"
-        my="4"
-        css={css`
-          font-size: 18px;
-          line-height: 24px;
-          font-weight: 500;
-        `}
-      >
-        {title}
-      </Heading>
-
-      <Box>{children}</Box>
+    <Flex gap="2" direction="column" pt="4" height="460px">
+      <ScrollArea>{children}</ScrollArea>
     </Flex>
   )
 }

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -6,7 +6,7 @@ type SettingsSectionProps = {
 
 export function SettingsSection({ children }: SettingsSectionProps) {
   return (
-    <Flex gap="2" direction="column" pt="4">
+    <Flex gap="2" direction="column" pt="4" p="1">
       <Box>{children}</Box>
     </Flex>
   )

--- a/src/components/Settings/UsageReportSettings.tsx
+++ b/src/components/Settings/UsageReportSettings.tsx
@@ -13,7 +13,7 @@ export const UsageReportSettings = () => {
   }
 
   return (
-    <SettingsSection title="Usage Report">
+    <SettingsSection>
       <Flex gap="2">
         <Controller
           control={control}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the Settings dialog by separating sections into tabs. This provides a cleaner user interface as we add more functionalities to the Studio and enable users with custom settings.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->
- Make the state of the settings dialog invalid
- Attempt to submit
- Check that tabs with errors are automatically selected and, inputs with errors automatically get focus

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/a01c999c-a401-4a8e-a255-2ec6c0097c92


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
