### PR TITLE
feat: move recording selector position

### DIFF
--- a/src/views/Generator/GeneratorControls/GeneratorControls.tsx
+++ b/src/views/Generator/GeneratorControls/GeneratorControls.tsx
@@ -40,7 +40,7 @@ export function GeneratorControls({ onSave, isDirty }: GeneratorControlsProps) {
   return (
     <>
       <RecordingSelector />
-      <Flex align="center" justify="between" gap="2">
+      <Flex align="center" justify="between" gap="2" ml="2">
         <ButtonWithTooltip
           onClick={onSave}
           disabled={!isDirty}

--- a/src/views/Generator/GeneratorControls/GeneratorControls.tsx
+++ b/src/views/Generator/GeneratorControls/GeneratorControls.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { DropdownMenu, IconButton } from '@radix-ui/themes'
+import { DropdownMenu, Flex, IconButton } from '@radix-ui/themes'
 
 import { useScriptPreview } from '@/hooks/useScriptPreview'
 import { exportScript } from '../Generator.utils'
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom'
 import { getRoutePath } from '@/routeMap'
 import { ButtonWithTooltip } from '@/components/ButtonWithTooltip'
 import { getFileNameWithoutExtension } from '@/utils/file'
+import { RecordingSelector } from '../RecordingSelector'
 
 interface GeneratorControlsProps {
   onSave: () => void
@@ -38,52 +39,55 @@ export function GeneratorControls({ onSave, isDirty }: GeneratorControlsProps) {
 
   return (
     <>
-      <ButtonWithTooltip
-        onClick={onSave}
-        disabled={!isDirty}
-        tooltip={!isDirty ? 'Changes saved' : ''}
-      >
-        Save generator
-      </ButtonWithTooltip>
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger>
-          <IconButton variant="ghost" color="gray">
-            <DotsVerticalIcon />
-          </IconButton>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content>
-          <DropdownMenu.Item
-            onSelect={() => setIsValidatorDialogOpen(true)}
-            disabled={!isScriptExportable}
-          >
-            Validate script
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            onSelect={() => setIsExportScriptDialogOpen(true)}
-            disabled={!isScriptExportable}
-          >
-            Export script
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator />
-          <DropdownMenu.Item onSelect={handleDeleteGenerator} color="red">
-            Delete generator
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
-      {isScriptExportable && (
-        <>
-          <ValidatorDialog
-            script={preview}
-            open={isValidatorDialogOpen}
-            onOpenChange={setIsValidatorDialogOpen}
-          />
-          <ExportScriptDialog
-            onExport={exportScript}
-            open={isExportScriptDialogOpen}
-            onOpenChange={setIsExportScriptDialogOpen}
-          />
-        </>
-      )}
+      <RecordingSelector />
+      <Flex align="center" justify="between" gap="2">
+        <ButtonWithTooltip
+          onClick={onSave}
+          disabled={!isDirty}
+          tooltip={!isDirty ? 'Changes saved' : ''}
+        >
+          Save generator
+        </ButtonWithTooltip>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger>
+            <IconButton variant="ghost" color="gray">
+              <DotsVerticalIcon />
+            </IconButton>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            <DropdownMenu.Item
+              onSelect={() => setIsValidatorDialogOpen(true)}
+              disabled={!isScriptExportable}
+            >
+              Validate script
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              onSelect={() => setIsExportScriptDialogOpen(true)}
+              disabled={!isScriptExportable}
+            >
+              Export script
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item onSelect={handleDeleteGenerator} color="red">
+              Delete generator
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+        {isScriptExportable && (
+          <>
+            <ValidatorDialog
+              script={preview}
+              open={isValidatorDialogOpen}
+              onOpenChange={setIsValidatorDialogOpen}
+            />
+            <ExportScriptDialog
+              onExport={exportScript}
+              open={isExportScriptDialogOpen}
+              onOpenChange={setIsExportScriptDialogOpen}
+            />
+          </>
+        )}
+      </Flex>
     </>
   )
 }

--- a/src/views/Generator/GeneratorSidebar/RequestList.tsx
+++ b/src/views/Generator/GeneratorSidebar/RequestList.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, ScrollArea } from '@radix-ui/themes'
+import { Flex, ScrollArea } from '@radix-ui/themes'
 import { Allotment } from 'allotment'
 import { useState } from 'react'
 import { css } from '@emotion/react'
@@ -9,7 +9,6 @@ import { ProxyData } from '@/types'
 import { Details } from '@/components/WebLogView/Details'
 import { Filter } from '@/components/WebLogView/Filter'
 import { useFilterRequests } from '@/components/WebLogView/Filter.hooks'
-import { RecordingSelector } from '../RecordingSelector'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
 import { useStudioUIStore } from '@/store/ui'
 import { useGeneratorStore } from '@/store/generator'
@@ -41,9 +40,6 @@ export function RequestList({ requests }: RequestListProps) {
 
   return (
     <Flex direction="column" height="100%">
-      <Box py="2" px="4">
-        <RecordingSelector />
-      </Box>
       <div
         css={css`
           flex-grow: 1;
@@ -66,7 +62,6 @@ export function RequestList({ requests }: RequestListProps) {
                       borderRadius: 0,
                       outlineOffset: '-2px',
                       boxShadow: 'none',
-                      borderTop: '1px solid var(--gray-a5)',
                     }}
                     size="2"
                   />

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -65,7 +65,10 @@ export function RecordingSelector() {
             id="recording-selector"
             placeholder="Select recording"
             css={css`
-              width: 250px;
+              width: 200px;
+              @media (max-width: 1055px) {
+                width: 125px;
+              }
             `}
           >
             <Flex as="span" align="center" gap="1">

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -66,7 +66,7 @@ export function RecordingSelector() {
             placeholder="Select recording"
             css={css`
               width: 200px;
-              @media (max-width: 1055px) {
+              @media (max-width: 1060px) {
                 width: 125px;
               }
             `}

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -65,7 +65,7 @@ export function RecordingSelector() {
             id="recording-selector"
             placeholder="Select recording"
             css={css`
-              width: 200px;
+              width: 300px;
               @media (max-width: 1060px) {
                 width: 125px;
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR moves the Recording dropdown from the "Requests" tab in the Preview section to the top bar on the Generator page.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

<img width="478" alt="image" src="https://github.com/user-attachments/assets/25402e90-b22c-498a-8ad0-2b42c60e5352" />



Smaller window size:

<img width="248" alt="image" src="https://github.com/user-attachments/assets/8ed02e4f-12a0-487e-82ba-a32e2995bfd2" />


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/317

<!-- Thanks for your contribution! 🙏🏼 -->
