### PR TITLE
feat: ability to disable a rule

### DIFF
--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -859,6 +859,7 @@ correlation_vars['correlation_1'] = resp.json().user_id`
     const rule: CorrelationRule = {
       type: 'correlation',
       id: '1',
+      enabled: true,
       extractor: {
         filter: { path: '' },
         selector: {
@@ -906,6 +907,7 @@ correlation_vars['correlation_1'] = resp.json().user_id`
     const rule: CorrelationRule = {
       type: 'correlation',
       id: '1',
+      enabled: true,
       extractor: {
         filter: { path: '' },
         selector: {
@@ -960,6 +962,7 @@ correlation_vars['correlation_1'] = resp.json().user_id`
     const rule: CorrelationRule = {
       type: 'correlation',
       id: '1',
+      enabled: true,
       extractor: {
         filter: { path: '' },
         selector: {

--- a/src/rules/rules.ts
+++ b/src/rules/rules.ts
@@ -20,9 +20,9 @@ function createSequentialIdPool() {
 
 export function applyRules(recording: ProxyData[], rules: TestRule[]) {
   const idGenerator = createSequentialIdPool()
-  const ruleInstances = rules.map((rule) =>
-    createRuleInstance(rule, idGenerator(rule.type))
-  )
+  const ruleInstances = rules
+    .filter((rule) => rule.enabled)
+    .map((rule) => createRuleInstance(rule, idGenerator(rule.type)))
 
   const requestSnippetSchemas = recording.map((data) =>
     ruleInstances.reduce<RequestSnippetSchema>((acc, rule) => rule.apply(acc), {

--- a/src/schemas/rules.ts
+++ b/src/schemas/rules.ts
@@ -98,6 +98,7 @@ export const CorrelationReplacerSchema = z.object({
 
 export const RuleBaseSchema = z.object({
   id: z.string(),
+  enabled: z.boolean().default(true),
 })
 
 export const ParameterizationRuleSchema = RuleBaseSchema.extend({

--- a/src/store/generator/fixtures.ts
+++ b/src/store/generator/fixtures.ts
@@ -3,6 +3,7 @@ import { TestRule } from '@/types/rules'
 export const rules: TestRule[] = [
   {
     id: '0',
+    enabled: true,
     type: 'customCode',
     filter: { path: '' },
     snippet: 'console.log("Hello, world!")',
@@ -11,6 +12,7 @@ export const rules: TestRule[] = [
   {
     type: 'correlation',
     id: '1',
+    enabled: true,
     extractor: {
       filter: { path: '' },
       selector: {
@@ -24,6 +26,7 @@ export const rules: TestRule[] = [
   {
     type: 'correlation',
     id: '3',
+    enabled: true,
     extractor: {
       filter: { path: '' },
       selector: {
@@ -36,6 +39,7 @@ export const rules: TestRule[] = [
   {
     type: 'correlation',
     id: '2',
+    enabled: true,
     extractor: {
       filter: { path: '' },
       selector: {
@@ -49,6 +53,7 @@ export const rules: TestRule[] = [
   {
     type: 'correlation',
     id: '4',
+    enabled: true,
     extractor: {
       filter: { path: 'api.k6.io/v3/account/me' },
       selector: {

--- a/src/store/generator/slices/rules.ts
+++ b/src/store/generator/slices/rules.ts
@@ -11,6 +11,7 @@ interface Actions {
   updateRule: (rule: TestRule) => void
   cloneRule: (id: string) => void
   deleteRule: (id: string) => void
+  toggleEnableRule: (id: string) => void
   swapRules: (idA: string, idB: string) => void
   setSelectedRuleId: (id: string | null) => void
 }
@@ -46,6 +47,13 @@ export const createRulesSlice: ImmerStateCreator<RulesSliceStore> = (set) => ({
       }
 
       state.rules = state.rules.filter((rule) => rule.id !== id)
+    }),
+  toggleEnableRule: (id) =>
+    set((state) => {
+      const index = state.rules.findIndex((r) => r.id === id)
+      if (state.rules[index]) {
+        state.rules[index].enabled = !state.rules[index].enabled
+      }
     }),
   swapRules: (idA, idB) =>
     set((state) => {

--- a/src/test/factories/generator.ts
+++ b/src/test/factories/generator.ts
@@ -39,6 +39,7 @@ export function createGeneratorState(
     addRule: vi.fn(),
     cloneRule: vi.fn(),
     deleteRule: vi.fn(),
+    toggleEnableRule: vi.fn(),
     rules: [],
     swapRules: vi.fn(),
     updateRule: vi.fn(),

--- a/src/test/fixtures/parameterizationRules.ts
+++ b/src/test/fixtures/parameterizationRules.ts
@@ -3,6 +3,7 @@ import { ParameterizationRule } from '@/types/rules'
 export const jsonRule = {
   type: 'parameterization',
   id: '1',
+  enabled: true,
   filter: { path: '' },
   selector: {
     type: 'json',
@@ -18,6 +19,7 @@ export const jsonRule = {
 export const urlRule = {
   type: 'parameterization',
   id: '2',
+  enabled: true,
   filter: { path: '' },
   selector: {
     type: 'begin-end',
@@ -34,6 +36,7 @@ export const urlRule = {
 export const headerRule = {
   type: 'parameterization',
   id: '3',
+  enabled: true,
   filter: { path: '' },
   selector: {
     type: 'regex',
@@ -49,6 +52,7 @@ export const headerRule = {
 export const customCodeReplaceProjectId = {
   type: 'parameterization',
   id: '4',
+  enabled: true,
   filter: { path: '' },
   selector: {
     type: 'regex',
@@ -67,6 +71,7 @@ export const customCodeReplaceProjectId = {
 export const customCodeReplaceCsrf = {
   type: 'parameterization',
   id: '4',
+  enabled: true,
   filter: { path: '' },
   selector: {
     type: 'regex',

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -6,6 +6,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
       return {
         type: 'correlation',
         id: self.crypto.randomUUID(),
+        enabled: true,
         extractor: {
           filter: { path: '' },
           selector: {
@@ -23,6 +24,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
       return {
         type: 'customCode',
         id: self.crypto.randomUUID(),
+        enabled: true,
         filter: { path: '' },
         snippet: '',
         placement: 'before',
@@ -31,6 +33,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
       return {
         type: 'parameterization',
         id: self.crypto.randomUUID(),
+        enabled: true,
         filter: { path: '' },
         selector: {
           type: 'begin-end',
@@ -44,6 +47,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
       return {
         type: 'verification',
         id: self.crypto.randomUUID(),
+        enabled: true,
         filter: { path: '' },
         selector: {
           type: 'begin-end',

--- a/src/views/Generator/RuleEditor/RuleEditor.tsx
+++ b/src/views/Generator/RuleEditor/RuleEditor.tsx
@@ -40,6 +40,17 @@ export function RuleEditorSwitch() {
   }
 }
 
+function RuleDisabledWarning() {
+  return (
+    <Callout.Root mb="4">
+      <Callout.Icon>
+        <InfoCircledIcon />
+      </Callout.Icon>
+      <Callout.Text>This rule is currently disabled.</Callout.Text>
+    </Callout.Root>
+  )
+}
+
 interface RuleEditorProps {
   rule: TestRule
 }
@@ -100,6 +111,7 @@ export function RuleEditor({ rule }: RuleEditorProps) {
               </IconButton>
             </Tooltip>
           </Box>
+          {!rule.enabled && <RuleDisabledWarning />}
           <RuleEditorSwitch />
         </Box>
       </form>

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRule.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRule.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Flex, Grid, IconButton } from '@radix-ui/themes'
+import { Flex, Grid, IconButton, Tooltip } from '@radix-ui/themes'
 import { DragHandleDots2Icon } from '@radix-ui/react-icons'
 
 import type { TestRule } from '@/types/rules'
@@ -48,62 +48,66 @@ export function TestRuleItem({
       : undefined
 
   return (
-    <Grid
-      ref={setNodeRef}
-      gap="2"
-      align="center"
-      p="2"
-      onClick={onSelect}
-      css={css`
-        position: relative;
-        transition: ${transition};
-        transform: ${isSorting ? undefined : CSS.Translate.toString(transform)};
-        border-bottom: 1px solid var(--gray-3);
-        background-color: ${isSelected ? 'var(--accent-2)' : 'unset'};
-        opacity: ${isDragging ? 0.5 : 1};
-        grid-column: 1 / -1;
-        grid-template-columns: subgrid;
+    <Tooltip content="This rule is disabled" hidden={rule.enabled}>
+      <Grid
+        ref={setNodeRef}
+        gap="2"
+        align="center"
+        p="2"
+        onClick={onSelect}
+        css={css`
+          position: relative;
+          transition: ${transition};
+          transform: ${isSorting
+            ? undefined
+            : CSS.Translate.toString(transform)};
+          border-bottom: 1px solid var(--gray-3);
+          background-color: ${isSelected ? 'var(--accent-2)' : 'unset'};
+          opacity: ${isDragging || !rule.enabled ? 0.5 : 1};
+          grid-column: 1 / -1;
+          grid-template-columns: subgrid;
 
-        &:first-of-type {
-          border-top: 1px solid var(--gray-3);
-        }
+          &:first-of-type {
+            border-top: 1px solid var(--gray-3);
+          }
 
-        &::before {
-          content: '';
-          position: absolute;
-          width: 100%;
-          left: 0;
-          top: ${insertPosition === Position.Before ? '-4px' : 'auto'};
-          bottom: ${insertPosition === Position.After ? '-4px' : 'auto'};
-          height: 2px;
-          background: var(--accent-5);
-          border-radius: var(--radius-1);
-          opacity: ${insertPosition !== undefined ? 1 : 0};
-        }
-      `}
-    >
-      <IconButton
-        variant="ghost"
-        color="gray"
-        aria-label="Drag to reorder"
-        {...attributes}
-        {...listeners}
+          &::before {
+            content: '';
+            position: absolute;
+            width: 100%;
+            left: 0;
+            top: ${insertPosition === Position.Before ? '-4px' : 'auto'};
+            bottom: ${insertPosition === Position.After ? '-4px' : 'auto'};
+            height: 2px;
+            background: var(--accent-5);
+            border-radius: var(--radius-1);
+            opacity: ${insertPosition !== undefined ? 1 : 0};
+          }
+        `}
       >
-        <DragHandleDots2Icon
+        <IconButton
+          variant="ghost"
           color="gray"
-          css={css`
-            cursor: grab;
-          `}
-          width={16}
-          height={16}
-          aria-hidden
-        />
-      </IconButton>
-      <TestRuleTypeBadge rule={rule} />
-      <Flex gap="2" overflow="hidden">
-        <TestRuleInlineContent rule={rule} />
-      </Flex>
-      <TestRuleActions ruleId={rule.id} enabled={rule.enabled} />
-    </Grid>
+          aria-label="Drag to reorder"
+          {...attributes}
+          {...listeners}
+        >
+          <DragHandleDots2Icon
+            color="gray"
+            css={css`
+              cursor: grab;
+            `}
+            width={16}
+            height={16}
+            aria-hidden
+          />
+        </IconButton>
+        <TestRuleTypeBadge rule={rule} />
+        <Flex gap="2" overflow="hidden">
+          <TestRuleInlineContent rule={rule} />
+        </Flex>
+        <TestRuleActions ruleId={rule.id} enabled={rule.enabled} />
+      </Grid>
+    </Tooltip>
   )
 }

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRule.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRule.tsx
@@ -103,7 +103,7 @@ export function TestRuleItem({
       <Flex gap="2" overflow="hidden">
         <TestRuleInlineContent rule={rule} />
       </Flex>
-      <TestRuleActions ruleId={rule.id} />
+      <TestRuleActions ruleId={rule.id} enabled={rule.enabled} />
     </Grid>
   )
 }

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleActions.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleActions.tsx
@@ -6,11 +6,13 @@ import { useGeneratorStore } from '@/store/generator'
 
 interface TestRuleActionsProps {
   ruleId: string
+  enabled: boolean
 }
 
-export function TestRuleActions({ ruleId }: TestRuleActionsProps) {
+export function TestRuleActions({ ruleId, enabled }: TestRuleActionsProps) {
   const cloneRule = useGeneratorStore((state) => state.cloneRule)
   const deleteRule = useGeneratorStore((state) => state.deleteRule)
+  const toggleEnableRule = useGeneratorStore((state) => state.toggleEnableRule)
   const setSelectedRuleId = useGeneratorStore(
     (state) => state.setSelectedRuleId
   )
@@ -25,6 +27,10 @@ export function TestRuleActions({ ruleId }: TestRuleActionsProps) {
 
   const handleCopy = () => {
     cloneRule(ruleId)
+  }
+
+  const handleToggleEnabled = () => {
+    toggleEnableRule(ruleId)
   }
 
   return (
@@ -42,6 +48,9 @@ export function TestRuleActions({ ruleId }: TestRuleActionsProps) {
         </IconButton>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
+        <DropdownMenu.Item onClick={handleToggleEnabled}>
+          {enabled ? 'Disable' : 'Enable'}
+        </DropdownMenu.Item>
         <DropdownMenu.Item onClick={handleEdit}>Edit</DropdownMenu.Item>
         <DropdownMenu.Item onClick={handleCopy}>Duplicate</DropdownMenu.Item>
         <DropdownMenu.Separator />

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
@@ -48,22 +48,10 @@ function VerificationContent({ rule }: { rule: VerificationRule }) {
   )
 }
 
-function EnabledStatus({ enabled }: { enabled: boolean }) {
-  const status = enabled ? 'enabled' : 'disabled'
-  return (
-    <>
-      <Tooltip content={`This rule is ${status}`}>
-        <Badge color={enabled ? 'green' : 'gray'}>{status}</Badge>
-      </Tooltip>
-    </>
-  )
-}
-
 function CorrelationContent({ rule }: { rule: CorrelationRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.extractor.filter} />
-      <EnabledStatus enabled={rule.enabled} />
       <TestRuleSelector rule={rule} />
     </>
   )
@@ -73,7 +61,6 @@ function ParameterizationContent({ rule }: { rule: ParameterizationRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.filter} />
-      <EnabledStatus enabled={rule.enabled} />
       <TestRuleSelector rule={rule} />
     </>
   )
@@ -83,7 +70,6 @@ function CustomCodeContent({ rule }: { rule: CustomCodeRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.filter} />{' '}
-      <EnabledStatus enabled={rule.enabled} />
       <Tooltip
         content={`${rule.placement === 'after' ? 'After' : 'Before'} matched requests`}
       >

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
@@ -48,10 +48,22 @@ function VerificationContent({ rule }: { rule: VerificationRule }) {
   )
 }
 
+function EnabledStatus({ enabled }: { enabled: boolean }) {
+  const status = enabled ? 'enabled' : 'disabled'
+  return (
+    <>
+      <Tooltip content={`This rule is ${status}`}>
+        <Badge color={enabled ? 'green' : 'gray'}>{status}</Badge>
+      </Tooltip>
+    </>
+  )
+}
+
 function CorrelationContent({ rule }: { rule: CorrelationRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.extractor.filter} />
+      <EnabledStatus enabled={rule.enabled} />
       <TestRuleSelector rule={rule} />
     </>
   )
@@ -61,6 +73,7 @@ function ParameterizationContent({ rule }: { rule: ParameterizationRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.filter} />
+      <EnabledStatus enabled={rule.enabled} />
       <TestRuleSelector rule={rule} />
     </>
   )
@@ -70,6 +83,7 @@ function CustomCodeContent({ rule }: { rule: CustomCodeRule }) {
   return (
     <>
       <TestRuleFilter filter={rule.filter} />{' '}
+      <EnabledStatus enabled={rule.enabled} />
       <Tooltip
         content={`${rule.placement === 'after' ? 'After' : 'Before'} matched requests`}
       >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces the ability to disable/enable a test rule. Disable rules will not be generated by the script.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Create a new Test Rule
- Disable the rule and check that it was not generated by the script
- Re-enable the same rule and check that it is now generated by the script

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/e039890d-258a-417b-8f32-955d51e09a68)

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/313

<!-- Thanks for your contribution! 🙏🏼 -->
