### PR TITLE
feat: add type column to WebLogView

### DIFF
--- a/src/components/WebLogView/Row.tsx
+++ b/src/components/WebLogView/Row.tsx
@@ -1,4 +1,4 @@
-import { Box, Table } from '@radix-ui/themes'
+import { Box, Table, Text } from '@radix-ui/themes'
 
 import { ProxyData, ProxyDataWithMatches } from '@/types'
 
@@ -6,6 +6,7 @@ import { MethodBadge } from '../MethodBadge'
 import { ResponseStatusBadge } from '../ResponseStatusBadge'
 import { TableCellWithTooltip } from '../TableCellWithTooltip'
 import { HighlightedText } from '../HighlightedText'
+import { isNonStaticAssetResponse } from '@/utils/staticAssets'
 
 interface RowProps {
   data: ProxyDataWithMatches
@@ -52,6 +53,11 @@ export function Row({ data, isSelected, onSelectRequest }: RowProps) {
             matches={data.matches}
           />
         </ResponseStatusBadge>
+      </Table.Cell>
+      <Table.Cell>
+        <Text size="1">
+          {isNonStaticAssetResponse(data) ? 'Dynamic' : 'Static'}
+        </Text>
       </Table.Cell>
       <TableCellWithTooltip>
         <HighlightedText text={data.request.host} matches={data.matches} />

--- a/src/components/WebLogView/Row.tsx
+++ b/src/components/WebLogView/Row.tsx
@@ -1,4 +1,4 @@
-import { Box, Table, Text } from '@radix-ui/themes'
+import { Box, Table } from '@radix-ui/themes'
 
 import { ProxyData, ProxyDataWithMatches } from '@/types'
 
@@ -6,7 +6,7 @@ import { MethodBadge } from '../MethodBadge'
 import { ResponseStatusBadge } from '../ResponseStatusBadge'
 import { TableCellWithTooltip } from '../TableCellWithTooltip'
 import { HighlightedText } from '../HighlightedText'
-import { isNonStaticAssetResponse } from '@/utils/staticAssets'
+import { getRequestType } from './WebLogView.utils'
 
 interface RowProps {
   data: ProxyDataWithMatches
@@ -54,11 +54,7 @@ export function Row({ data, isSelected, onSelectRequest }: RowProps) {
           />
         </ResponseStatusBadge>
       </Table.Cell>
-      <Table.Cell>
-        <Text size="1">
-          {isNonStaticAssetResponse(data) ? 'Dynamic' : 'Static'}
-        </Text>
-      </Table.Cell>
+      <TableCellWithTooltip>{getRequestType(data)}</TableCellWithTooltip>
       <TableCellWithTooltip>
         <HighlightedText text={data.request.host} matches={data.matches} />
       </TableCellWithTooltip>

--- a/src/components/WebLogView/WebLogView.tsx
+++ b/src/components/WebLogView/WebLogView.tsx
@@ -93,6 +93,7 @@ function RequestList({
         <Table.Row>
           <Table.ColumnHeaderCell width="70px">Method</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="60px">Status</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell width="70px">Type</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="20%">Host</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="80%">Path</Table.ColumnHeaderCell>
         </Table.Row>

--- a/src/components/WebLogView/WebLogView.tsx
+++ b/src/components/WebLogView/WebLogView.tsx
@@ -93,7 +93,7 @@ function RequestList({
         <Table.Row>
           <Table.ColumnHeaderCell width="70px">Method</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="60px">Status</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell width="70px">Type</Table.ColumnHeaderCell>
+          <Table.ColumnHeaderCell width="80px">Type</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="20%">Host</Table.ColumnHeaderCell>
           <Table.ColumnHeaderCell width="80%">Path</Table.ColumnHeaderCell>
         </Table.Row>

--- a/src/components/WebLogView/WebLogView.utils.ts
+++ b/src/components/WebLogView/WebLogView.utils.ts
@@ -1,4 +1,6 @@
 import { GroupedProxyData, ProxyData } from '@/types'
+import { getContentType } from '@/utils/headers'
+import { isNonStaticAssetResponse } from '@/utils/staticAssets'
 
 export function removeQueryStringFromUrl(url: string) {
   return url.split('?')[0]
@@ -19,4 +21,13 @@ export function isGroupedProxyData(
   data: ProxyData[] | GroupedProxyData
 ): data is GroupedProxyData {
   return !Array.isArray(data)
+}
+
+export function getRequestType(data: ProxyData) {
+  if (isNonStaticAssetResponse(data)) {
+    return 'fetch'
+  }
+
+  const mimeType = getContentType(data.response?.headers ?? [])
+  return mimeType ? mimeType.split('/')[1] : 'unknown'
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,6 @@ export interface FolderContent {
 
 export type ProxyStatus = 'online' | 'offline' | 'restarting'
 
-export interface ProxyDataWithMatches extends ProxyData {
+export type ProxyDataWithMatches = ProxyData & {
   matches?: SearchMatch[]
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,6 @@ export interface FolderContent {
 
 export type ProxyStatus = 'online' | 'offline' | 'restarting'
 
-export type ProxyDataWithMatches = ProxyData & {
+export interface ProxyDataWithMatches extends ProxyData {
   matches?: SearchMatch[]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a new `Type` column to the `WebLogView` component to differentiate static assets from dynamic requests.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Toggle the "Show static assets" switch
- Check that the Type column shows the appropriate label for each request

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/342e3758-293d-4155-b2b8-2a227960b0d4)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/325

<!-- Thanks for your contribution! 🙏🏼 -->
