### PR TITLE
style: Unify cookie and header previews

### DIFF
--- a/src/components/WebLogView/Cookies.tsx
+++ b/src/components/WebLogView/Cookies.tsx
@@ -1,7 +1,6 @@
-import { Flex } from '@radix-ui/themes'
+import { DataList, Flex } from '@radix-ui/themes'
 
 import { Cookie } from '@/types'
-import { Table } from '@/components/Table'
 import { HighlightedText } from '../HighlightedText'
 import { SearchMatch } from '@/types/fuse'
 
@@ -21,34 +20,25 @@ export function Cookies({
   }
 
   return (
-    <Table.Root size="1" variant="surface">
-      <Table.Header>
-        <Table.Row>
-          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Value</Table.ColumnHeaderCell>
-        </Table.Row>
-      </Table.Header>
-
-      <Table.Body>
-        {cookies.map(([name, value], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>
-              <HighlightedText
-                text={name}
-                matches={matches}
-                highlightAllMatches
-              />
-            </Table.Cell>
-            <Table.Cell>
-              <HighlightedText
-                text={value}
-                matches={matches}
-                highlightAllMatches
-              />
-            </Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table.Root>
+    <DataList.Root size="1" trim="both">
+      {cookies.map(([name, value]) => (
+        <DataList.Item key={name}>
+          <DataList.Label>
+            <HighlightedText
+              text={name}
+              matches={matches}
+              highlightAllMatches
+            />
+          </DataList.Label>
+          <DataList.Value>
+            <HighlightedText
+              text={value}
+              matches={matches}
+              highlightAllMatches
+            />
+          </DataList.Value>
+        </DataList.Item>
+      ))}
+    </DataList.Root>
   )
 }

--- a/src/components/WebLogView/RequestDetails/RequestDetails.tsx
+++ b/src/components/WebLogView/RequestDetails/RequestDetails.tsx
@@ -58,7 +58,9 @@ export function RequestDetails({ data }: RequestDetailsProps) {
       </Tabs.Content>
 
       <Tabs.Content value="cookies">
-        <Cookies cookies={data.request?.cookies} matches={requestMatches} />
+        <Box p="2" height="100%">
+          <Cookies cookies={data.request?.cookies} matches={requestMatches} />
+        </Box>
       </Tabs.Content>
 
       <Tabs.Content value="queryParams">

--- a/src/components/WebLogView/ResponseDetails/ResponseDetails.tsx
+++ b/src/components/WebLogView/ResponseDetails/ResponseDetails.tsx
@@ -1,4 +1,4 @@
-import { Box, ScrollArea } from '@radix-ui/themes'
+import { Box } from '@radix-ui/themes'
 
 import { ProxyDataWithMatches } from '@/types'
 import { Tabs } from '../Tabs'
@@ -34,19 +34,17 @@ export function ResponseDetails({ data }: ResponseDetailsProps) {
       </Tabs.List>
 
       <Tabs.Content value="headers">
-        <ScrollArea style={{ height: '100%' }}>
-          <Box p="2" height="100%">
-            <Headers data={data} matches={responseMatches} />
-          </Box>
-        </ScrollArea>
+        <Box p="2" height="100%">
+          <Headers data={data} matches={responseMatches} />
+        </Box>
       </Tabs.Content>
       <Tabs.Content value="content">
         <Content data={data} />
       </Tabs.Content>
       <Tabs.Content value="cookies">
-        <ScrollArea style={{ height: '100%' }}>
+        <Box p="2" height="100%">
           <Cookies cookies={data.response?.cookies} matches={responseMatches} />
-        </ScrollArea>
+        </Box>
       </Tabs.Content>
     </Tabs.Root>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the same components as `Headers` for better UI consistency

## How to Test
Check that cookies are displayed correctly

## Screenshots (if appropriate):
Before
<img width="461" alt="image" src="https://github.com/user-attachments/assets/35867d19-864d-4362-9847-af14c478ca09" />

After
<img width="462" alt="image" src="https://github.com/user-attachments/assets/4110331e-691f-459c-a5cd-80303be9cb67" />

