### PR TITLE
feat: capture additional logs for proxy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -671,8 +671,10 @@ const launchProxyAndAttachEmitter = async (browserWindow: BrowserWindow) => {
       proxyEmitter.emit('status:change', 'restarting')
       currentProxyProcess = await launchProxyAndAttachEmitter(browserWindow)
 
+      const errorMessage = `Proxy failed to start on port ${proxyPort}, restarting...`
+      log.error(errorMessage)
       sendToast(browserWindow.webContents, {
-        title: 'Proxy failed to start, restarting...',
+        title: errorMessage,
         status: 'error',
       })
     },

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -86,10 +86,14 @@ export const launchProxy = (
     const proxyData = safeJsonParse<ProxyData>(data)
     if (proxyData) {
       browserWindow.webContents.send('proxy:data', proxyData)
+    } else {
+      // the proxy outputs some errors to stdout
+      // example: [Errno 48] HTTP(S) proxy failed to listen on *:6001
+      log.error(data)
     }
   })
 
-  proxy.stderr.on('data', (data) => {
+  proxy.stderr.on('data', (data: Buffer) => {
     console.error(`stderr: ${data}`)
     log.error(data.toString())
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When the proxy fails to start, the only line outputted to the log file is the following:

```.log
[2024-11-07 10:53:51.755] [error] Error logged during startup, exiting...
```

This happens because mitmproxy outputs some errors to stdout and, we are not capturing them.

With the changes in this PR, the log file will look like this when the proxy port is already in use, but additional information will be captured regardless of the error:

```log
[2024-11-07 10:48:52.998] [error] Error logged during startup, exiting...
[2024-11-07 10:48:52.999] [error] [10:48:52.998] [Errno 48] HTTP(S) proxy (upstream mode) failed to listen on *:6001 with [Errno 48] error while attempting to bind on address ('0.0.0.0', 6001): address already in use
[2024-11-07 10:48:53.000] [error] Try specifying a different port by using `--mode upstream:localhost:200@6003`.
[2024-11-07 10:48:53.000] [error] Proxy failed to start on port 6001, restarting...
```

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- launch a separate instance of k6 Studio (such as a production build using a valid port or, start mitmproxy on your terminal `mitmproxy --mode regular@6001`)
- launch k6 studio using this branch and change the port to the same as the other instance. Make sure the "Automatically find port" option is disabled
- the proxy should fail to launch due to the port being busy
- check the log file

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
