### PR TITLE
feat: Show actions menu button when hover over file item

### DIFF
--- a/src/components/FileTree/File.tsx
+++ b/src/components/FileTree/File.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react'
 import { NavLink, useNavigate } from 'react-router-dom'
 
-import { FileContextMenu } from './FileContextMenu'
+import { FileActionsMenu, FileContextMenu } from './FileContextMenu'
 import { useRef, useState } from 'react'
-import { Tooltip } from '@radix-ui/themes'
+import { Grid, Tooltip } from '@radix-ui/themes'
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
 import { useBoolean } from 'react-use'
 import { InlineEditor } from './InlineEditor'
@@ -32,16 +32,40 @@ export function File({ file, isSelected }: FileProps) {
     <FileContextMenu
       file={file}
       isSelected={isSelected}
-      handleRename={() => setEditMode(true)}
+      onRename={() => setEditMode(true)}
     >
-      <div>
+      <Grid
+        columns="1fr auto"
+        align="center"
+        pr="4"
+        css={css`
+          & > button {
+            opacity: 0;
+          }
+
+          &:hover > button,
+          & > button:focus,
+          & > button[data-state='open'] {
+            opacity: 1;
+          }
+
+          &:hover {
+            background-color: var(--gray-4);
+          }
+        `}
+      >
         <EditableFile
           file={file}
           isSelected={isSelected}
           editMode={editMode}
           setEditMode={setEditMode}
         />
-      </div>
+        <FileActionsMenu
+          file={file}
+          isSelected={isSelected}
+          onRename={() => setEditMode(true)}
+        />
+      </Grid>
     </FileContextMenu>
   )
 }
@@ -94,20 +118,27 @@ function EditableFile({
   }
 
   return (
-    <Tooltip content={displayName} side="right" hidden={!hasEllipsis}>
+    <Tooltip
+      content={displayName}
+      side="right"
+      sideOffset={24}
+      hidden={!hasEllipsis}
+    >
       <NavLink
         ref={linkRef}
         css={[
           fileStyle,
           css`
+            border-radius: 4px;
             font-weight: ${isSelected ? 700 : 400};
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
             text-decoration: none;
 
-            &:hover {
-              background-color: var(--gray-4);
+            &:focus-visible {
+              outline: 2px solid var(--focus-8);
+              outline-offset: -1px;
             }
 
             &.active {

--- a/src/components/FileTree/FileContextMenu.tsx
+++ b/src/components/FileTree/FileContextMenu.tsx
@@ -1,21 +1,84 @@
 import { getRoutePath } from '@/routeMap'
 import { StudioFile } from '@/types'
-import { ContextMenu } from '@radix-ui/themes'
+import { DotsHorizontalIcon } from '@radix-ui/react-icons'
+import { ContextMenu, DropdownMenu, IconButton } from '@radix-ui/themes'
 import { PropsWithChildren } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 interface FileContextMenuProps {
   file: StudioFile
   isSelected: boolean
-  handleRename: () => void
+  onRename: () => void
 }
 
 export function FileContextMenu({
   file,
   children,
   isSelected,
-  handleRename,
+  onRename,
 }: PropsWithChildren<FileContextMenuProps>) {
+  const items = useFileContextMenuItems({ file, isSelected, onRename })
+
+  return (
+    <ContextMenu.Root>
+      <ContextMenu.Trigger>{children}</ContextMenu.Trigger>
+
+      <ContextMenu.Content size="1">
+        {items.map((item) => (
+          <ContextMenu.Item
+            key={item.label}
+            onClick={item.onClick}
+            color={item.destructive ? 'red' : undefined}
+          >
+            {item.label}
+          </ContextMenu.Item>
+        ))}
+      </ContextMenu.Content>
+    </ContextMenu.Root>
+  )
+}
+
+export function FileActionsMenu({
+  file,
+  isSelected,
+  onRename,
+}: FileContextMenuProps) {
+  const items = useFileContextMenuItems({ file, isSelected, onRename })
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <IconButton variant="ghost" aria-label="Actions" color="gray" size="1">
+          <DotsHorizontalIcon />
+        </IconButton>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Content size="1">
+        {items.map((item) => (
+          <DropdownMenu.Item
+            key={item.label}
+            onClick={item.onClick}
+            color={item.destructive ? 'red' : undefined}
+          >
+            {item.label}
+          </DropdownMenu.Item>
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}
+
+interface UseFileContextMenuItemsArgs {
+  file: StudioFile
+  isSelected: boolean
+  onRename: () => void
+}
+
+function useFileContextMenuItems({
+  file,
+  isSelected,
+  onRename,
+}: UseFileContextMenuItemsArgs): FileContextMenuItem[] {
   const navigate = useNavigate()
 
   const handleOpenFolder = () => {
@@ -28,18 +91,15 @@ export function FileContextMenu({
     }
   }
 
-  return (
-    <ContextMenu.Root>
-      <ContextMenu.Trigger>{children}</ContextMenu.Trigger>
-      <ContextMenu.Content size="1">
-        <ContextMenu.Item onClick={handleRename}>Rename</ContextMenu.Item>
-        <ContextMenu.Item onClick={handleOpenFolder}>
-          Open containing folder
-        </ContextMenu.Item>
-        <ContextMenu.Item color="red" onClick={handleDelete}>
-          Delete
-        </ContextMenu.Item>
-      </ContextMenu.Content>
-    </ContextMenu.Root>
-  )
+  return [
+    { label: 'Rename', onClick: onRename },
+    { label: 'Open containing folder', onClick: handleOpenFolder },
+    { label: 'Delete', onClick: handleDelete, destructive: true },
+  ]
+}
+
+type FileContextMenuItem = {
+  label: string
+  onClick: () => void
+  destructive?: boolean
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make it easier to discover file actions by adding a menu, that can be opened with keyboard or mouse click

## How to Test
Verify that both context menu (on right click) and this new menu work and look identical.



## Screenshots (if appropriate):
<img width="402" alt="image" src="https://github.com/user-attachments/assets/207379c0-9db8-433c-ada8-259afe43541d" />

