### PR TITLE
fix: "New recording" button discards existing recording

### DIFF
--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -86,12 +86,7 @@ export function RecordingPreviewer() {
           )}
 
           {!isDiscardable && (
-            <Button
-              onClick={handleDiscard}
-              variant="outline"
-              asChild
-              css={{ cursor: 'default' }}
-            >
+            <Button variant="outline" asChild css={{ cursor: 'default' }}>
               <Link to={getRoutePath('recorder')}>New recording</Link>
             </Button>
           )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When viewing an existing recording and clicking "New recording" the viewed recording gets deleted. This is destructive and unexpected behavior. 

Steps to reproduce:
1. Open existing recording
2. Click "New recording" button.

**Expected behavior:**
Existing recording is preserved and new recording starts.

**Actual behavior:**
Existing recording gets deleted

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
