### PR TITLE
fix: sourcemaps not uploading to Sentry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ env.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
             # on macos we also build the x64 app separately
             npm run publish -- --arch=x64
@@ -86,8 +86,8 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ env.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ env.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: npm run publish
 
       - name: cleanup macos certificates

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@radix-ui/react-toast": "^1.2.1",
         "@radix-ui/themes": "^3.0.5",
         "@sentry/electron": "^5.7.0",
-        "@sentry/vite-plugin": "^2.22.6",
+        "@sentry/vite-plugin": "^2.23.0",
         "@tanstack/react-query": "^5.55.4",
         "@vitejs/plugin-react": "^4.3.1",
         "allotment": "^1.20.2",
@@ -4542,9 +4542,9 @@
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "2.22.6",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.22.6.tgz",
-      "integrity": "sha512-V2g1Y1I5eSe7dtUVMBvAJr8BaLRr4CLrgNgtPaZyMT4Rnps82SrZ5zqmEkLXPumlXhLUWR6qzoMNN2u+RXVXfQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-2.23.0.tgz",
+      "integrity": "sha512-+uLqaCKeYmH/W2YUV1XHkFEtpHdx/aFjCQahPVsvXyqg13dfkR6jaygPL4DB5DJtUSmPFCUE3MEk9ZO5JlhJYg==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4569,14 +4569,14 @@
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
-      "version": "2.22.6",
-      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.22.6.tgz",
-      "integrity": "sha512-1esQdgSUCww9XAntO4pr7uAM5cfGhLsgTK9MEwAKNfvpMYJi9NUTYa3A7AZmdA8V6107Lo4OD7peIPrDRbaDCg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-2.23.0.tgz",
+      "integrity": "sha512-Qbw+jZFK63w+V193l0eCFKLzGba2Iu93Fx8kCRzZ3uqjky002H8U3pu4mKgcc11J+u8QTjfNZGUyXsxz0jv2mg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
-        "@sentry/babel-plugin-component-annotate": "2.22.6",
-        "@sentry/cli": "^2.36.1",
+        "@sentry/babel-plugin-component-annotate": "2.23.0",
+        "@sentry/cli": "2.39.1",
         "dotenv": "^16.3.1",
         "find-up": "^5.0.0",
         "glob": "^9.3.2",
@@ -4910,12 +4910,12 @@
       }
     },
     "node_modules/@sentry/vite-plugin": {
-      "version": "2.22.6",
-      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.22.6.tgz",
-      "integrity": "sha512-zIieP1VLWQb3wUjFJlwOAoaaJygJhXeUoGd0e/Ha2RLb2eW2S+4gjf6y6NqyY71tZ74LYVZKg/4prB6FAZSMXQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-2.23.0.tgz",
+      "integrity": "sha512-iLbqxan3DUkFJqbx7DOtJ2fTd6g+TmNS1PIdaDFfpvVG4Lg9AYp4Xege6BBCrGQYl+wUE3poWfNhASfch/s51Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "2.22.6",
+        "@sentry/bundler-plugin-core": "2.23.0",
         "unplugin": "1.0.1"
       },
       "engines": {
@@ -5997,6 +5997,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -6622,6 +6623,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -7837,9 +7839,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -10797,6 +10799,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -12628,6 +12631,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16172,6 +16176,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -16195,6 +16200,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -16206,6 +16212,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@radix-ui/react-toast": "^1.2.1",
     "@radix-ui/themes": "^3.0.5",
     "@sentry/electron": "^5.7.0",
-    "@sentry/vite-plugin": "^2.22.6",
+    "@sentry/vite-plugin": "^2.23.0",
     "@tanstack/react-query": "^5.55.4",
     "@vitejs/plugin-react": "^4.3.1",
     "allotment": "^1.20.2",

--- a/vite.preload.config.ts
+++ b/vite.preload.config.ts
@@ -1,6 +1,7 @@
 import type { ConfigEnv, UserConfig } from 'vite'
 import { defineConfig, mergeConfig } from 'vite'
 import { getBuildConfig, external, pluginHotRestart } from './vite.base.config'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // https://vitejs.dev/config
 export default defineConfig((env) => {
@@ -21,8 +22,16 @@ export default defineConfig((env) => {
           assetFileNames: '[name].[ext]',
         },
       },
+      sourcemap: true,
     },
-    plugins: [pluginHotRestart('reload')],
+    plugins: [
+      pluginHotRestart('reload'),
+      sentryVitePlugin({
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+      }),
+    ],
   }
 
   return mergeConfig(getBuildConfig(forgeEnv), config)

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 import { pluginExposeRenderer } from './vite.base.config'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { version } from './package.json'
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 
 // https://vitejs.dev/config
 export default defineConfig((env) => {
@@ -17,6 +18,7 @@ export default defineConfig((env) => {
     base: './',
     build: {
       outDir: `.vite/renderer/${name}`,
+      sourcemap: true,
     },
     plugins: [
       react({
@@ -24,6 +26,11 @@ export default defineConfig((env) => {
       }),
       pluginExposeRenderer(name),
       tsconfigPaths(),
+      sentryVitePlugin({
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        org: process.env.SENTRY_ORG,
+        project: process.env.SENTRY_PROJECT,
+      }),
     ],
     resolve: {
       preserveSymlinks: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where sourcemaps were not being uploaded to Sentry during a release.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

When looking at the release logs we can see the following warning:

```
[sentry-vite-plugin] Warning: No project provided. Will not create release. Please set the `project` option to your Sentry project slug.
```

We can also see that the `SENTRY_PROJECT` and `SENTRY_ORG` variables are not being read properly from the repo settings:

```
SENTRY_DSN: ***
SENTRY_AUTH_TOKEN: ***
SENTRY_ORG:
SENTRY_PROJECT:
```

This caused `@sentry/vite-plugin` not to know which Sentry project to associate the sourcemaps with.

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
