### PR TITLE
fix: Filename tooltip obscures other files

### DIFF
--- a/src/components/FileTree/File.tsx
+++ b/src/components/FileTree/File.tsx
@@ -94,7 +94,7 @@ function EditableFile({
   }
 
   return (
-    <Tooltip content={displayName} hidden={!hasEllipsis}>
+    <Tooltip content={displayName} side="right" hidden={!hasEllipsis}>
       <NavLink
         ref={linkRef}
         css={[


### PR DESCRIPTION

## Screenshots (if appropriate):
Before
<img width="431" alt="image" src="https://github.com/user-attachments/assets/6b455b2b-45d1-477a-a593-d846fbd63c2f" />

After
<img width="515" alt="image" src="https://github.com/user-attachments/assets/bb0ff730-34c3-4383-a55f-0b54a02db4e4" />
