### PR TITLE
fix: Validator requires admin role on Windows

### DIFF
--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -3,7 +3,3 @@ export const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1F]/
 
 // Limit the file size for preview to avoid performance issues
 export const FILE_SIZE_PREVIEW_THRESHOLD = 1024 * 1024 * 10
-
-export const TEMP_SCRIPT_FILENAME = 'k6-studio-script.js'
-
-export const TEMP_GENERATOR_SCRIPT_FILENAME = 'k6-studio-generator-script.js'

--- a/src/constants/workspace.ts
+++ b/src/constants/workspace.ts
@@ -8,5 +8,9 @@ export const SCRIPTS_PATH = path.join(PROJECT_PATH, 'Scripts')
 export const DATA_FILES_PATH = path.join(PROJECT_PATH, 'Data')
 
 export const TEMP_PATH = path.join(app.getPath('temp'), 'k6-studio')
-export const SCRIPTS_TEMP_PATH = path.join(TEMP_PATH, 'Scripts')
-export const DATA_FILES_TEMP_PATH = path.join(TEMP_PATH, 'Data')
+export const TEMP_SCRIPT_SUFFIX = '__tmp-k6studio__.js'
+export const TEMP_K6_ARCHIVE_PATH = path.join(TEMP_PATH, 'k6-studio-test.tar')
+export const TEMP_GENERATOR_SCRIPT_PATH = path.join(
+  SCRIPTS_PATH,
+  'k6-studio-generator-script' + TEMP_SCRIPT_SUFFIX
+)

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,7 +31,8 @@ import {
   GENERATORS_PATH,
   RECORDINGS_PATH,
   SCRIPTS_PATH,
-  SCRIPTS_TEMP_PATH,
+  TEMP_GENERATOR_SCRIPT_PATH,
+  TEMP_SCRIPT_SUFFIX,
 } from './constants/workspace'
 import {
   sendToast,
@@ -43,7 +44,6 @@ import invariant from 'tiny-invariant'
 import {
   FILE_SIZE_PREVIEW_THRESHOLD,
   INVALID_FILENAME_CHARS,
-  TEMP_GENERATOR_SCRIPT_FILENAME,
 } from './constants/files'
 import { HarWithOptionalResponse } from './types/har'
 import { GeneratorFileData } from './types/generator'
@@ -331,14 +331,21 @@ ipcMain.handle('script:select', async (event) => {
   return scriptPath
 })
 
-ipcMain.handle('script:open', async (_, fileName: string) => {
-  const script = await readFile(path.join(SCRIPTS_PATH, fileName), {
-    encoding: 'utf-8',
-    flag: 'r',
-  })
+ipcMain.handle(
+  'script:open',
+  async (_, scriptPath: string, absolute: boolean = false) => {
+    const resolvedScriptPath = absolute
+      ? scriptPath
+      : path.join(SCRIPTS_PATH, scriptPath)
 
-  return script
-})
+    const script = await readFile(resolvedScriptPath, {
+      encoding: 'utf-8',
+      flag: 'r',
+    })
+
+    return script
+  }
+)
 
 ipcMain.handle(
   'script:run',
@@ -352,12 +359,12 @@ ipcMain.handle(
       ? scriptPath
       : path.join(SCRIPTS_PATH, scriptPath)
 
-    currentk6Process = await runScript(
+    currentk6Process = await runScript({
       browserWindow,
-      resolvedScriptPath,
-      appSettings.proxy.port,
-      appSettings.telemetry.usageReport
-    )
+      scriptPath: resolvedScriptPath,
+      proxyPort: appSettings.proxy.port,
+      usageReport: appSettings.telemetry.usageReport,
+    })
   }
 )
 
@@ -373,20 +380,18 @@ ipcMain.on('script:stop', (event) => {
 })
 
 ipcMain.handle('script:run-from-generator', async (event, script: string) => {
-  const scriptFromGeneratorPath = path.join(
-    SCRIPTS_TEMP_PATH,
-    TEMP_GENERATOR_SCRIPT_FILENAME
-  )
-  await writeFile(scriptFromGeneratorPath, script)
+  await writeFile(TEMP_GENERATOR_SCRIPT_PATH, script)
 
   const browserWindow = browserWindowFromEvent(event)
 
-  currentk6Process = await runScript(
+  currentk6Process = await runScript({
     browserWindow,
-    scriptFromGeneratorPath,
-    appSettings.proxy.port,
-    appSettings.telemetry.usageReport
-  )
+    scriptPath: TEMP_GENERATOR_SCRIPT_PATH,
+    proxyPort: appSettings.proxy.port,
+    usageReport: appSettings.telemetry.usageReport,
+  })
+
+  await unlink(TEMP_GENERATOR_SCRIPT_PATH)
 })
 
 ipcMain.handle(
@@ -533,7 +538,7 @@ ipcMain.handle('ui:get-files', async () => {
     .filter((f) => typeof f !== 'undefined')
 
   const scripts = (await readdir(SCRIPTS_PATH, { withFileTypes: true }))
-    .filter((f) => f.isFile())
+    .filter((f) => f.isFile() && !f.name.endsWith(TEMP_SCRIPT_SUFFIX))
     .map((f) => getStudioFileFromPath(path.join(SCRIPTS_PATH, f.name)))
     .filter((f) => typeof f !== 'undefined')
 
@@ -849,7 +854,7 @@ function configureWatcher(browserWindow: BrowserWindow) {
   watcher.on('add', (filePath) => {
     const file = getStudioFileFromPath(filePath)
 
-    if (!file) {
+    if (!file || filePath.endsWith(TEMP_SCRIPT_SUFFIX)) {
       return
     }
 
@@ -859,7 +864,7 @@ function configureWatcher(browserWindow: BrowserWindow) {
   watcher.on('unlink', (filePath) => {
     const file = getStudioFileFromPath(filePath)
 
-    if (!file) {
+    if (!file || filePath.endsWith(TEMP_SCRIPT_SUFFIX)) {
       return
     }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -66,8 +66,11 @@ const script = {
   showScriptSelectDialog: (): Promise<string | void> => {
     return ipcRenderer.invoke('script:select')
   },
-  openScript: (filePath: string): Promise<string> => {
-    return ipcRenderer.invoke('script:open', filePath)
+  openScript: (
+    scriptPath: string,
+    absolute: boolean = false
+  ): Promise<string> => {
+    return ipcRenderer.invoke('script:open', scriptPath, absolute)
   },
   runScriptFromGenerator: (script: string): Promise<void> => {
     return ipcRenderer.invoke('script:run-from-generator', script)

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,18 +1,57 @@
 import { app, dialog, BrowserWindow } from 'electron'
 import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process'
-import { readFile, writeFile, symlink, unlink } from 'fs/promises'
+import { readFile, writeFile, unlink } from 'fs/promises'
 import path from 'path'
 import readline from 'readline/promises'
 import { K6Check, K6Log } from './types'
 import { getArch, getPlatform } from './utils/electron'
-import {
-  DATA_FILES_PATH,
-  DATA_FILES_TEMP_PATH,
-  SCRIPTS_TEMP_PATH,
-} from './constants/workspace'
-import { TEMP_SCRIPT_FILENAME } from './constants/files'
+import { TEMP_K6_ARCHIVE_PATH, TEMP_SCRIPT_SUFFIX } from './constants/workspace'
 
 export type K6Process = ChildProcessWithoutNullStreams
+
+const spawnK6 = ({
+  args,
+  env = {},
+  onStdOut = () => {},
+  onStdErr = () => {},
+  onClose = () => {},
+}: {
+  args: string[]
+  env?: NodeJS.ProcessEnv
+  onStdOut?: (data: string) => void
+  onStdErr?: (data: string) => void
+  onClose?: (code: number) => void
+}) => {
+  let k6Path: string
+
+  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+    k6Path = path.join(
+      app.getAppPath(),
+      'resources',
+      getPlatform(),
+      getArch(),
+      'k6'
+    )
+  } else {
+    k6Path = path.join(process.resourcesPath, getArch(), 'k6')
+  }
+
+  // add .exe on windows
+  k6Path += getPlatform() === 'win' ? '.exe' : ''
+
+  const k6 = spawn(k6Path, args, {
+    env: { ...process.env, ...env },
+  })
+
+  const stderrReader = readline.createInterface(k6.stderr)
+  const stdoutReader = readline.createInterface(k6.stdout)
+
+  stdoutReader.on('line', onStdOut)
+  stderrReader.on('line', onStdErr)
+  k6.on('close', onClose)
+
+  return k6
+}
 
 export const showScriptSelectDialog = async (browserWindow: BrowserWindow) => {
   const result = await dialog.showOpenDialog(browserWindow, {
@@ -26,100 +65,111 @@ export const showScriptSelectDialog = async (browserWindow: BrowserWindow) => {
   return scriptPath
 }
 
-export const runScript = async (
-  browserWindow: BrowserWindow,
-  scriptPath: string,
-  proxyPort: number,
-  enableUsageReport: boolean
-) => {
-  const modifiedScript = await enhanceScript(scriptPath)
-  const modifiedScriptPath = path.join(SCRIPTS_TEMP_PATH, TEMP_SCRIPT_FILENAME)
-  await writeFile(modifiedScriptPath, modifiedScript)
+export const runScript = async ({
+  scriptPath,
+  proxyPort,
+  usageReport,
+  browserWindow,
+}: {
+  scriptPath: string
+  proxyPort: number
+  usageReport: boolean
+  browserWindow: BrowserWindow
+}) => {
+  // 1. Read the script content
+  const script = await readFile(scriptPath, { encoding: 'utf-8' })
 
-  const proxyEnv = {
-    HTTP_PROXY: `http://localhost:${proxyPort}`,
-    HTTPS_PROXY: `http://localhost:${proxyPort}`,
-    NO_PROXY: 'jslib.k6.io',
-  }
+  // 2. Enhance the script content
+  const modifiedScript = await enhanceScript(script)
 
-  let k6Path: string
+  // 3. Save the enhanced script content to a temp file in the same directory as the original script
+  // (k6 will look for modules/data files in the same directory as the script)
+  const dirname = path.dirname(scriptPath)
+  const randomTempFileName = `.${Math.random().toString(36).substring(7)}${TEMP_SCRIPT_SUFFIX}`
+  const tempScriptPath = path.join(dirname, randomTempFileName)
+  await writeFile(tempScriptPath, modifiedScript)
 
-  // if we are in dev server we take resources directly, otherwise look in the app resources folder.
-  if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
-    k6Path = path.join(
-      app.getAppPath(),
-      'resources',
-      getPlatform(),
-      getArch(),
-      'k6'
-    )
-  } else {
-    // only the architecture directory will be in resources on the packaged app
-    k6Path = path.join(process.resourcesPath, getArch(), 'k6')
-  }
+  // 4. Archive the script and its dependencies
+  const archivePath = await archiveScript(tempScriptPath)
 
-  // add .exe on windows
-  k6Path += getPlatform() === 'win' ? '.exe' : ''
+  // 5. Delete the temp script file
+  await unlink(tempScriptPath)
 
-  const k6Args = [
-    'run',
-    modifiedScriptPath,
-    '--vus=1',
-    '--iterations=1',
-    '--insecure-skip-tls-verify',
-    '--log-format=json',
-    '--quiet',
-    ...(!enableUsageReport ? ['--no-usage-report'] : []),
-  ]
-
-  // Create symlink to data folder so it can be accessed by the script
-  await symlink(DATA_FILES_PATH, DATA_FILES_TEMP_PATH, 'dir')
-
-  const k6 = spawn(k6Path, k6Args, {
-    env: { ...process.env, ...proxyEnv },
-  })
-
-  const stderrReader = readline.createInterface(k6.stderr)
-  const stdoutReader = readline.createInterface(k6.stdout)
-
-  stdoutReader.on('line', (data) => {
-    console.log(`stdout: ${data}`)
-
-    // TODO: https://github.com/grafana/k6-studio/issues/277
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const checkData: K6Check[] = JSON.parse(data)
-    browserWindow.webContents.send('script:check', checkData)
-  })
-
-  stderrReader.on('line', (data) => {
-    // TODO: https://github.com/grafana/k6-studio/issues/277
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const logData: K6Log = JSON.parse(data)
-    browserWindow.webContents.send('script:log', logData)
-  })
-
-  k6.on('close', async (code) => {
-    console.log(`k6 process exited with code ${code}`)
-
-    // Remove symlink
-    await unlink(DATA_FILES_TEMP_PATH)
-
-    let channel = 'script:failed'
-    if (code === 0) {
-      channel = 'script:finished'
-    } else if (code === 105) {
-      channel = 'script:stopped'
-    }
-    browserWindow.webContents.send(channel)
+  // 6. Run the test
+  const k6 = spawnK6({
+    args: [
+      'run',
+      archivePath,
+      '--vus=1',
+      '--iterations=1',
+      '--insecure-skip-tls-verify',
+      '--log-format=json',
+      '--quiet',
+      ...(usageReport ? [] : ['--no-usage-report']),
+    ],
+    env: {
+      HTTP_PROXY: `http://localhost:${proxyPort}`,
+      HTTPS_PROXY: `http://localhost:${proxyPort}`,
+      NO_PROXY: 'jslib.k6.io',
+    },
+    onStdOut: createChecksHandler(browserWindow),
+    onStdErr: createLogsHandler(browserWindow),
+    onClose: createCloseHandler(browserWindow),
   })
 
   return k6
 }
 
-const enhanceScript = async (scriptPath: string) => {
+const createCloseHandler = (browserWindow: BrowserWindow) => (code: number) => {
+  console.log(`k6 process exited with code ${code}`)
+  let channel = 'script:failed'
+  if (code === 0) {
+    channel = 'script:finished'
+  } else if (code === 105) {
+    channel = 'script:stopped'
+  }
+  browserWindow.webContents.send(channel)
+}
+
+const createChecksHandler =
+  (browserWindow: BrowserWindow) => (data: string) => {
+    // TODO: https://github.com/grafana/k6-studio/issues/277
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const checkData: K6Check[] = JSON.parse(data)
+    browserWindow.webContents.send('script:check', checkData)
+  }
+
+const createLogsHandler = (browserWindow: BrowserWindow) => (data: string) => {
+  // TODO: https://github.com/grafana/k6-studio/issues/277
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const logData: K6Log = JSON.parse(data)
+  browserWindow.webContents.send('script:log', logData)
+}
+
+export const archiveScript = (scriptPath: string): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const k6Args = ['archive', scriptPath, '-O', TEMP_K6_ARCHIVE_PATH]
+
+    spawnK6({
+      args: k6Args,
+      onClose: (code) => {
+        if (code === 0) {
+          resolve(TEMP_K6_ARCHIVE_PATH)
+        } else {
+          reject(
+            new Error(
+              `Failed to create archive: k6 process exited with code ${code}`
+            )
+          )
+        }
+      },
+    })
+  })
+}
+
+const enhanceScript = async (scriptContent: string) => {
   const groupSnippet = await getJsSnippet('group_snippet.js')
   const checksSnippet = await getJsSnippet('checks_snippet.js')
-  const scriptContent = await readFile(scriptPath, { encoding: 'utf-8' })
   const scriptLines = scriptContent.split('\n')
   const httpImportIndex = scriptLines.findIndex((line) =>
     line.includes('k6/http')

--- a/src/script.ts
+++ b/src/script.ts
@@ -90,7 +90,7 @@ export const runScript = async ({
   await writeFile(tempScriptPath, modifiedScript)
 
   // 4. Archive the script and its dependencies
-  const archivePath = await archiveScript(tempScriptPath)
+  const archivePath = await archiveScript(tempScriptPath, browserWindow)
 
   // 5. Delete the temp script file
   await unlink(tempScriptPath)
@@ -146,7 +146,10 @@ const createLogsHandler = (browserWindow: BrowserWindow) => (data: string) => {
   browserWindow.webContents.send('script:log', logData)
 }
 
-export const archiveScript = (scriptPath: string): Promise<string> => {
+export const archiveScript = (
+  scriptPath: string,
+  browserWindow: BrowserWindow
+): Promise<string> => {
   return new Promise((resolve, reject) => {
     const k6Args = ['archive', scriptPath, '-O', TEMP_K6_ARCHIVE_PATH]
 
@@ -156,6 +159,7 @@ export const archiveScript = (scriptPath: string): Promise<string> => {
         if (code === 0) {
           resolve(TEMP_K6_ARCHIVE_PATH)
         } else {
+          browserWindow.webContents.send('script:failed')
           reject(
             new Error(
               `Failed to create archive: k6 process exited with code ${code}`

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -6,7 +6,6 @@ import {
   RECORDINGS_PATH,
   GENERATORS_PATH,
   SCRIPTS_PATH,
-  SCRIPTS_TEMP_PATH,
   TEMP_PATH,
 } from '../constants/workspace'
 
@@ -33,9 +32,5 @@ export const setupProjectStructure = async () => {
 
   if (!existsSync(DATA_FILES_PATH)) {
     await mkdir(DATA_FILES_PATH)
-  }
-
-  if (!existsSync(SCRIPTS_TEMP_PATH)) {
-    await mkdir(SCRIPTS_TEMP_PATH)
   }
 }

--- a/src/views/Generator/ValidatorDialog.tsx
+++ b/src/views/Generator/ValidatorDialog.tsx
@@ -59,12 +59,15 @@ export function ValidatorDialog({
   }, [open, handleRunScript])
 
   useEffect(() => {
-    const onScriptExecutionComplete = () => setIsRunning(false)
+    return window.studio.script.onScriptFinished(() => {
+      setIsRunning(false)
+    })
+  }, [])
 
-    return () => {
-      window.studio.script.onScriptFinished(onScriptExecutionComplete)
-      window.studio.script.onScriptFailed(onScriptExecutionComplete)
-    }
+  useEffect(() => {
+    return window.studio.script.onScriptFailed(() => {
+      setIsRunning(false)
+    })
   }, [])
 
   return (

--- a/src/views/Validator/Validator.hooks.ts
+++ b/src/views/Validator/Validator.hooks.ts
@@ -6,7 +6,7 @@ export function useScriptPath() {
   const { state } = useLocation() as { state: { externalScriptPath: string } }
 
   return {
-    scriptPath: fileName || state?.externalScriptPath,
+    scriptPath: state?.externalScriptPath ? state.externalScriptPath : fileName,
     isExternal: Boolean(state?.externalScriptPath),
   }
 }

--- a/src/views/Validator/Validator.tsx
+++ b/src/views/Validator/Validator.tsx
@@ -42,13 +42,16 @@ export function Validator() {
   }, [navigate])
 
   useEffect(() => {
-    if (!scriptPath || isExternal) {
+    if (!scriptPath) {
       return
     }
 
     ;(async () => {
       setIsLoading(true)
-      const fileContent = await window.studio.script.openScript(scriptPath)
+      const fileContent = await window.studio.script.openScript(
+        scriptPath,
+        isExternal
+      )
       setIsLoading(false)
       setScript(fileContent)
     })()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Fix the issue of not being able to validate tests on Windows in some cases
    * Recently, we changed how test runs were initiated to support external dependencies in future. We used `symlink` to create a temporary symlink, which didn't work on Windows under some conditions (we suspect it had something to do with the user role/permissions).
    * We switched to a different approach, one that should also address a recently reported issue with validating external scripts with dependencies
* Fix the issue of not being able to see the external script content
* Fix the issue of not being able to validate external scripts with dependencies (data files, external modules, etc)

## How to Test

- Test both `Validator` and `Validator dialog`
- Make sure external scripts work as well
- Test on Windows

## Related PR(s)/Issue(s)

Hopefully, it will also fix this bug: https://github.com/grafana/k6-studio/issues/435 - I created a very simple script with external dependencies and it worked, so 🤞 

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
