### PR TITLE
feat: Record, display and generate code for form submit events

### DIFF
--- a/extension/src/recorder.ts
+++ b/extension/src/recorder.ts
@@ -167,3 +167,25 @@ window.addEventListener(
   },
   { capture: true, passive: true }
 )
+
+window.addEventListener('submit', (ev) => {
+  if (ev.target instanceof Element === false) {
+    return
+  }
+
+  // The `submitter` property will be null if the submission was triggered by a script.
+  // In that case, we will assume that there was some other recorded action that caused
+  // that script to run.
+  if (ev.submitter === null) {
+    return
+  }
+
+  captureEvents({
+    type: 'form-submitted',
+    eventId: crypto.randomUUID(),
+    timestamp: Date.now(),
+    form: generateSelector(ev.target),
+    submitter: generateSelector(ev.submitter),
+    tab: '',
+  })
+})

--- a/install-k6.js
+++ b/install-k6.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process')
 const { existsSync } = require('fs')
 
-const K6_VERSION = 'v0.56.0'
+const K6_VERSION = 'v0.55.0'
 const K6_PATH_MAC_AMD = `k6-${K6_VERSION}-macos-amd64`
 const K6_PATH_MAC_ARM = `k6-${K6_VERSION}-macos-arm64`
 const K6_PATH_WIN_AMD = `k6-${K6_VERSION}-windows-amd64`

--- a/install-k6.js
+++ b/install-k6.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process')
 const { existsSync } = require('fs')
 
-const K6_VERSION = 'v0.55.0'
+const K6_VERSION = 'v0.56.0'
 const K6_PATH_MAC_AMD = `k6-${K6_VERSION}-macos-amd64`
 const K6_PATH_MAC_ARM = `k6-${K6_VERSION}-macos-arm64`
 const K6_PATH_WIN_AMD = `k6-${K6_VERSION}-windows-amd64`

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -150,6 +150,23 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
+      case 'form-submitted':
+        return {
+          type: 'click',
+          nodeId: event.eventId,
+          button: 'left',
+          modifiers: {
+            ctrl: false,
+            shift: false,
+            alt: false,
+            meta: false,
+          },
+          inputs: {
+            previous,
+            locator: getLocator(event.tab, event.submitter),
+          },
+        }
+
       default:
         return exhaustive(event)
     }

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -66,6 +66,13 @@ const SelectEventSchema = BrowserEventBaseSchema.extend({
   multiple: z.boolean(),
 })
 
+const FormSubmittedEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('form-submitted'),
+  tab: z.string(),
+  form: z.string(),
+  submitter: z.string(),
+})
+
 export const BrowserEventSchema = discriminatedUnion('type', [
   PageNavigationEventSchema,
   PageReloadEventSchema,
@@ -74,14 +81,16 @@ export const BrowserEventSchema = discriminatedUnion('type', [
   CheckEventSchema,
   SwitchEventSchema,
   SelectEventSchema,
+  FormSubmittedEventSchema,
 ])
 
 export type PageNavigationEvent = z.infer<typeof PageNavigationEventSchema>
 export type PageReloadEvent = z.infer<typeof PageReloadEventSchema>
 export type ClickEvent = z.infer<typeof ClickEventSchema>
 export type InputChangeEvent = z.infer<typeof InputChangeEventSchema>
-export type CheckEventSchema = z.infer<typeof CheckEventSchema>
-export type SwitchEventSchema = z.infer<typeof SwitchEventSchema>
-export type SelectEventSchema = z.infer<typeof SelectEventSchema>
+export type CheckEvent = z.infer<typeof CheckEventSchema>
+export type SwitchEvent = z.infer<typeof SwitchEventSchema>
+export type SelectEvent = z.infer<typeof SelectEventSchema>
+export type FormSubmittedEvent = z.infer<typeof FormSubmittedEventSchema>
 
 export type BrowserEvent = z.infer<typeof BrowserEventSchema>

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -88,9 +88,9 @@ export type PageNavigationEvent = z.infer<typeof PageNavigationEventSchema>
 export type PageReloadEvent = z.infer<typeof PageReloadEventSchema>
 export type ClickEvent = z.infer<typeof ClickEventSchema>
 export type InputChangeEvent = z.infer<typeof InputChangeEventSchema>
-export type CheckEvent = z.infer<typeof CheckEventSchema>
-export type SwitchEvent = z.infer<typeof SwitchEventSchema>
-export type SelectEvent = z.infer<typeof SelectEventSchema>
+export type CheckEventSchema = z.infer<typeof CheckEventSchema>
+export type SwitchEventSchema = z.infer<typeof SwitchEventSchema>
+export type SelectEventSchema = z.infer<typeof SelectEventSchema>
 export type FormSubmittedEvent = z.infer<typeof FormSubmittedEventSchema>
 
 export type BrowserEvent = z.infer<typeof BrowserEventSchema>

--- a/src/views/Recorder/BrowserEventLog.tsx
+++ b/src/views/Recorder/BrowserEventLog.tsx
@@ -12,6 +12,7 @@ import {
   GlobeIcon,
   InputIcon,
   RadiobuttonIcon,
+  ReaderIcon,
   TargetIcon,
   UpdateIcon,
 } from '@radix-ui/react-icons'
@@ -101,6 +102,9 @@ function EventIcon({ event }: EventIconProps) {
     case 'select':
       return <DropdownMenuIcon />
 
+    case 'form-submitted':
+      return <ReaderIcon />
+
     default:
       return exhaustive(event)
   }
@@ -164,7 +168,7 @@ function ClickDescription({ event }: ClickDescriptionProps) {
   return (
     <>
       <Kbd size="2">{clickedText}</Kbd> on element{' '}
-      <strong>{event.selector}</strong>
+      <strong>{event.selector}</strong>.
     </>
   )
 }
@@ -213,6 +217,13 @@ function EventDescription({ event }: EventDescriptionProps) {
         <>
           Selected {formatOptions(event.selected)} from{' '}
           <Selector>{event.selector}</Selector>.
+        </>
+      )
+
+    case 'form-submitted':
+      return (
+        <>
+          Submitted form <Selector>{event.form}</Selector>.
         </>
       )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for capturing form submit events. Submitting a form will now result in a mouse click on the submit button that caused the submit.

## How to Test

1. Record a page that uses forms, e.g. https://test.k6.io/members.php
2. Submit the form by pressing a submit button.
3. Submit the form by pressing Enter in an input.
4. Export and run a script.

> #### Note: I noticed that I got an occasional "Cannot find context with specified id" when running the script. I tried bumping k6 to 0.56.0 and it went away. 🤔 

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
