### PR TITLE
fix: prevent app from crashing when settings file is invalid

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import { sendReport } from './usageReport'
 import { AppSettings } from './types/settings'
 import {
   getSettings,
+  initSettings,
   saveSettings,
   selectBrowserExecutable,
   selectUpstreamCertificate,
@@ -195,6 +196,7 @@ const createWindow = async () => {
 }
 
 app.whenReady().then(async () => {
+  await initSettings()
   appSettings = await getSettings()
   nativeTheme.themeSource = appSettings.appearance.theme
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,8 +182,8 @@ const createWindow = async () => {
     proxyEmitter.removeAllListeners('status:change')
   )
 
-  mainWindow.on('move', () => trackWindowState(mainWindow))
-  mainWindow.on('resize', () => trackWindowState(mainWindow))
+  mainWindow.on('moved', () => trackWindowState(mainWindow))
+  mainWindow.on('resized', () => trackWindowState(mainWindow))
   mainWindow.on('close', (event) => {
     mainWindow.webContents.send('app:close')
     if (currentClientRoute.startsWith('/generator') && !wasAppClosedByClient) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On Windows, the settings file was noticed to be created without any content, likely due to other issues during initialization that can be observed in the full log file found at https://github.com/grafana/k6-studio/issues/345.

This PR makes changes that ensure that the application initializes with valid settings when the JSON file is corrupted.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

In any platform, using this branch:

- Delete the `k6-studio-dev.json` file
- Initialize the app and check that the default configuration is loaded


- Remove the content of `k6-studio-dev.json` (make it 0 bytes or anything else than a JSON)
- Initialize the app and check that the default configuration is loaded

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/345

<!-- Thanks for your contribution! 🙏🏼 -->
