### PR TITLE
ensure window state is tracked when settings dialog is open

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,7 @@ import { sendReport } from './usageReport'
 import { AppSettings } from './types/settings'
 import {
   getSettings,
+  initSettings,
   saveSettings,
   selectBrowserExecutable,
   selectUpstreamCertificate,
@@ -195,6 +196,7 @@ const createWindow = async () => {
 }
 
 app.whenReady().then(async () => {
+  await initSettings()
   appSettings = await getSettings()
   nativeTheme.themeSource = appSettings.appearance.theme
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,8 +182,8 @@ const createWindow = async () => {
     proxyEmitter.removeAllListeners('status:change')
   )
 
-  mainWindow.on('move', () => trackWindowState(mainWindow))
-  mainWindow.on('resize', () => trackWindowState(mainWindow))
+  mainWindow.on('moved', () => trackWindowState(mainWindow))
+  mainWindow.on('resized', () => trackWindowState(mainWindow))
   mainWindow.on('close', (event) => {
     mainWindow.webContents.send('app:close')
     if (currentClientRoute.startsWith('/generator') && !wasAppClosedByClient) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -582,7 +582,9 @@ ipcMain.handle('settings:save', async (event, data: AppSettings) => {
 
   const browserWindow = browserWindowFromEvent(event)
   try {
-    const modifiedSettings = await saveSettings(data)
+    // don't pass fields that are not submitted by the form
+    const { windowState: _, ...settings } = data
+    const modifiedSettings = await saveSettings(settings)
     applySettings(modifiedSettings, browserWindow)
 
     sendToast(browserWindow.webContents, {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -73,14 +73,14 @@ export async function getSettings() {
 
 /**
  * Write the new settings to the settings file
- * @param newSettings
+ * @param settings
  * @returns The settings that have changed
  */
-export async function saveSettings(newSettings: AppSettings) {
+export async function saveSettings(settings: Partial<AppSettings>) {
   const currentSettings = await getSettings()
-  const diff = getSettingsDiff(currentSettings, newSettings)
+  const newSettings = { ...currentSettings, ...settings }
   await writeFile(filePath, JSON.stringify(newSettings))
-  return diff
+  return getSettingsDiff(currentSettings, settings)
 }
 
 /**
@@ -89,7 +89,10 @@ export async function saveSettings(newSettings: AppSettings) {
  * @param newSettings
  * @returns the difference between the old and new settings
  */
-function getSettingsDiff(oldSettings: AppSettings, newSettings: AppSettings) {
+function getSettingsDiff(
+  oldSettings: AppSettings,
+  newSettings: Partial<AppSettings>
+) {
   const diff: Record<string, unknown> = {}
 
   for (const key in newSettings) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The window state is not being persisted when the Settings dialog is open and, you move or resize the main window. This PR makes changes to the `saveSettings` function to ensure only fields that are being submitted from the form are being overwritten.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Launch the app
- Open the Settings dialog
- Move and resize the main window
- Make any other change on the settings dialog,such as changing the proxy port or changing the theme
- Submit your changes
- Close the app and check that window state and remaining settings were properly persisted

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
