### PR TITLE
fix: intel mac app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,13 @@ jobs:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ env.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
-        run: npm run publish
+        run: |
+            # on macos we also build the x64 app separately
+            if [ "${{ runner.os }}" == "macOS" ]; then
+              npm run publish -- --arch=x64
+            fi
+
+            npm run publish
 
       - name: cleanup macos certificates
         if: startsWith(matrix.platform, 'macos-')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This specifically builds the x64 version of the app separately for `intel` macs.
Although an `universal` build is possible, it doubles the size of the app for the end user.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
