### PR TITLE
fix: onMount prop conflict with ReactMonacoEditor component

### DIFF
--- a/src/components/Monaco/ReactMonacoEditor.tsx
+++ b/src/components/Monaco/ReactMonacoEditor.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@/hooks/useTheme'
-import { Editor, EditorProps, loader } from '@monaco-editor/react'
+import { Editor, EditorProps, loader, Monaco } from '@monaco-editor/react'
 import * as monaco from 'monaco-editor'
 import { EditorToolbar, ToolbarState } from './EditorToolbar'
 import { useMemo, useState } from 'react'
@@ -56,6 +56,17 @@ export function ReactMonacoEditor({
     return true
   }, [editor])
 
+  const handleEditorMount = (
+    editor: monaco.editor.IStandaloneCodeEditor,
+    monaco: Monaco
+  ) => {
+    setEditor(editor)
+
+    if (props.onMount) {
+      props.onMount(editor, monaco)
+    }
+  }
+
   return (
     <Flex height="100%" width="100%" direction="column">
       {showToolbar && (
@@ -71,7 +82,7 @@ export function ReactMonacoEditor({
           ...props.options,
           wordWrap: toolbarState.wordWrap,
         }}
-        onMount={(editor) => setEditor(editor)}
+        onMount={handleEditorMount}
         theme={theme === 'dark' ? 'vs-dark' : 'k6-studio-light'}
       />
     </Flex>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a bug that was introduced in https://github.com/grafana/k6-studio/pull/355 and caused the instance of the Monaco Editor in the "Script Preview" tab to show with no content after the first render.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open the Script Preview tab
- Check that the script is properly generated
- Switch to a different generator
- Check that the Script Preview tab contains the correct script

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
