### PR TITLE
internal(Thresholds): polish UI

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -120,6 +120,7 @@ describe('Code generation', () => {
             value: 1,
           },
         },
+        thresholds: [],
       },
       testData: {
         variables: [],
@@ -129,7 +130,6 @@ describe('Code generation', () => {
       allowlist: [],
       includeStaticAssets: false,
       scriptName: 'my-script.js',
-      thresholds: [],
     }
 
     it('should generate imports', async () => {
@@ -528,7 +528,8 @@ describe('Code generation', () => {
               cookies: {}
             }
   
-            url = http.url\`http://test.k6.io/api/v1/users\`
+            url = http.url\`http://
+            /api/v1/users\`
             resp = http.request('POST', url, \`${JSON.stringify({ user_id: '333' })}\`, params)
   
             params = {

--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -120,7 +120,6 @@ describe('Code generation', () => {
             value: 1,
           },
         },
-        thresholds: [],
       },
       testData: {
         variables: [],
@@ -130,6 +129,7 @@ describe('Code generation', () => {
       allowlist: [],
       includeStaticAssets: false,
       scriptName: 'my-script.js',
+      thresholds: [],
     }
 
     it('should generate imports', async () => {
@@ -528,8 +528,7 @@ describe('Code generation', () => {
               cookies: {}
             }
   
-            url = http.url\`http://
-            /api/v1/users\`
+            url = http.url\`http://test.k6.io/api/v1/users\`
             resp = http.request('POST', url, \`${JSON.stringify({ user_id: '333' })}\`, params)
   
             params = {

--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -120,6 +120,7 @@ describe('Code generation', () => {
             value: 1,
           },
         },
+        thresholds: [],
       },
       testData: {
         variables: [],
@@ -129,7 +130,6 @@ describe('Code generation', () => {
       allowlist: [],
       includeStaticAssets: false,
       scriptName: 'my-script.js',
-      thresholds: [],
     }
 
     it('should generate imports', async () => {

--- a/src/components/Form/ControlledSelect.tsx
+++ b/src/components/Form/ControlledSelect.tsx
@@ -1,4 +1,4 @@
-import { Select } from '@radix-ui/themes'
+import { Select, Tooltip, TooltipProps } from '@radix-ui/themes'
 import { ReactNode } from 'react'
 import { Control, Controller, FieldValues, Path } from 'react-hook-form'
 
@@ -14,6 +14,7 @@ interface ControlledSelectProps<
   options: O[]
   selectProps?: Select.RootProps
   contentProps?: Select.ContentProps
+  tooltipProps?: TooltipProps
   onChange?: (value: O extends Option ? O['value'] : string) => void
 }
 
@@ -26,6 +27,7 @@ export function ControlledSelect<
   options,
   selectProps = {},
   contentProps = {},
+  tooltipProps = { content: undefined, hidden: true },
   onChange,
 }: ControlledSelectProps<T, O>) {
   return (
@@ -38,11 +40,13 @@ export function ControlledSelect<
           value={field.value}
           onValueChange={onChange ?? field.onChange}
         >
-          <Select.Trigger
-            onBlur={field.onBlur}
-            id={name}
-            css={{ width: '100%' }}
-          />
+          <Tooltip {...tooltipProps}>
+            <Select.Trigger
+              onBlur={field.onBlur}
+              id={name}
+              css={{ width: '100%' }}
+            />
+          </Tooltip>
           <Select.Content {...contentProps}>
             {options.map((option) =>
               'options' in option ? (

--- a/src/views/Generator/TestOptions/TestOptions.tsx
+++ b/src/views/Generator/TestOptions/TestOptions.tsx
@@ -10,11 +10,13 @@ import { Thresholds } from './Thresholds'
 import { DataFiles } from './DataFiles'
 import { useFeaturesStore } from '@/store/features'
 import { Feature } from '@/components/Feature'
+import { useState } from 'react'
 
 export function TestOptions() {
   const { thresholds: isThresholdsEnabled } = useFeaturesStore(
     (store) => store.features
   )
+  const [selectedTab, setSelectedTab] = useState('loadProfile')
 
   return (
     <PopoverDialog
@@ -28,7 +30,7 @@ export function TestOptions() {
       }
     >
       <Inset>
-        <Tabs.Root defaultValue="loadProfile">
+        <Tabs.Root value={selectedTab} onValueChange={setSelectedTab}>
           <Tabs.List
             css={css`
               margin-bottom: var(--space-3);

--- a/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
@@ -68,6 +68,10 @@ export function ThresholdRow({ field, index, remove }: ThresholdRowProps) {
             options={urlOptions}
             control={control}
             name={`thresholds.${index}.url`}
+            tooltipProps={{
+              content:
+                threshold.url === '*' ? 'Across all URLs' : threshold.url,
+            }}
             contentProps={{
               css: css`
                 .rt-SelectLabel {

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -2,7 +2,7 @@ import { ThresholdDataSchema } from '@/schemas/generator'
 import { useGeneratorStore } from '@/store/generator'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Button, Text } from '@radix-ui/themes'
+import { Button, Text, Link as RadixLink } from '@radix-ui/themes'
 import { useCallback, useEffect } from 'react'
 import { useForm, useFieldArray, FormProvider } from 'react-hook-form'
 import { ThresholdRow } from './ThresholdRow'
@@ -27,6 +27,13 @@ export function Thresholds() {
     control,
     name: 'thresholds',
   })
+
+  const handleOpenDocs = (event: React.MouseEvent) => {
+    event.preventDefault()
+    return window.studio.browser.openExternalLink(
+      'https://grafana.com/docs/k6/latest/using-k6/thresholds'
+    )
+  }
 
   function handleAddThreshold(event: React.MouseEvent) {
     event.preventDefault()
@@ -59,9 +66,12 @@ export function Thresholds() {
     <FormProvider {...formMethods}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Text size="2" as="p" mb="4">
-          Define pass/fail criteria for your test metrics. If the performance of
-          the system under test does not meet the conditions, the test finishes
-          with a failed status.
+          Define pass/fail criteria for your test metrics. Learn more about
+          thresholds in the{' '}
+          <RadixLink href="" onClick={handleOpenDocs}>
+            docs
+          </RadixLink>
+          .
         </Text>
         <Table.Root size="1" variant="surface" layout="fixed">
           <Table.Header>

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -79,7 +79,9 @@ export function Thresholds() {
               <Table.ColumnHeaderCell width="45px">
                 Value
               </Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell width="20px">Stop</Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell width="35px">
+                Stop Test
+              </Table.ColumnHeaderCell>
               <Table.ColumnHeaderCell width="0"></Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -82,7 +82,7 @@ export function Thresholds() {
               <Table.ColumnHeaderCell width="35px">
                 Stop Test
               </Table.ColumnHeaderCell>
-              <Table.ColumnHeaderCell width="0"></Table.ColumnHeaderCell>
+              <Table.ColumnHeaderCell width="22px"></Table.ColumnHeaderCell>
             </Table.Row>
           </Table.Header>
 

--- a/src/views/Generator/ValidatorDialog.tsx
+++ b/src/views/Generator/ValidatorDialog.tsx
@@ -59,9 +59,12 @@ export function ValidatorDialog({
   }, [open, handleRunScript])
 
   useEffect(() => {
-    return window.studio.script.onScriptFinished(() => {
-      setIsRunning(false)
-    })
+    const onScriptExecutionComplete = () => setIsRunning(false)
+
+    return () => {
+      window.studio.script.onScriptFinished(onScriptExecutionComplete)
+      window.studio.script.onScriptFailed(onScriptExecutionComplete)
+    }
   }, [])
 
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses some UI inconsistencies and bugs on the Thresholds feature.

- Tooltip in the URLs Select component
- Rename "Stop" column to "Stop test"
- Fix `isRunning` state in Validator Dialog when a threshold crosses
- Remember last selected tab in Test Options

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Enable the Thresholds feature
- Check the Thresholds tab in Test Options

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/95d344a6-aaea-4de7-8ac1-1e1e28452c7f)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
