### PR TITLE
feat: enable Sentry in renderer process

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -29,8 +29,31 @@
 import { ProxyData } from './types'
 import './index.tsx'
 import { setMonacoEnv } from './components/Monaco/setMonacoEnv'
+import * as Sentry from '@sentry/electron/renderer'
 
 setMonacoEnv()
+
+// Sentry integration
+if (process.env.NODE_ENV !== 'development') {
+  Sentry.init({
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    tracesSampleRate: 1.0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1.0,
+
+    // conditionally send the event based on the user's settings
+    beforeSend: async (event) => {
+      const { telemetry } = await window.studio.settings.getSettings()
+      if (telemetry.errorReport) {
+        return event
+      }
+      return null
+    },
+  })
+}
 
 // Proxy
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR enables the Sentry integration in the renderer process, accounting for the user's preference to opt out of it.  This PR is dependant on https://github.com/grafana/k6-studio/pull/393.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Enable Sentry to run the development environment (both in `main.ts` and `renderer.ts`)
- Manually throw an error in the React code
- Run the app with the `SENTRY_DSN` env variable set (grab it from the project in Sentry) `SENTRY_DSN=xx npm start`
- Reproduce the error in runtime and check Sentry

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/396

<!-- Thanks for your contribution! 🙏🏼 -->
