### PR TITLE
fix: Old name is shown when trying to rename file again

### DIFF
--- a/src/components/FileTree/File.hooks.ts
+++ b/src/components/FileTree/File.hooks.ts
@@ -10,7 +10,7 @@ export function useRenameFile(file: StudioFile) {
   return useMutation({
     mutationFn: (newName: string) =>
       window.studio.ui.renameFile(file.fileName, newName, file.type),
-    onMutate: (newName: string) => {
+    onSuccess: (_, newName) => {
       // There's a slight delay between the add and remove callbacks being triggered,
       // causing the UI to flicker because it thinks the renamed file is actually
       // a new file. To prevent this, we optimistically update the file list.
@@ -21,17 +21,6 @@ export function useRenameFile(file: StudioFile) {
       }
       removeFile(file)
       addFile(updatedFile)
-
-      return { updatedFile }
-    },
-    onError: (_, __, context) => {
-      if (!context) {
-        return
-      }
-
-      // Rollback the optimistic update
-      removeFile(context.updatedFile)
-      addFile(file)
     },
   })
 }

--- a/src/components/FileTree/File.hooks.ts
+++ b/src/components/FileTree/File.hooks.ts
@@ -1,0 +1,37 @@
+import { useStudioUIStore } from '@/store/ui'
+import { StudioFile } from '@/types'
+import { getFileNameWithoutExtension } from '@/utils/file'
+import { useMutation } from '@tanstack/react-query'
+
+export function useRenameFile(file: StudioFile) {
+  const addFile = useStudioUIStore((state) => state.addFile)
+  const removeFile = useStudioUIStore((state) => state.removeFile)
+
+  return useMutation({
+    mutationFn: (newName: string) =>
+      window.studio.ui.renameFile(file.fileName, newName, file.type),
+    onMutate: (newName: string) => {
+      // There's a slight delay between the add and remove callbacks being triggered,
+      // causing the UI to flicker because it thinks the renamed file is actually
+      // a new file. To prevent this, we optimistically update the file list.
+      const updatedFile = {
+        ...file,
+        displayName: getFileNameWithoutExtension(newName),
+        fileName: newName,
+      }
+      removeFile(file)
+      addFile(updatedFile)
+
+      return { updatedFile }
+    },
+    onError: (_, __, context) => {
+      if (!context) {
+        return
+      }
+
+      // Rollback the optimistic update
+      removeFile(context.updatedFile)
+      addFile(file)
+    },
+  })
+}

--- a/src/components/FileTree/FileList.tsx
+++ b/src/components/FileTree/FileList.tsx
@@ -25,7 +25,7 @@ export function FileList({ files, noFilesMessage }: FileListProps) {
       `}
     >
       {files.map((file) => (
-        <li key={file.fileName}>
+        <li key={file.displayName}>
           <File file={file} isSelected={file.fileName === currentFile} />
         </li>
       ))}

--- a/src/components/FileTree/InlineEditor.tsx
+++ b/src/components/FileTree/InlineEditor.tsx
@@ -47,6 +47,7 @@ export function InlineEditor({
         <input
           value={localValue}
           onChange={(e) => setValue(e.target.value)}
+          onBlur={() => onSave(localValue)}
           css={{
             outline: '1px solid var(--focus-8)',
           }}

--- a/src/components/FileTree/InlineEditor.tsx
+++ b/src/components/FileTree/InlineEditor.tsx
@@ -47,7 +47,6 @@ export function InlineEditor({
         <input
           value={localValue}
           onChange={(e) => setValue(e.target.value)}
-          onBlur={() => onSave(localValue)}
           css={{
             outline: '1px solid var(--focus-8)',
           }}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -149,7 +149,7 @@ const ui = {
     oldFileName: string,
     newFileName: string,
     type: StudioFile['type']
-  ): Promise<string> => {
+  ): Promise<void> => {
     return ipcRenderer.invoke('ui:rename-file', oldFileName, newFileName, type)
   },
 } as const


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/472

## Description
* Fix https://github.com/grafana/k6-studio/issues/472
* Fix a bug with overwriting existing files when renaming

## How to Test
* Try renaming files - it should work as expected
* Try using a filename that already exists - the rename operation should fail with a toast notification shown to the user


