### PR TITLE
fix(windows): Chrome folder is shown when no starting URL is provided

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -70,7 +70,7 @@ export const launchBrowser = async (
       `--proxy-server=http://localhost:${appSettings.proxy.port}`,
       `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
       disableChromeOptimizations,
-      url ?? 'about:blank',
+      url || 'about:blank',
     ],
     onExit: sendBrowserClosedEvent,
   })

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -70,7 +70,7 @@ export const launchBrowser = async (
       `--proxy-server=http://localhost:${appSettings.proxy.port}`,
       `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
       disableChromeOptimizations,
-      url ?? '',
+      url ?? 'about:blank',
     ],
     onExit: sendBrowserClosedEvent,
   })

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -70,7 +70,7 @@ export const launchBrowser = async (
       `--proxy-server=http://localhost:${appSettings.proxy.port}`,
       `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
       disableChromeOptimizations,
-      url || 'about:blank',
+      url?.trim() || 'about:blank',
     ],
     onExit: sendBrowserClosedEvent,
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On Windows, if the user doesn't provide a URL before starting a recording, the browser shows the Chrome folder.
<img width="628" alt="image" src="https://github.com/user-attachments/assets/48bf82af-1f8d-4094-b969-a7936a6a2645" />

## How to Test

On a windows machine:
1. Open the app
2. Go to Recorder
3. Click `Start recording` while leaving the `Starting URL` blank
4. Verify that the browser is launched with an empty page