### PR TITLE
refactor: Extract Json preview into separate component

### DIFF
--- a/src/components/JsonPreview.tsx
+++ b/src/components/JsonPreview.tsx
@@ -1,0 +1,37 @@
+import ReactJson from '@microlink/react-json-view'
+
+import { useTheme } from '@/hooks/useTheme'
+import { k6StudioLightBackground } from '@/components/Monaco/themes/k6StudioLight'
+import { k6StudioDarkBackground } from '@/components/Monaco/themes/k6StudioDark'
+
+interface JsonPreviewProps {
+  content: object
+}
+
+export function JsonPreview({ content }: JsonPreviewProps) {
+  const theme = useTheme()
+
+  return (
+    <ReactJson
+      shouldCollapse={(field) => field.name !== 'root'}
+      src={content}
+      theme={theme === 'dark' ? 'monokai' : 'rjv-default'}
+      style={theme === 'dark' ? reactJsonDarkStyles : reactJsonLightStyles}
+    />
+  )
+}
+
+const reactJsonStyles = {
+  fontSize: 12,
+  height: '100%',
+}
+
+const reactJsonDarkStyles = {
+  ...reactJsonStyles,
+  background: k6StudioDarkBackground,
+}
+
+const reactJsonLightStyles = {
+  ...reactJsonStyles,
+  background: k6StudioLightBackground,
+}

--- a/src/components/WebLogView/ResponseDetails/Preview.tsx
+++ b/src/components/WebLogView/ResponseDetails/Preview.tsx
@@ -1,9 +1,6 @@
-import { ReadOnlyEditor } from '../../Monaco/ReadOnlyEditor'
-import ReactJson from '@microlink/react-json-view'
+import { ReadOnlyEditor } from '@/components/Monaco/ReadOnlyEditor'
+import { JsonPreview } from '@/components/JsonPreview'
 import { Font } from './Font'
-import { useTheme } from '@/hooks/useTheme'
-import { k6StudioLightBackground } from '@/components/Monaco/themes/k6StudioLight'
-import { k6StudioDarkBackground } from '@/components/Monaco/themes/k6StudioDark'
 
 interface PreviewProps {
   content: string
@@ -12,8 +9,6 @@ interface PreviewProps {
 }
 
 export function Preview({ content, contentType, format }: PreviewProps) {
-  const theme = useTheme()
-
   if (format === 'html') {
     return (
       <iframe
@@ -52,14 +47,9 @@ export function Preview({ content, contentType, format }: PreviewProps) {
 
   if (format === 'json') {
     return (
-      <ReactJson
-        shouldCollapse={(field) => field.name !== 'root'}
-        // TODO: https://github.com/grafana/k6-studio/issues/277
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        src={JSON.parse(content)}
-        theme={theme === 'dark' ? 'monokai' : 'rjv-default'}
-        style={theme === 'dark' ? reactJsonDarkStyles : reactJsonLightStyles}
-      />
+      // TODO: https://github.com/grafana/k6-studio/issues/277
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      <JsonPreview content={JSON.parse(content)} />
     )
   }
 
@@ -70,19 +60,4 @@ const mediaStyles = {
   display: 'block',
   maxWidth: '100%',
   boxShadow: 'var(--shadow-3)',
-}
-
-const reactJsonStyles = {
-  fontSize: 12,
-  height: '100%',
-}
-
-const reactJsonDarkStyles = {
-  ...reactJsonStyles,
-  background: k6StudioDarkBackground,
-}
-
-const reactJsonLightStyles = {
-  ...reactJsonStyles,
-  background: k6StudioLightBackground,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Initially, I wanted to re-use json preview for data files, but after some prototyping, I decided to use a simple Table instead. I thought I'd still create this PR as it should make it easier to re-use this in other places.

## How to Test
Check that preview of JSON payloads/response bodies works as expected

