### PR TITLE
fix: Last item scripts list isn't always accessible

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -28,78 +28,81 @@ export function Sidebar({ isExpanded, onCollapseSidebar }: SidebarProps) {
       maxWidth="100%"
       overflow="hidden"
       position="relative"
+      asChild
     >
-      <Flex align="center" m="2" gap="2">
-        <SearchField
-          css={css`
-            flex: 1 1 0;
-          `}
-          filter={searchTerm}
-          placeholder="Find files..."
-          size="1"
-          onChange={setSearchTerm}
-        />
-
-        {isExpanded && (
-          <IconButton
+      <Flex direction="column">
+        <Flex align="center" m="2" gap="2">
+          <SearchField
+            css={css`
+              flex: 1 1 0;
+            `}
+            filter={searchTerm}
+            placeholder="Find files..."
             size="1"
-            variant="ghost"
-            color="gray"
-            onClick={onCollapseSidebar}
-          >
-            <PinLeftIcon />
-          </IconButton>
-        )}
-      </Flex>
-      <ScrollArea scrollbars="vertical">
-        <Flex direction="column" gap="2">
-          <FileTree
-            label="Recordings"
-            files={recordings}
-            noFilesMessage="No recordings found"
-            actions={
-              <>
-                <Tooltip content="New recording" side="right">
+            onChange={setSearchTerm}
+          />
+
+          {isExpanded && (
+            <IconButton
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={onCollapseSidebar}
+            >
+              <PinLeftIcon />
+            </IconButton>
+          )}
+        </Flex>
+        <ScrollArea scrollbars="vertical">
+          <Flex direction="column" gap="2" pb="2">
+            <FileTree
+              label="Recordings"
+              files={recordings}
+              noFilesMessage="No recordings found"
+              actions={
+                <>
+                  <Tooltip content="New recording" side="right">
+                    <IconButton
+                      asChild
+                      aria-label="New recording"
+                      variant="ghost"
+                      size="1"
+                    >
+                      <Link to={getRoutePath('recorder')}>
+                        <PlusIcon />
+                      </Link>
+                    </IconButton>
+                  </Tooltip>
+                </>
+              }
+            />
+            <FileTree
+              label="Test generators"
+              files={generators}
+              noFilesMessage="No generators found"
+              actions={
+                <Tooltip content="New generator" side="right">
                   <IconButton
                     asChild
-                    aria-label="New recording"
+                    aria-label="New generator"
                     variant="ghost"
                     size="1"
+                    onClick={createNewGenerator}
+                    css={{ cursor: 'pointer' }}
                   >
-                    <Link to={getRoutePath('recorder')}>
-                      <PlusIcon />
-                    </Link>
+                    <PlusIcon />
                   </IconButton>
                 </Tooltip>
-              </>
-            }
-          />
-          <FileTree
-            label="Test generators"
-            files={generators}
-            noFilesMessage="No generators found"
-            actions={
-              <Tooltip content="New generator" side="right">
-                <IconButton
-                  asChild
-                  aria-label="New generator"
-                  variant="ghost"
-                  size="1"
-                  onClick={createNewGenerator}
-                  css={{ cursor: 'pointer' }}
-                >
-                  <PlusIcon />
-                </IconButton>
-              </Tooltip>
-            }
-          />
-          <FileTree
-            label="Scripts"
-            files={scripts}
-            noFilesMessage="No scripts found"
-          />
-        </Flex>
-      </ScrollArea>
+              }
+            />
+            <FileTree
+              label="Scripts"
+              files={scripts}
+              noFilesMessage="No scripts found"
+            />
+          </Flex>
+        </ScrollArea>
+      </Flex>
     </Box>
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See attached screenshots

## How to Test
* Resize the window to the min supported height
* Make sure you have enough files for the scrollbar to appear
* Verify that the last item is clearly visible

## Screenshots (if appropriate):
Before
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/e1411e07-c279-4b44-ba98-8e46ddc69728" />

After
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/2463baa7-e5af-4830-afde-826fadc33956" />


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
