### PR TITLE
feat: Add text selector

### DIFF
--- a/src/rules/correlation.utils.ts
+++ b/src/rules/correlation.utils.ts
@@ -1,6 +1,12 @@
 import { CorrelationRule } from '@/types/rules'
-import { Request } from '@/types'
-import { replaceRequestValues, replaceTextMatches } from './shared'
+import { Cookie, Header, Request } from '@/types'
+import {
+  replaceContent,
+  replaceCookies,
+  replaceHeaders,
+  replaceRequestValues,
+  replaceUrl,
+} from './shared'
 
 export function replaceCorrelatedValues({
   rule,
@@ -16,7 +22,7 @@ export function replaceCorrelatedValues({
   const varName = `\${correlation_vars['correlation_${uniqueId}']}`
   // Default behaviour replaces all occurences of the string
   if (!rule.replacer?.selector) {
-    return replaceTextMatches(request, extractedValue, varName)
+    return replaceAllTextMatches(request, extractedValue, varName)
   }
 
   return replaceRequestValues({
@@ -24,4 +30,33 @@ export function replaceCorrelatedValues({
     request,
     value: varName,
   })
+}
+
+function replaceAllTextMatches(
+  request: Request,
+  extractedValue: string,
+  variableName: string
+): Request {
+  const content = replaceContent(request.content, extractedValue, variableName)
+  const url = replaceUrl(request.url, extractedValue, variableName)
+  const path = replaceUrl(request.path, extractedValue, variableName)
+  const headers: Header[] = replaceHeaders(
+    request.headers,
+    extractedValue,
+    variableName
+  )
+  const cookies: Cookie[] = replaceCookies(
+    request.cookies,
+    extractedValue,
+    variableName
+  )
+
+  return {
+    ...request,
+    content,
+    url,
+    path,
+    headers,
+    cookies,
+  }
 }

--- a/src/rules/selectors/text.test.ts
+++ b/src/rules/selectors/text.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { replaceText } from './text'
+import { createRequest } from '@/test/factories/proxyData'
+import { TextSelector } from '@/types/rules'
+
+describe('replaceText', () => {
+  it('replaces text matches in URL', () => {
+    const request = createRequest({
+      url: 'http://test.k6.io/api/v1/foo',
+      path: '/api/v1/foo',
+    })
+
+    const selectorMatch: TextSelector = {
+      type: 'text',
+      from: 'url',
+      value: 'foo',
+    }
+
+    const selectorNotMatch: TextSelector = {
+      type: 'text',
+      from: 'url',
+      value: 'not-existing',
+    }
+
+    expect(replaceText(request, selectorMatch, 'TEST_VALUE')?.url).toEqual(
+      'http://test.k6.io/api/v1/TEST_VALUE'
+    )
+    expect(replaceText(request, selectorMatch, 'TEST_VALUE')?.path).toEqual(
+      '/api/v1/TEST_VALUE'
+    )
+
+    expect(replaceText(request, selectorNotMatch, 'TEST_VALUE')).toBeUndefined()
+  })
+
+  it('replaces text matches in body', () => {
+    const request = createRequest({
+      content: 'foo bar baz',
+    })
+
+    const selectorMatch: TextSelector = {
+      type: 'text',
+      from: 'body',
+      value: 'bar',
+    }
+
+    const selectorNotMatch: TextSelector = {
+      type: 'text',
+      from: 'body',
+      value: 'not-existing',
+    }
+
+    expect(replaceText(request, selectorMatch, 'TEST_VALUE')?.content).toEqual(
+      'foo TEST_VALUE baz'
+    )
+
+    expect(replaceText(request, selectorNotMatch, 'TEST_VALUE')).toBeUndefined()
+  })
+
+  it('replaces text matches in headers', () => {
+    const request = createRequest({
+      headers: [['content-type', 'application/json']],
+    })
+
+    const selectorMatch: TextSelector = {
+      type: 'text',
+      from: 'headers',
+      value: 'application/json',
+    }
+
+    const selectorNotMatch: TextSelector = {
+      type: 'text',
+      from: 'headers',
+      value: 'not-existing',
+    }
+
+    expect(replaceText(request, selectorMatch, 'TEST_VALUE')?.headers).toEqual([
+      ['content-type', 'TEST_VALUE'],
+    ])
+
+    expect(replaceText(request, selectorNotMatch, 'TEST_VALUE')).toBeUndefined()
+  })
+})

--- a/src/rules/selectors/text.ts
+++ b/src/rules/selectors/text.ts
@@ -1,0 +1,77 @@
+import { TextSelector } from '@/types/rules'
+import { exhaustive } from '@/utils/typescript'
+import { replaceContent, replaceUrl, replaceHeaders } from '../shared'
+import { Request } from '@/types'
+
+export function replaceText(
+  request: Request,
+  selector: TextSelector,
+  value: string
+): Request | undefined {
+  if (selector.value.trim() === '') {
+    return
+  }
+
+  switch (selector.from) {
+    case 'body':
+      return replaceTextBody(request, selector, value)
+
+    case 'headers':
+      return replaceTextHeader(request, selector, value)
+
+    case 'url':
+      return replaceTextUrl(request, selector, value)
+
+    default:
+      return exhaustive(selector.from)
+  }
+}
+
+function replaceTextBody(
+  request: Request,
+  selector: TextSelector,
+  value: string
+): Request | undefined {
+  if (!request?.content?.includes(selector.value)) {
+    return
+  }
+
+  return {
+    ...request,
+    content: replaceContent(request.content, selector.value, value),
+  }
+}
+
+function replaceTextUrl(
+  request: Request,
+  selector: TextSelector,
+  value: string
+): Request | undefined {
+  if (!request.url.includes(selector.value)) {
+    return
+  }
+  return {
+    ...request,
+    url: replaceUrl(request.url, selector.value, value),
+    path: replaceUrl(request.path, selector.value, value),
+  }
+}
+
+function replaceTextHeader(
+  request: Request,
+  selector: TextSelector,
+  value: string
+): Request | undefined {
+  const headerExists = request?.headers.find(([, value]) =>
+    value.includes(selector.value)
+  )
+
+  if (!headerExists) {
+    return
+  }
+
+  return {
+    ...request,
+    headers: replaceHeaders(request.headers, selector.value, value),
+  }
+}

--- a/src/rules/shared.ts
+++ b/src/rules/shared.ts
@@ -6,17 +6,18 @@ import {
   HeaderNameSelector,
   JsonSelector,
   RegexSelector,
-  Selector,
+  ReplacerSelector,
 } from '@/types/rules'
 import { canonicalHeaderKey, isJsonReqResp } from './utils'
 import { exhaustive } from '@/utils/typescript'
+import { replaceText } from './selectors/text'
 
 export function replaceRequestValues({
   selector,
   value,
   request,
 }: {
-  selector: Selector
+  selector: ReplacerSelector
   request: Request
   value: string
 }): Request | undefined {
@@ -29,6 +30,8 @@ export function replaceRequestValues({
       return replaceJsonBody(selector, request, value)
     case 'header-name':
       return replaceHeaderByName(request, selector, value)
+    case 'text':
+      return replaceText(request, selector, value)
     default:
       return exhaustive(selector)
   }
@@ -65,35 +68,6 @@ const replaceRegex = (
       return replaceRegexUrl(selector, request, variableName)
     default:
       return exhaustive(selector.from)
-  }
-}
-
-export function replaceTextMatches(
-  request: Request,
-  extractedValue: string,
-  variableName: string
-): Request {
-  const content = replaceContent(request.content, extractedValue, variableName)
-  const url = replaceUrl(request.url, extractedValue, variableName)
-  const path = request.path.replaceAll(extractedValue, `\${${variableName}}`)
-  const headers: Header[] = replaceHeaders(
-    request.headers,
-    extractedValue,
-    variableName
-  )
-  const cookies: Cookie[] = replaceCookies(
-    request.cookies,
-    extractedValue,
-    variableName
-  )
-
-  return {
-    ...request,
-    content,
-    url,
-    path,
-    headers,
-    cookies,
   }
 }
 

--- a/src/schemas/generator/v1/rules.ts
+++ b/src/schemas/generator/v1/rules.ts
@@ -72,11 +72,25 @@ export const StatusCodeSelectorSchema = z.object({
   type: z.literal('status-code'),
 })
 
-export const SelectorSchema = z.discriminatedUnion('type', [
+export const TextSelectorSchema = z.object({
+  type: z.literal('text'),
+  from: z.enum(['headers', 'body', 'url']),
+  value: z.string(),
+})
+
+export const ExtractorSelectorSchema = z.discriminatedUnion('type', [
   BeginEndSelectorSchema,
   RegexSelectorSchema,
   JsonSelectorSchema,
   HeaderNameSelectorSchema,
+])
+
+export const ReplacerSelectorSchema = z.discriminatedUnion('type', [
+  BeginEndSelectorSchema,
+  RegexSelectorSchema,
+  JsonSelectorSchema,
+  HeaderNameSelectorSchema,
+  TextSelectorSchema,
 ])
 
 export const VerificationRuleSelectorSchema = z.discriminatedUnion('type', [
@@ -87,13 +101,13 @@ export const VerificationRuleSelectorSchema = z.discriminatedUnion('type', [
 
 export const CorrelationExtractorSchema = z.object({
   filter: FilterSchema,
-  selector: SelectorSchema,
+  selector: ExtractorSelectorSchema,
   variableName: z.string().optional(),
 })
 
 export const CorrelationReplacerSchema = z.object({
   filter: FilterSchema,
-  selector: SelectorSchema.optional(),
+  selector: ReplacerSelectorSchema.optional(),
 })
 
 export const RuleBaseSchema = z.object({
@@ -104,7 +118,7 @@ export const RuleBaseSchema = z.object({
 export const ParameterizationRuleSchema = RuleBaseSchema.extend({
   type: z.literal('parameterization'),
   filter: FilterSchema,
-  selector: SelectorSchema,
+  selector: ReplacerSelectorSchema,
   value: z.discriminatedUnion('type', [
     VariableValueSchema,
     ArrayValueSchema,

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -9,16 +9,18 @@ import {
   CustomCodeRuleSchema,
   CustomCodeSelectorSchema,
   CustomCodeValueSchema,
+  ExtractorSelectorSchema,
   FilterSchema,
   HeaderNameSelectorSchema,
   JsonSelectorSchema,
   ParameterizationRuleSchema,
   RecordedValueSchema,
   RegexSelectorSchema,
+  ReplacerSelectorSchema,
   RuleBaseSchema,
-  SelectorSchema,
   StatusCodeSelectorSchema,
   TestRuleSchema,
+  TextSelectorSchema,
   VariableValueSchema,
   VerificationRuleSchema,
   VerificationRuleSelectorSchema,
@@ -80,7 +82,10 @@ export type JsonSelector = z.infer<typeof JsonSelectorSchema>
 export type StatusCodeSelector = z.infer<typeof StatusCodeSelectorSchema>
 export type CustomCodeSelector = z.infer<typeof CustomCodeSelectorSchema>
 export type HeaderNameSelector = z.infer<typeof HeaderNameSelectorSchema>
-export type Selector = z.infer<typeof SelectorSchema>
+export type TextSelector = z.infer<typeof TextSelectorSchema>
+export type ReplacerSelector = z.infer<typeof ReplacerSelectorSchema>
+export type ExtractorSelector = z.infer<typeof ExtractorSelectorSchema>
+export type Selector = ReplacerSelector | ExtractorSelector
 export type VerificationRuleSelector = z.infer<
   typeof VerificationRuleSelectorSchema
 >

--- a/src/views/Generator/RuleEditor/SelectorField.constants.ts
+++ b/src/views/Generator/RuleEditor/SelectorField.constants.ts
@@ -1,0 +1,48 @@
+import { Selector } from '@/types/rules'
+
+export const fromOptions: Array<{
+  value: Selector['from']
+  label: string
+}> = [
+  { value: 'headers', label: 'Headers' },
+  { value: 'body', label: 'Body' },
+  { value: 'url', label: 'URL' },
+]
+
+const typeOptions = {
+  beginEnd: { value: 'begin-end', label: 'Begin-End' },
+  regex: { value: 'regex', label: 'Regex' },
+  json: { value: 'json', label: 'JSON' },
+  headerName: { value: 'header-name', label: 'Name' },
+  text: { value: 'text', label: 'Text' },
+} as const
+
+type AllowedSelectorMapType = Record<
+  'replacer' | 'extractor',
+  Record<Selector['from'], Array<{ value: Selector['type']; label: string }>>
+>
+
+export const allowedSelectorMap: AllowedSelectorMapType = {
+  replacer: {
+    headers: [
+      typeOptions.beginEnd,
+      typeOptions.regex,
+      typeOptions.headerName,
+      typeOptions.text,
+    ],
+    body: [
+      typeOptions.beginEnd,
+      typeOptions.regex,
+      typeOptions.json,
+      typeOptions.text,
+    ],
+    url: [typeOptions.beginEnd, typeOptions.regex, typeOptions.text],
+  },
+
+  // Extractor doesn't support literal text as a selector
+  extractor: {
+    headers: [typeOptions.beginEnd, typeOptions.regex, typeOptions.headerName],
+    body: [typeOptions.beginEnd, typeOptions.regex, typeOptions.json],
+    url: [typeOptions.beginEnd, typeOptions.regex],
+  },
+}

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
@@ -1,7 +1,11 @@
 import { Badge, Strong, Tooltip } from '@radix-ui/themes'
 import { css } from '@emotion/react'
 
-import { CorrelationRule, ParameterizationRule, Selector } from '@/types/rules'
+import {
+  CorrelationRule,
+  ParameterizationRule,
+  ReplacerSelector,
+} from '@/types/rules'
 import { exhaustive } from '@/utils/typescript'
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
 import { useRef } from 'react'
@@ -71,7 +75,7 @@ function ParameterizationSelectorContent({
   )
 }
 
-function SelectorLabel({ selector }: { selector: Selector }) {
+function SelectorLabel({ selector }: { selector: ReplacerSelector }) {
   switch (selector.type) {
     case 'json':
       return (
@@ -94,6 +98,8 @@ function SelectorLabel({ selector }: { selector: Selector }) {
       )
     case 'header-name':
       return <Strong>{stringFallback(selector.name)}</Strong>
+    case 'text':
+      return <Strong>{stringFallback(selector.value)}</Strong>
     default:
       return exhaustive(selector)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add text selector to exact string match replacements. Previously you'd have to use a workaround with regex selector: regex: (value_to_be_placed). 

This selector applies to parameterization rule and correlation rule custom replacer, but not correlation extractor, because it doesn't make sense to correlate on static value.

## How to Test

- Test with parameterization rule: try both "text value" and "variable" replacement
- Test with custom replacer in correlation rule

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![screencapture 2025-01-22 at 11 25 14](https://github.com/user-attachments/assets/fbea8bab-f777-427a-8fa0-41b9a487e2c3)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Resolves https://github.com/grafana/k6-studio/issues/315

<!-- Thanks for your contribution! 🙏🏼 -->
