### PR TITLE
feat: generator schema migration

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -69,7 +69,7 @@ describe('Code generation', () => {
         generateScript({
           recording: [],
           generator: {
-            version: '0',
+            version: '1.0',
             recordingPath: 'test',
             options: {
               loadProfile: {

--- a/src/schemas/generator/README.md
+++ b/src/schemas/generator/README.md
@@ -14,10 +14,10 @@ For when a new migration is needed:
 4. Update `/schemas/generators/index.ts` to use the new version:
 
 ```ts
-function migrate(settings: z.infer<typeof AnySettingSchema>) {
+function migrate(generator: z.infer<typeof AnyGeneratorSchema>) {
 
 case '1.0':
-  return migrate(v1.migrate(settings))
+  return migrate(v1.migrate(generator))
 
 }
 ```

--- a/src/schemas/generator/README.md
+++ b/src/schemas/generator/README.md
@@ -1,0 +1,25 @@
+# Generator migration
+
+Migrations are needed when changing the structure of existing generators file such as renaming or deleting keys.
+
+If you're simply adding new options to the generator file, a migration may not be needed. In this case, extend the latest schema available.
+
+## Creating a new migration
+
+For when a new migration is needed:
+
+1. Create a directory for the new version (e.g. `/v2`).
+2. Declare the new schema with appropriate changes.
+3. In `/v1/index.ts`, implement a `migrate` function that takes a `v1` schema and returns a `v2` schema.
+4. Update `/schemas/generators/index.ts` to use the new version:
+
+```ts
+function migrate(settings: z.infer<typeof AnySettingSchema>) {
+
+case '1.0':
+  return migrate(v1.migrate(settings))
+
+}
+```
+
+5. Make changes to the remaining implementation to use the new schema.

--- a/src/schemas/generator/index.test.ts
+++ b/src/schemas/generator/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { migrate } from '.'
+import * as v0 from './v0'
+
+describe('Generator migration', () => {
+  it('should migrate from v0 to latest', () => {
+    const v0Generator: v0.GeneratorSchema = {
+      version: '0',
+      recordingPath: 'test',
+      options: {
+        loadProfile: {
+          executor: 'shared-iterations',
+          vus: 1,
+          iterations: 1,
+        },
+        thinkTime: {
+          sleepType: 'iterations',
+          timing: {
+            type: 'fixed',
+            value: 1,
+          },
+        },
+      },
+      testData: {
+        variables: [],
+      },
+      rules: [],
+      allowlist: [],
+      includeStaticAssets: false,
+      scriptName: 'my-script.js',
+    }
+
+    expect(migrate(v0Generator).version).toBe('1.0')
+  })
+})

--- a/src/schemas/generator/index.ts
+++ b/src/schemas/generator/index.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+import * as v0 from './v0'
+import * as v1 from './v1'
+import { exhaustive } from '../../utils/typescript'
+
+const AnyGeneratorSchema = z.discriminatedUnion('version', [
+  v0.GeneratorFileDataSchema,
+  v1.GeneratorFileDataSchema,
+])
+
+export function migrate(generator: z.infer<typeof AnyGeneratorSchema>) {
+  switch (generator.version) {
+    case '0':
+      return migrate(v0.migrate(generator))
+    case '1.0':
+      return generator
+    default:
+      return exhaustive(generator)
+  }
+}
+
+export const GeneratorFileDataSchema = AnyGeneratorSchema.transform(migrate)

--- a/src/schemas/generator/v0/index.ts
+++ b/src/schemas/generator/v0/index.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { TestRuleSchema } from '@/schemas/rules'
+import { TestDataSchema } from '@/schemas/testData'
+import { TestOptionsSchema } from '@/schemas/testOptions'
+import * as v1 from '../v1'
+
+export const GeneratorFileDataSchema = z.object({
+  version: z.literal('0'),
+  recordingPath: z.string(),
+  options: TestOptionsSchema,
+  testData: TestDataSchema,
+  rules: TestRuleSchema.array(),
+  allowlist: z.string().array(),
+  includeStaticAssets: z.boolean(),
+  scriptName: z.string().default('my-script.js'),
+})
+
+export type GeneratorSchema = z.infer<typeof GeneratorFileDataSchema>
+
+// Migrate generator to the next version
+export function migrate(generator: GeneratorSchema): v1.GeneratorSchema {
+  return {
+    version: '1.0',
+    allowlist: generator.allowlist,
+    includeStaticAssets: generator.includeStaticAssets,
+    options: generator.options,
+    recordingPath: generator.recordingPath,
+    rules: generator.rules,
+    scriptName: generator.scriptName,
+    testData: generator.testData,
+  }
+}

--- a/src/schemas/generator/v1/index.ts
+++ b/src/schemas/generator/v1/index.ts
@@ -4,7 +4,7 @@ import { TestDataSchema } from '@/schemas/testData'
 import { TestOptionsSchema } from '@/schemas/testOptions'
 
 export const GeneratorFileDataSchema = z.object({
-  version: z.string(),
+  version: z.literal('1.0'),
   recordingPath: z.string(),
   options: TestOptionsSchema,
   testData: TestDataSchema,
@@ -13,3 +13,10 @@ export const GeneratorFileDataSchema = z.object({
   includeStaticAssets: z.boolean(),
   scriptName: z.string().default('my-script.js'),
 })
+
+export type GeneratorSchema = z.infer<typeof GeneratorFileDataSchema>
+
+// TODO: Migrate generator to the next version
+export function migrate(generator: z.infer<typeof GeneratorFileDataSchema>) {
+  return { ...generator }
+}

--- a/src/store/generator/selectors.ts
+++ b/src/store/generator/selectors.ts
@@ -48,7 +48,7 @@ export function selectGeneratorData(state: GeneratorStore): GeneratorFileData {
   } = state
 
   return {
-    version: '0',
+    version: '1.0',
     recordingPath,
     options: {
       loadProfile,

--- a/src/test/factories/generator.ts
+++ b/src/test/factories/generator.ts
@@ -27,7 +27,7 @@ export function createGeneratorData(
     testData: {
       variables: [],
     },
-    version: '1.0.0',
+    version: '1.0',
     ...data,
   }
 }

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -4,7 +4,7 @@ import { createEmptyRule } from './rules'
 
 export function createNewGeneratorFile(recordingPath = ''): GeneratorFileData {
   return {
-    version: '0',
+    version: '1.0',
     recordingPath,
     options: {
       loadProfile: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds migrations to the generator schema, ensuring that changes to its structure remain backward-compatible. This allows the generator to work properly even when the schema is updated.

The pattern adopted in this PR is based on the settings migration https://github.com/grafana/k6-studio/pull/371.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- make changes to the latest version of the schema `/schemas/generator/v1/index.ts` such as renaming a property.
- change the `migrate` function in `/schemas/generator/v0/index.ts` to return the new schema.
- make appropriate changes to the remaining implementation so the new schema is used. This may require changing the slices and several other parts of the code.
- ensure the Generator file has `version: '0'` and all old properties before testing.
- open the old generator file and check that options were migrated.

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/370

<!-- Thanks for your contribution! 🙏🏼 -->
