### PR TITLE
feat: add hostname as prefix of har filename

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -403,8 +403,8 @@ ipcMain.handle(
 )
 
 // HAR
-ipcMain.handle('har:save', async (_, data) => {
-  const fileName = generateFileNameWithTimestamp('har')
+ipcMain.handle('har:save', async (_, data: string, prefix?: string) => {
+  const fileName = generateFileNameWithTimestamp('har', prefix)
   await writeFile(path.join(RECORDINGS_PATH, fileName), data)
   return fileName
 })

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -106,8 +106,8 @@ const script = {
 } as const
 
 const har = {
-  saveFile: (data: string): Promise<string> => {
-    return ipcRenderer.invoke('har:save', data)
+  saveFile: (data: string, prefix?: string): Promise<string> => {
+    return ipcRenderer.invoke('har:save', data, prefix)
   },
   openFile: (filePath: string): Promise<HarFile> => {
     return ipcRenderer.invoke('har:open', filePath)

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -9,6 +9,7 @@ import { View } from '@/components/Layout/View'
 import { RequestsSection } from './RequestsSection'
 import { useListenProxyData } from '@/hooks/useListenProxyData'
 import {
+  getHostNameFromURL,
   startRecording,
   stopRecording,
   useDebouncedProxyData,
@@ -35,7 +36,7 @@ const INITIAL_GROUPS: Group[] = [
 
 export function Recorder() {
   const [selectedRequest, setSelectedRequest] = useState<ProxyData | null>(null)
-
+  const [startUrl, setStartUrl] = useState<string>()
   const [groups, setGroups] = useState<Group[]>(() => INITIAL_GROUPS)
 
   const group = useMemo(() => groups[groups.length - 1], [groups])
@@ -57,6 +58,7 @@ export function Recorder() {
 
   const handleStartRecording = useCallback(
     async (url?: string) => {
+      setStartUrl(url)
       try {
         resetProxyData()
         setRecorderState('starting')
@@ -103,15 +105,17 @@ export function Recorder() {
       })
 
       const har = proxyDataToHar(grouped)
+      const prefix = startUrl && getHostNameFromURL(startUrl)
       const fileName = await window.studio.har.saveFile(
-        JSON.stringify(har, null, 4)
+        JSON.stringify(har, null, 4),
+        prefix
       )
 
       return fileName
     } finally {
       setRecorderState('idle')
     }
-  }, [groups, proxyData])
+  }, [groups, proxyData, startUrl])
 
   async function handleStopRecording() {
     stopRecording()

--- a/src/views/Recorder/Recorder.utils.ts
+++ b/src/views/Recorder/Recorder.utils.ts
@@ -75,6 +75,16 @@ function getRequestSignature(request: Request) {
   return `${request.method} ${request.url}`
 }
 
+export function getHostNameFromURL(url: string) {
+  // ensure that a URL without protocol is parsed correctly
+  const urlWithProtocol = url?.startsWith('http') ? url : `http://${url}`
+  try {
+    return new URL(urlWithProtocol).hostname
+  } catch {
+    return undefined
+  }
+}
+
 // TODO: add error and timeout handling
 export async function startRecording(url?: string) {
   // Kill previous browser window


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR provides a more meaningful file name for the recording based on the starting URL.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- start a new recording
- input the starting URL
- stop the recording
- check that the generated HAR file contains hostname of the starting URL
- check that omitting the starting URL does not include any prefix

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/b5c14208-8ebb-4cc1-b71f-2a4750586806)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/306

<!-- Thanks for your contribution! 🙏🏼 -->
