### PR TITLE
chore: Remove yarn usage from pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn lint-staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "format": "prettier --ignore-unknown --write \"./**/*\"",
-    "prepare": "husky"
+    "prepare": "husky && husky install"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.4.0",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We use `npm` in k6 studio, but the pre-commit hook still references `yarn`, which could lead to not being able to create commits if you don't have `yarn` installed

## How to Test
* Checkout the branch and make sure you can add commits to it and the pre-commit hook runs (adding an obvious eslint issue should be an easy way to do it)