### PR TITLE
internal(Thresholds): Validate and save to Generator file

### DIFF
--- a/src/schemas/generator/v1/thresholds.ts
+++ b/src/schemas/generator/v1/thresholds.ts
@@ -44,7 +44,9 @@ export const ThresholdSchema = z.object({
   url: z.string().optional(),
   statistic: ThresholdStatisticSchema,
   condition: ThresholdConditionSchema,
-  value: z.number({ message: 'Invalid value' }),
+  value: z
+    .number({ message: 'Invalid value' })
+    .min(0, { message: 'Invalid value' }),
   stopTest: z.boolean().default(false),
 })
 

--- a/src/store/generator/selectors.ts
+++ b/src/store/generator/selectors.ts
@@ -49,6 +49,7 @@ export function selectGeneratorData(state: GeneratorStore): GeneratorFileData {
     allowlist,
     includeStaticAssets,
     scriptName,
+    thresholds,
   } = state
 
   return {
@@ -66,7 +67,7 @@ export function selectGeneratorData(state: GeneratorStore): GeneratorFileData {
     allowlist,
     includeStaticAssets,
     scriptName,
-    thresholds: [],
+    thresholds,
   }
 }
 

--- a/src/store/generator/slices/thresholds.ts
+++ b/src/store/generator/slices/thresholds.ts
@@ -6,9 +6,7 @@ interface State {
 }
 
 interface Actions {
-  addThreshold: (threshold: Threshold) => void
-  updateThreshold: (threshold: Threshold) => void
-  deleteThreshold: (id: string) => void
+  setThresholds: (thresholds: Threshold[]) => void
 }
 
 export type ThresholdSliceStore = State & Actions
@@ -17,20 +15,8 @@ export const createThresholdSlice: ImmerStateCreator<ThresholdSliceStore> = (
   set
 ) => ({
   thresholds: [],
-  addThreshold: (threshold) =>
+  setThresholds: (thresholds: Threshold[]) =>
     set((state) => {
-      state.thresholds.push(threshold)
-    }),
-  updateThreshold(threshold) {
-    set((state) => {
-      const index = state.thresholds.findIndex((t) => t.id === threshold.id)
-      if (index !== -1) {
-        state.thresholds[index] = threshold
-      }
-    })
-  },
-  deleteThreshold: (id) =>
-    set((state) => {
-      state.thresholds = state.thresholds.filter((t) => t.id !== id)
+      state.thresholds = thresholds
     }),
 })

--- a/src/test/factories/generator.ts
+++ b/src/test/factories/generator.ts
@@ -94,9 +94,7 @@ export function createGeneratorState(
     setVus: vi.fn(),
 
     thresholds: [],
-    addThreshold: vi.fn(),
-    updateThreshold: vi.fn(),
-    deleteThreshold: vi.fn(),
+    setThresholds: vi.fn(),
 
     ...state,
   }

--- a/src/types/thresholds.ts
+++ b/src/types/thresholds.ts
@@ -3,8 +3,10 @@ import {
   ThresholdDataSchema,
   ThresholdMetricSchema,
   ThresholdSchema,
+  ThresholdStatisticSchema,
 } from '@/schemas/generator'
 
 export type Threshold = z.infer<typeof ThresholdSchema>
 export type ThresholdData = z.infer<typeof ThresholdDataSchema>
 export type ThresholdMetric = z.infer<typeof ThresholdMetricSchema>
+export type ThresholdStatstic = z.infer<typeof ThresholdStatisticSchema>

--- a/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
@@ -1,5 +1,5 @@
 import { FieldGroup, ControlledSelect } from '@/components/Form'
-import { ThresholdData } from '@/types/thresholds'
+import { Threshold, ThresholdData } from '@/types/thresholds'
 import { TrashIcon } from '@radix-ui/react-icons'
 import { Table, TextField, Checkbox, IconButton, Flex } from '@radix-ui/themes'
 import {
@@ -17,6 +17,7 @@ import {
 import { useThresholdURLOptions } from './Thresholds.hooks'
 import { css } from '@emotion/react'
 import { useTheme } from '@/hooks/useTheme'
+import { useEffect } from 'react'
 
 type ThresholdRowProps = {
   index: number
@@ -30,11 +31,25 @@ export function ThresholdRow({ field, index, remove }: ThresholdRowProps) {
     formState: { errors },
     control,
     watch,
+    setValue,
   } = useFormContext<ThresholdData>()
 
   const urlOptions = useThresholdURLOptions()
-  const threshold = watch('thresholds')[index]
+  const threshold = watch('thresholds')[index] as Threshold
   const theme = useTheme()
+
+  // Handle selected statistic when the metric field changes
+  useEffect(() => {
+    const availableStatistics = getStatisticOptions(threshold.metric).map(
+      (option) => option.value
+    )
+    if (!availableStatistics.includes(threshold.statistic)) {
+      const newStatistic = availableStatistics[0]
+      if (newStatistic) {
+        setValue(`thresholds.${index}.statistic`, newStatistic)
+      }
+    }
+  }, [threshold.metric, threshold.statistic, index, setValue])
 
   return (
     <Table.Row key={field.id}>
@@ -115,6 +130,7 @@ export function ThresholdRow({ field, index, remove }: ThresholdRowProps) {
             name={`thresholds.${index}.stopTest`}
             render={({ field }) => (
               <Checkbox
+                checked={field.value}
                 onCheckedChange={field.onChange}
                 {...register(`thresholds.${index}.stopTest`)}
               />

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -11,6 +11,7 @@ import { Table } from '@/components/Table'
 
 export function Thresholds() {
   const thresholds = useGeneratorStore((store) => store.thresholds)
+  const setThresholds = useGeneratorStore((store) => store.setThresholds)
 
   const formMethods = useForm<{ thresholds: Threshold[] }>({
     resolver: zodResolver(ThresholdDataSchema),
@@ -41,9 +42,12 @@ export function Thresholds() {
     })
   }
 
-  const onSubmit = useCallback((data: ThresholdData) => {
-    console.log('onSubmit', data)
-  }, [])
+  const onSubmit = useCallback(
+    (data: ThresholdData) => {
+      setThresholds(data.thresholds)
+    },
+    [setThresholds]
+  )
 
   // Submit onChange
   useEffect(() => {

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
@@ -1,5 +1,5 @@
 import { ThresholdMetricSchema } from '@/schemas/generator'
-import { ThresholdMetric } from '@/types/thresholds'
+import { ThresholdMetric, ThresholdStatstic } from '@/types/thresholds'
 import { exhaustive } from '@/utils/typescript'
 
 type ThresholdMetricMap = {
@@ -92,7 +92,10 @@ export const THRESHOLD_CONDITIONS_OPTIONS = [
   { label: '!==', value: '!==' },
 ]
 
-export const getStatisticOptions = (metricName: ThresholdMetric) => {
+type StatisticOption = { label: string; value: ThresholdStatstic }
+export const getStatisticOptions = (
+  metricName: ThresholdMetric
+): Array<StatisticOption> => {
   const { type } = metricsMap[metricName]
 
   switch (type) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements logic to validate and persist the state of the thresholds to the Generator file.

- 🔨 Codegen pending
- 🔨 UI polishing pending

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Type the konami code and enable Thresholds
- Open a generator and configure some thresholds
- Check that the generator state is now dirty
- Save the generator and check that the data is persisted

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
