### PR TITLE
fix: intel mac proxy

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -9,6 +9,17 @@ import { FusesPlugin } from '@electron-forge/plugin-fuses'
 import { FuseV1Options, FuseVersion } from '@electron/fuses'
 import { getPlatform, getArch } from './src/utils/electron'
 
+let resources = [
+  './resources/' + getPlatform() + '/' + getArch(),
+]
+
+if (getPlatform() === 'mac') {
+  resources = [
+    './resources/mac/arm64',
+    './resources/mac/x86_64',
+  ]
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     icon: './resources/icons/logo',
@@ -20,7 +31,7 @@ const config: ForgeConfig = {
       './resources/splashscreen.html',
       './resources/logo-splashscreen-dark.svg',
       './resources/logo-splashscreen.svg',
-      './resources/' + getPlatform() + '/' + getArch(),
+      ...resources,
     ],
     osxSign: {
       optionsForFile: () => {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -8,16 +8,17 @@ import { VitePlugin } from '@electron-forge/plugin-vite'
 import { FusesPlugin } from '@electron-forge/plugin-fuses'
 import { FuseV1Options, FuseVersion } from '@electron/fuses'
 import { getPlatform, getArch } from './src/utils/electron'
+import path from 'path'
 
-let resources = [
-  './resources/' + getPlatform() + '/' + getArch(),
-]
+function getPlatformSpecificResources() {
+  // on mac we are using a single image to build both architectures so we
+  // will need to include both binaries in the final package for it to work.
+  // Otherwise the x86_64 build will still be having the resources/arm64 only binaries
+  if (getPlatform() === 'mac') {
+    return ['./resources/mac/arm64', './resources/mac/x86_64']
+  }
 
-if (getPlatform() === 'mac') {
-  resources = [
-    './resources/mac/arm64',
-    './resources/mac/x86_64',
-  ]
+  return [path.join('./resources/', getPlatform(), getArch())]
 }
 
 const config: ForgeConfig = {
@@ -31,7 +32,7 @@ const config: ForgeConfig = {
       './resources/splashscreen.html',
       './resources/logo-splashscreen-dark.svg',
       './resources/logo-splashscreen.svg',
-      ...resources,
+      ...getPlatformSpecificResources(),
     ],
     osxSign: {
       optionsForFile: () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "k6-studio",
   "productName": "k6 Studio",
-  "version": "0.13.0",
+  "version": "0.12.0",
   "description": "k6 Studio",
   "repository": "github:grafana/k6-studio",
   "main": ".vite/build/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "k6-studio",
   "productName": "k6 Studio",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "k6 Studio",
   "repository": "github:grafana/k6-studio",
   "main": ".vite/build/main.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix https://github.com/grafana/k6-studio/issues/460
Fix https://github.com/grafana/k6-studio/issues/486

The build for both mac architectures is done on an arm machine and that would make the packager packager only the `arm64` folder even on an `x86_64` architecture, this PR fixes that by including both folders on mac with a small cost of `71~MB` increase of application size
<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
