### PR TITLE
feat: Feature toggle for browser recording in settings dialog

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -81,7 +81,9 @@ export const launchBrowser = async (
       '--disable-search-engine-choice-screen',
       `--proxy-server=http://localhost:${appSettings.proxy.port}`,
       `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
-      `--load-extension=${extensionPath}`,
+      appSettings.recorder.enableBrowserRecorder
+        ? `--load-extension=${extensionPath}`
+        : '',
       disableChromeOptimizations,
       url ?? '',
     ],

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -2,7 +2,7 @@ import { AppSettings } from '@/types/settings'
 import { Flex, Text, Checkbox } from '@radix-ui/themes'
 import { Controller, useFormContext } from 'react-hook-form'
 import { SettingsSection } from './SettingsSection'
-import { FileUploadInput } from '../Form'
+import { FieldGroup, FileUploadInput } from '../Form'
 import { useEffect } from 'react'
 
 export const RecorderSettings = () => {
@@ -60,6 +60,38 @@ export const RecorderSettings = () => {
         hint="The location of the browser executable (k6 Studio currently supports Chrome)"
         disabled={recorder.detectBrowserPath}
       />
+
+      <FieldGroup
+        label="Browser recording"
+        name="recorder.enableBrowserRecorder"
+        errors={errors}
+        hint={
+          <>
+            Enables the <em>experimental</em> browser recording feature. With
+            this feature enabled user interactions in the browser are recorded
+            alongside network requests. The recorded interactions can be
+            exported as a k6 browser script.
+          </>
+        }
+        hintType="text"
+      >
+        <Flex>
+          <Controller
+            control={control}
+            name="recorder.enableBrowserRecorder"
+            render={({ field }) => (
+              <Text size="2" as="label">
+                <Checkbox
+                  {...register('recorder.enableBrowserRecorder')}
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />{' '}
+                Enable browser recording (experimental)
+              </Text>
+            )}
+          />
+        </Flex>
+      </FieldGroup>
     </SettingsSection>
   )
 }

--- a/src/schemas/settings/index.test.ts
+++ b/src/schemas/settings/index.test.ts
@@ -13,6 +13,7 @@ describe('Settings migration', () => {
       },
       recorder: {
         detectBrowserPath: true,
+        enableBrowserRecorder: true,
       },
       windowState: {
         width: 1200,

--- a/src/schemas/settings/v1/index.ts
+++ b/src/schemas/settings/v1/index.ts
@@ -60,6 +60,7 @@ export const ProxySettingsSchema = z
 
 const RecorderDetectBrowserPathSchema = z.object({
   detectBrowserPath: z.literal(true),
+  enableBrowserRecorder: z.boolean().default(false),
 })
 
 const RecorderBrowserPathSchema = RecorderDetectBrowserPathSchema.extend({

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ const defaultSettings: AppSettings = {
   },
   recorder: {
     detectBrowserPath: true,
+    enableBrowserRecorder: true,
   },
   windowState: {
     width: 1200,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds an option to enabled/disable browser recording in the settings dialog (enabled by default for now).

## How to Test

1. Open the settings dialog.
2. Go to the Recorder tab.
3. Disable browser recording.
4. Start a recording.
5. Check that the browser extension hasn't been loaded.
6. Stop the recording.
7. Enable browser recording.
8. Start a recording.
9. Check that the browser extension is loaded.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/c81f226d-8846-4844-a5fb-fb773bb92b8d)

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Closes https://github.com/grafana/k6-cloud/issues/3085

<!-- Thanks for your contribution! 🙏🏼 -->
