### PR TITLE
feat: Simpler default file names

### DIFF
--- a/src/components/Layout/Sidebar/Sidebar.hooks.ts
+++ b/src/components/Layout/Sidebar/Sidebar.hooks.ts
@@ -6,7 +6,7 @@ import { orderBy } from 'lodash-es'
 import { useEffect, useMemo } from 'react'
 
 function orderByFileName(files: Map<string, StudioFile>) {
-  return orderBy([...files.values()], (s) => s.fileName)
+  return orderBy([...files.values()], (s) => s.displayName)
 }
 
 function toFileMap(files: StudioFile[]) {

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -19,8 +19,9 @@ interface SidebarProps {
 export function Sidebar({ isExpanded, onCollapseSidebar }: SidebarProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const { recordings, generators, scripts, dataFiles } = useFiles(searchTerm)
-
   const createNewGenerator = useCreateGenerator()
+
+  const handleCreateNewGenerator = () => createNewGenerator()
 
   const handleImportDataFile = () => {
     return window.studio.data.importFile()
@@ -92,7 +93,7 @@ export function Sidebar({ isExpanded, onCollapseSidebar }: SidebarProps) {
                     aria-label="New generator"
                     variant="ghost"
                     size="1"
-                    onClick={createNewGenerator}
+                    onClick={handleCreateNewGenerator}
                     css={{ cursor: 'pointer' }}
                   >
                     <PlusIcon />

--- a/src/hooks/useCreateGenerator.test.ts
+++ b/src/hooks/useCreateGenerator.test.ts
@@ -50,7 +50,7 @@ describe('useCreateGenerator', () => {
       await result.current()
     })
 
-    expect(window.studio.generator.createGenerator).toHaveBeenCalledWith()
+    expect(window.studio.generator.createGenerator).toHaveBeenCalledWith('')
     expect(navigate).toHaveBeenCalledWith(routePath)
   })
 

--- a/src/hooks/useCreateGenerator.test.ts
+++ b/src/hooks/useCreateGenerator.test.ts
@@ -1,22 +1,13 @@
 import { useNavigate } from 'react-router-dom'
 import { useCreateGenerator } from './useCreateGenerator'
-import { createNewGeneratorFile } from '@/utils/generator'
-import { generateFileNameWithTimestamp } from '@/utils/file'
 import { getRoutePath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { act } from 'react'
-import { createGeneratorData } from '@/test/factories/generator'
 
 vi.mock('react-router-dom', () => ({
   useNavigate: vi.fn(),
-}))
-vi.mock('@/utils/generator', () => ({
-  createNewGeneratorFile: vi.fn(),
-}))
-vi.mock('@/utils/file', () => ({
-  generateFileNameWithTimestamp: vi.fn(),
 }))
 vi.mock('@/routeMap', () => ({
   getRoutePath: vi.fn(),
@@ -41,16 +32,14 @@ describe('useCreateGenerator', () => {
   })
 
   it('should navigate to the correct path on successful generator creation', async () => {
-    const newGenerator = createGeneratorData()
     const fileName = 'test-file.json'
     const routePath = '/generator/test-file.json'
 
-    vi.mocked(createNewGeneratorFile).mockReturnValue(newGenerator)
-    vi.mocked(generateFileNameWithTimestamp).mockReturnValue(fileName)
     vi.mocked(getRoutePath).mockReturnValue(routePath)
     vi.stubGlobal('studio', {
       generator: {
-        saveGenerator: vi.fn().mockResolvedValue(fileName),
+        createGenerator: vi.fn().mockResolvedValue(fileName),
+        saveGenerator: vi.fn(),
         loadGenerator: vi.fn(),
       },
     })
@@ -61,15 +50,7 @@ describe('useCreateGenerator', () => {
       await result.current()
     })
 
-    expect(createNewGeneratorFile).toHaveBeenCalled()
-    expect(generateFileNameWithTimestamp).toHaveBeenCalledWith(
-      'json',
-      'Generator'
-    )
-    expect(window.studio.generator.saveGenerator).toHaveBeenCalledWith(
-      JSON.stringify(newGenerator, null, 2),
-      fileName
-    )
+    expect(window.studio.generator.createGenerator).toHaveBeenCalledWith()
     expect(navigate).toHaveBeenCalledWith(routePath)
   })
 

--- a/src/hooks/useCreateGenerator.ts
+++ b/src/hooks/useCreateGenerator.ts
@@ -1,8 +1,6 @@
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { generateFileNameWithTimestamp } from '@/utils/file'
-import { createNewGeneratorFile } from '@/utils/generator'
 import { getRoutePath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 import log from 'electron-log/renderer'
@@ -13,11 +11,7 @@ export function useCreateGenerator() {
 
   const createTestGenerator = useCallback(async () => {
     try {
-      const newGenerator = createNewGeneratorFile()
-      const fileName = await window.studio.generator.saveGenerator(
-        JSON.stringify(newGenerator, null, 2),
-        generateFileNameWithTimestamp('json', 'Generator')
-      )
+      const fileName = await window.studio.generator.createGenerator()
 
       navigate(
         getRoutePath('generator', { fileName: encodeURIComponent(fileName) })

--- a/src/hooks/useCreateGenerator.ts
+++ b/src/hooks/useCreateGenerator.ts
@@ -9,21 +9,25 @@ export function useCreateGenerator() {
   const navigate = useNavigate()
   const showToast = useToast()
 
-  const createTestGenerator = useCallback(async () => {
-    try {
-      const fileName = await window.studio.generator.createGenerator()
+  const createTestGenerator = useCallback(
+    async (recordingPath = '') => {
+      try {
+        const fileName =
+          await window.studio.generator.createGenerator(recordingPath)
 
-      navigate(
-        getRoutePath('generator', { fileName: encodeURIComponent(fileName) })
-      )
-    } catch (error) {
-      showToast({
-        status: 'error',
-        title: 'Failed to create generator',
-      })
-      log.error(error)
-    }
-  }, [navigate, showToast])
+        navigate(
+          getRoutePath('generator', { fileName: encodeURIComponent(fileName) })
+        )
+      } catch (error) {
+        showToast({
+          status: 'error',
+          title: 'Failed to create generator',
+        })
+        log.error(error)
+      }
+    },
+    [navigate, showToast]
+  )
 
   return createTestGenerator
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,7 +3,7 @@
 import { ipcRenderer, contextBridge, IpcRendererEvent } from 'electron'
 import { ProxyData, K6Log, K6Check, ProxyStatus, StudioFile } from './types'
 import { HarFile } from './types/har'
-import { GeneratorFile } from './types/generator'
+import { GeneratorFileData } from './types/generator'
 import { AddToastPayload } from './types/toast'
 import { AppSettings } from './types/settings'
 import * as Sentry from './sentry'
@@ -160,10 +160,16 @@ const ui = {
 } as const
 
 const generator = {
-  saveGenerator: (generatorFile: string, fileName: string): Promise<string> => {
-    return ipcRenderer.invoke('generator:save', generatorFile, fileName)
+  createGenerator: (): Promise<string> => {
+    return ipcRenderer.invoke('generator:create')
   },
-  loadGenerator: (fileName: string): Promise<GeneratorFile> => {
+  saveGenerator: (
+    generator: GeneratorFileData,
+    fileName: string
+  ): Promise<void> => {
+    return ipcRenderer.invoke('generator:save', generator, fileName)
+  },
+  loadGenerator: (fileName: string): Promise<GeneratorFileData> => {
     return ipcRenderer.invoke('generator:open', fileName)
   },
 } as const

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -163,8 +163,8 @@ const ui = {
 } as const
 
 const generator = {
-  createGenerator: (): Promise<string> => {
-    return ipcRenderer.invoke('generator:create')
+  createGenerator: (recordingPath: string): Promise<string> => {
+    return ipcRenderer.invoke('generator:create', recordingPath)
   },
   saveGenerator: (
     generator: GeneratorFileData,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { ipcRenderer, contextBridge, IpcRendererEvent } from 'electron'
 import { ProxyData, K6Log, K6Check, ProxyStatus, StudioFile } from './types'
-import { HarFile } from './types/har'
+import { HarFile, HarWithOptionalResponse } from './types/har'
 import { GeneratorFileData } from './types/generator'
 import { AddToastPayload } from './types/toast'
 import { AppSettings } from './types/settings'
@@ -107,7 +107,10 @@ const script = {
 } as const
 
 const har = {
-  saveFile: (data: string, prefix?: string): Promise<string> => {
+  saveFile: (
+    data: HarWithOptionalResponse,
+    prefix: string
+  ): Promise<string> => {
     return ipcRenderer.invoke('har:save', data, prefix)
   },
   openFile: (filePath: string): Promise<HarFile> => {

--- a/src/types/generator.ts
+++ b/src/types/generator.ts
@@ -1,9 +1,4 @@
 import { z } from 'zod'
 import { GeneratorFileDataSchema } from '@/schemas/generator'
 
-export interface GeneratorFile {
-  name: string
-  content: GeneratorFileData
-}
-
 export type GeneratorFileData = z.infer<typeof GeneratorFileDataSchema>

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -6,12 +6,7 @@ export function generateFileNameWithTimestamp(
   extension: string,
   prefix?: string
 ) {
-  const timestamp =
-    new Date()
-      .toISOString()
-      .replace(/:/g, '-')
-      .replace(/T/g, '_')
-      .split('.')[0] ?? ''
+  const timestamp = new Date().toISOString().split('T')[0] ?? ''
   return `${prefix ? `${prefix} - ` : ''}${timestamp}.${extension}`
 }
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -2,14 +2,6 @@ import { getRoutePath } from '../routeMap'
 import { StudioFileType } from '@/types'
 import { exhaustive } from './typescript'
 
-export function generateFileNameWithTimestamp(
-  extension: string,
-  prefix?: string
-) {
-  const timestamp = new Date().toISOString().split('T')[0] ?? ''
-  return `${prefix ? `${prefix} - ` : ''}${timestamp}.${extension}`
-}
-
 export function getFileNameWithoutExtension(fileName: string) {
   return fileName.replace(/\.[^/.]+$/, '')
 }

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -5,7 +5,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
     case 'correlation':
       return {
         type: 'correlation',
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         enabled: true,
         extractor: {
           filter: { path: '' },
@@ -23,7 +23,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
     case 'customCode':
       return {
         type: 'customCode',
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         enabled: true,
         filter: { path: '' },
         snippet: '',
@@ -32,7 +32,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
     case 'parameterization':
       return {
         type: 'parameterization',
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         enabled: true,
         filter: { path: '' },
         selector: {
@@ -46,7 +46,7 @@ export function createEmptyRule(type: TestRule['type']): TestRule {
     case 'verification':
       return {
         type: 'verification',
-        id: self.crypto.randomUUID(),
+        id: crypto.randomUUID(),
         enabled: true,
         filter: { path: '' },
         selector: {

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -15,3 +15,14 @@ export type ImmerStateCreator<T> = StateCreator<
   [],
   T
 >
+
+export function isNodeJsErrnoException(
+  error: unknown
+): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    'errno' in error &&
+    'syscall' in error
+  )
+}

--- a/src/views/Generator/Generator.hooks.ts
+++ b/src/views/Generator/Generator.hooks.ts
@@ -2,11 +2,7 @@ import { useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
 import { useToast } from '@/store/ui/useToast'
-import {
-  loadGeneratorFile,
-  loadHarFile,
-  writeGeneratorToFile,
-} from './Generator.utils'
+import { loadGeneratorFile, loadHarFile } from './Generator.utils'
 import { selectGeneratorData, useGeneratorStore } from '@/store/generator'
 import { GeneratorFileData } from '@/types/generator'
 import { useMutation, useQuery } from '@tanstack/react-query'
@@ -41,7 +37,10 @@ export function useUpdateValueInGeneratorFile(fileName: string) {
   return useMutation({
     mutationFn: async ({ key, value }: { key: string; value: unknown }) => {
       const generator = await loadGeneratorFile(fileName)
-      await writeGeneratorToFile(fileName, { ...generator, [key]: value })
+      await window.studio.generator.saveGenerator(
+        { ...generator, [key]: value },
+        fileName
+      )
     },
   })
 }
@@ -51,7 +50,7 @@ export function useSaveGeneratorFile(fileName: string) {
 
   return useMutation({
     mutationFn: async (generator: GeneratorFileData) => {
-      await writeGeneratorToFile(fileName, generator)
+      await window.studio.generator.saveGenerator(generator, fileName)
       await queryClient.invalidateQueries({ queryKey: ['generator', fileName] })
     },
 

--- a/src/views/Generator/Generator.utils.ts
+++ b/src/views/Generator/Generator.utils.ts
@@ -31,19 +31,9 @@ export async function exportScript(fileName: string) {
   await window.studio.script.saveScript(script, fileName)
 }
 
-export const writeGeneratorToFile = (
-  fileName: string,
-  generatorData: GeneratorFileData
-) => {
-  return window.studio.generator.saveGenerator(
-    JSON.stringify(generatorData, null, 2),
-    fileName
-  )
-}
-
 export const loadGeneratorFile = async (fileName: string) => {
-  const generatorFile = await window.studio.generator.loadGenerator(fileName)
-  return GeneratorFileDataSchema.parse(generatorFile.content)
+  const generator = await window.studio.generator.loadGenerator(fileName)
+  return GeneratorFileDataSchema.parse(generator)
 }
 
 export const loadHarFile = async (fileName: string) => {

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -16,6 +16,8 @@ import { ExperimentalBanner } from '@/components/ExperimentalBanner'
 export function Home() {
   const createNewGenerator = useCreateGenerator()
 
+  const handleCreateNewGenerator = () => createNewGenerator()
+
   return (
     <Flex direction="column" height="100%">
       <ExperimentalBanner />
@@ -67,7 +69,7 @@ export function Home() {
             title="Generator"
             description="Transform a recorded flow into a k6 test script"
           >
-            <Button variant="ghost" onClick={createNewGenerator}>
+            <Button variant="ghost" onClick={handleCreateNewGenerator}>
               <PlusCircledIcon />
               Generate test
             </Button>

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -105,11 +105,8 @@ export function Recorder() {
       })
 
       const har = proxyDataToHar(grouped)
-      const prefix = startUrl && getHostNameFromURL(startUrl)
-      const fileName = await window.studio.har.saveFile(
-        JSON.stringify(har, null, 4),
-        prefix
-      )
+      const prefix = getHostNameFromURL(startUrl) ?? 'Recording'
+      const fileName = await window.studio.har.saveFile(har, prefix)
 
       return fileName
     } finally {

--- a/src/views/Recorder/Recorder.utils.ts
+++ b/src/views/Recorder/Recorder.utils.ts
@@ -75,7 +75,7 @@ function getRequestSignature(request: Request) {
   return `${request.method} ${request.url}`
 }
 
-export function getHostNameFromURL(url: string) {
+export function getHostNameFromURL(url?: string) {
   // ensure that a URL without protocol is parsed correctly
   const urlWithProtocol = url?.startsWith('http') ? url : `http://${url}`
   try {

--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -50,6 +50,8 @@ export function RecordingPreviewer() {
 
   const groups = useProxyDataGroups(proxyData)
 
+  const handleCreateGenerator = () => createTestGenerator(fileName)
+
   const handleDeleteRecording = async () => {
     await window.studio.ui.deleteFile({
       type: 'recording',
@@ -87,7 +89,7 @@ export function RecordingPreviewer() {
             </Button>
           )}
 
-          <Button onClick={createTestGenerator}>Create test generator</Button>
+          <Button onClick={handleCreateGenerator}>Create test generator</Button>
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               <IconButton variant="ghost" aria-label="Actions" color="gray">

--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -5,19 +5,16 @@ import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import invariant from 'tiny-invariant'
 
-import {
-  generateFileNameWithTimestamp,
-  getFileNameWithoutExtension,
-} from '@/utils/file'
+import { getFileNameWithoutExtension } from '@/utils/file'
 import { View } from '@/components/Layout/View'
 import { RequestsSection } from '@/views/Recorder/RequestsSection'
-import { createNewGeneratorFile } from '@/utils/generator'
 import { ProxyData } from '@/types'
 import { harToProxyData } from '@/utils/harToProxyData'
 import { getRoutePath } from '@/routeMap'
 import { Details } from '@/components/WebLogView/Details'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
 import { EmptyMessage } from '@/components/EmptyMessage'
+import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 
 export function RecordingPreviewer() {
   const [proxyData, setProxyData] = useState<ProxyData[]>([])
@@ -25,6 +22,7 @@ export function RecordingPreviewer() {
   const [selectedRequest, setSelectedRequest] = useState<ProxyData | null>(null)
   const { fileName } = useParams()
   const navigate = useNavigate()
+  const createTestGenerator = useCreateGenerator()
   // TODO: https://github.com/grafana/k6-studio/issues/277
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const { state } = useLocation()
@@ -61,20 +59,6 @@ export function RecordingPreviewer() {
     navigate(getRoutePath('home'))
   }
 
-  const handleCreateTestGenerator = async () => {
-    const newGenerator = createNewGeneratorFile(fileName)
-    const generatorFileName = await window.studio.generator.saveGenerator(
-      JSON.stringify(newGenerator, null, 2),
-      generateFileNameWithTimestamp('json', 'Generator')
-    )
-
-    navigate(
-      getRoutePath('generator', {
-        fileName: encodeURIComponent(generatorFileName),
-      })
-    )
-  }
-
   const handleDiscard = async () => {
     await window.studio.ui.deleteFile({
       type: 'recording',
@@ -103,9 +87,7 @@ export function RecordingPreviewer() {
             </Button>
           )}
 
-          <Button onClick={handleCreateTestGenerator}>
-            Create test generator
-          </Button>
+          <Button onClick={createTestGenerator}>Create test generator</Button>
           <DropdownMenu.Root>
             <DropdownMenu.Trigger>
               <IconButton variant="ghost" aria-label="Actions" color="gray">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Make auto-generated file names shorter and reduce noise, by removing the timestamp and using optional increment at the end.
- Remove `GeneratorFile` as it's become redundant
- Stringify HAR/Generator data in the main process
<img width="249" alt="image" src="https://github.com/user-attachments/assets/9d6ed0b4-0644-4603-bd1c-3490741bacd0" />


## How to Test
Verify that the following works as before (apart from the new filenames):
- Create an new generator, then do it again on the same date
- Create a few new recordings with the same starting URL
- Create a new recording without a starting URL
- Try re-configuring a generator and saving changes

