### PR TITLE
fix: Caret icon doesn't change state in Validator dialog

### DIFF
--- a/src/components/Collapsible.tsx
+++ b/src/components/Collapsible.tsx
@@ -37,7 +37,7 @@ const Header = styled.div`
 const CaretIcon = styled(CaretRightIcon)`
   transform: rotate(0deg);
 
-  [data-state='open'] & {
+  button[data-state='open'] & {
     transform: rotate(90deg);
   }
 `

--- a/src/components/WebLogView/WebLogView.tsx
+++ b/src/components/WebLogView/WebLogView.tsx
@@ -10,7 +10,6 @@ import { useDeepCompareEffect } from 'react-use'
 interface WebLogViewProps {
   requests: ProxyDataWithMatches[]
   groups?: GroupType[]
-  activeGroup?: string
   selectedRequestId?: string
   onSelectRequest: (data: ProxyDataWithMatches | null) => void
   onUpdateGroup?: (group: GroupType) => void

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -212,7 +212,6 @@ export function Recorder() {
                 selectedRequestId={selectedRequest?.id}
                 autoScroll
                 groups={groups}
-                activeGroup={group?.id}
                 onSelectRequest={setSelectedRequest}
                 onUpdateGroup={handleUpdateGroup}
                 resetProxyData={handleResetRecording}

--- a/src/views/Recorder/RequestsSection.tsx
+++ b/src/views/Recorder/RequestsSection.tsx
@@ -16,7 +16,6 @@ interface RequestsSectionProps {
   groups?: Group[]
   selectedRequestId?: string
   autoScroll?: boolean
-  activeGroup?: string
   noDataElement?: ReactNode
   onSelectRequest: (data: ProxyData | null) => void
   onUpdateGroup?: (group: Group) => void
@@ -29,7 +28,6 @@ export function RequestsSection({
   noDataElement,
   autoScroll = false,
   groups,
-  activeGroup,
   onSelectRequest,
   onUpdateGroup,
   resetProxyData,
@@ -90,7 +88,6 @@ export function RequestsSection({
           <WebLogView
             requests={filteredRequests}
             groups={groups}
-            activeGroup={activeGroup}
             selectedRequestId={selectedRequestId}
             onSelectRequest={onSelectRequest}
             onUpdateGroup={onUpdateGroup}


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/321

## How to Test
* Open the validator dialog
* Run a script
* Verify that the group sections have expected caret state

## Screenshots (if appropriate):
<img width="241" alt="image" src="https://github.com/user-attachments/assets/b12c0cda-5dc4-4153-a2fa-843acdf8c66a" />