### PR TITLE
internal(Data files): Add data files support in Parameterization rules

### DIFF
--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -32,7 +32,7 @@ export function generateScript({
     ${generateDataFileDeclarations(generator.testData.files)}
 
     export default function() {
-      ${generateVUCode(recording, generator.rules, generator.options.thinkTime)}
+      ${generateVUCode(recording, generator.rules, generator.options.thinkTime, generator.testData.files)}
     }
   `
 }
@@ -92,10 +92,24 @@ export function generateDataFileDeclarations(files: DataFile[]): string {
   return `const FILES = {\n${fileKeyValuePairs}\n};`
 }
 
+export function generateDataFileIterationItemsMap(files: DataFile[]) {
+  const keyValuePairs = files
+    .map(({ name }) => {
+      const displayName = getFileNameWithoutExtension(name)
+
+      return `
+      "${displayName}": FILES["${displayName}"][Math.floor(Math.random() * FILES["${displayName}"].length)]`
+    })
+    .join(',\n')
+
+  return `const FILE_ITEMS = {\n${keyValuePairs}\n};`
+}
+
 export function generateVUCode(
   recording: ProxyData[],
   rules: TestRule[],
-  thinkTime: ThinkTime
+  thinkTime: ThinkTime,
+  dataFiles: DataFile[]
 ): string {
   const cleanedRecording = cleanupRecording(recording)
 
@@ -125,6 +139,7 @@ export function generateVUCode(
     let match
     let regex
     let url
+    ${generateDataFileIterationItemsMap(dataFiles)}
     const correlation_vars = {}
     `,
     groupSnippets,

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -32,7 +32,7 @@ export function generateScript({
     ${generateDataFileDeclarations(generator.testData.files)}
 
     export default function() {
-      ${generateVUCode(recording, generator.rules, generator.options.thinkTime, generator.testData.files)}
+      ${generateVUCode(recording, generator.rules, generator.options.thinkTime)}
     }
   `
 }
@@ -89,27 +89,17 @@ export function generateDataFileDeclarations(files: DataFile[]): string {
     })
     .join(',\n')
 
-  return `const FILES = {\n${fileKeyValuePairs}\n};`
-}
+  const getRandomItemFunction = `
+    const getRandomItem = (array) => array[Math.floor(Math.random() * array.length)];
+  `
 
-export function generateDataFileIterationItemsMap(files: DataFile[]) {
-  const keyValuePairs = files
-    .map(({ name }) => {
-      const displayName = getFileNameWithoutExtension(name)
-
-      return `
-      "${displayName}": FILES["${displayName}"][Math.floor(Math.random() * FILES["${displayName}"].length)]`
-    })
-    .join(',\n')
-
-  return `const FILE_ITEMS = {\n${keyValuePairs}\n};`
+  return `const FILES = {\n${fileKeyValuePairs}\n};${getRandomItemFunction}`
 }
 
 export function generateVUCode(
   recording: ProxyData[],
   rules: TestRule[],
-  thinkTime: ThinkTime,
-  dataFiles: DataFile[]
+  thinkTime: ThinkTime
 ): string {
   const cleanedRecording = cleanupRecording(recording)
 
@@ -139,7 +129,6 @@ export function generateVUCode(
     let match
     let regex
     let url
-    ${generateDataFileIterationItemsMap(dataFiles)}
     const correlation_vars = {}
     `,
     groupSnippets,

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -30,6 +30,7 @@ export function generateScript({
 
     ${generateVariableDeclarations(generator.testData.variables)}
     ${generateDataFileDeclarations(generator.testData.files)}
+    ${generateGetRandomItemFunction(generator.testData.files)}
 
     export default function() {
       ${generateVUCode(recording, generator.rules, generator.options.thinkTime)}
@@ -46,7 +47,7 @@ export function generateImports(generator: GeneratorFileData): string {
     ...REQUIRED_IMPORTS,
     // Import SharedArray for data files
     ...(hasDataFiles ? [K6_EXPORTS['k6/data']] : []),
-    // TODO: replace with k6/experimental/csv once https://github.com/grafana/k6/pull/4295 is released
+    // TODO: replace with k6/experimental/csv once we switch to k6@0.57.0 or higher
     ...(hasCsvDataFiles ? [JSLIB['papaparse']] : []),
   ]
 
@@ -89,11 +90,18 @@ export function generateDataFileDeclarations(files: DataFile[]): string {
     })
     .join(',\n')
 
-  const getRandomItemFunction = `
-    const getRandomItem = (array) => array[Math.floor(Math.random() * array.length)];
-  `
+  return `const FILES = {\n${fileKeyValuePairs}\n};`
+}
 
-  return `const FILES = {\n${fileKeyValuePairs}\n};${getRandomItemFunction}`
+export function generateGetRandomItemFunction(files: DataFile[]) {
+  if (files.length === 0) {
+    return ''
+  }
+
+  return `
+    function getRandomItem(array){
+      return array[Math.floor(Math.random() * array.length)]
+    }`
 }
 
 export function generateVUCode(

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -10,6 +10,8 @@ import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 import { SearchField } from '@/components/SearchField'
 import { useState } from 'react'
 import { Feature } from '@/components/Feature'
+import log from 'electron-log/renderer'
+import { useToast } from '@/store/ui/useToast'
 
 interface SidebarProps {
   isExpanded?: boolean
@@ -20,11 +22,20 @@ export function Sidebar({ isExpanded, onCollapseSidebar }: SidebarProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const { recordings, generators, scripts, dataFiles } = useFiles(searchTerm)
   const createNewGenerator = useCreateGenerator()
+  const showToast = useToast()
 
   const handleCreateNewGenerator = () => createNewGenerator()
 
-  const handleImportDataFile = () => {
-    return window.studio.data.importFile()
+  const handleImportDataFile = async () => {
+    try {
+      await window.studio.data.importFile()
+    } catch (error) {
+      showToast({
+        title: 'Failed to import recording',
+        status: 'error',
+      })
+      log.error(error)
+    }
   }
 
   return (

--- a/src/constants/files.ts
+++ b/src/constants/files.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-control-regex
 export const INVALID_FILENAME_CHARS = /[<>:"/\\|?*\x00-\x1F]/
 
-// Limit the file size for preview to avoid performance issues
-export const FILE_SIZE_PREVIEW_THRESHOLD = 1024 * 1024 * 10
+// TODO: Find a better way to handle large files
+// Limit the file size for data files to avoid performance issues
+export const MAX_DATA_FILE_SIZE = 1024 * 1024 * 10

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -120,7 +120,7 @@ const data = {
   importFile: (): Promise<string | undefined> => {
     return ipcRenderer.invoke('data-file:import')
   },
-  loadPreview: (filePath: string): Promise<DataFilePreview | null> => {
+  loadPreview: (filePath: string): Promise<DataFilePreview> => {
     return ipcRenderer.invoke('data-file:load-preview', filePath)
   },
 } as const

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -7,6 +7,7 @@ import {
 import { exhaustive } from '@/utils/typescript'
 import { replaceRequestValues } from './shared'
 import { matchFilter } from './utils'
+import { getFileNameWithoutExtension } from '@/utils/file'
 
 export function createParameterizationRuleInstance(
   rule: ParameterizationRule,
@@ -87,6 +88,11 @@ function getRuleValue(rule: ParameterizationRule, id: number) {
 
     case 'variable':
       return `\${VARS['${value.variableName}']}`
+
+    case 'dataFileValue': {
+      const displayName = getFileNameWithoutExtension(value.fileName)
+      return `\${FILE_ITEMS['${displayName}']['${value.propertyName}']}`
+    }
 
     case 'customCode':
       return `\${getParameterizationValue${id}()}`

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -91,7 +91,7 @@ function getRuleValue(rule: ParameterizationRule, id: number) {
 
     case 'dataFileValue': {
       const displayName = getFileNameWithoutExtension(value.fileName)
-      return `\${FILE_ITEMS['${displayName}']['${value.propertyName}']}`
+      return `\${getRandomItem(FILES['${displayName}'])['${value.propertyName}']}`
     }
 
     case 'customCode':

--- a/src/schemas/generator/v1/rules.ts
+++ b/src/schemas/generator/v1/rules.ts
@@ -5,6 +5,12 @@ export const VariableValueSchema = z.object({
   variableName: z.string(),
 })
 
+export const DataFileValueSchema = z.object({
+  type: z.literal('dataFileValue'),
+  fileName: z.string(),
+  propertyName: z.string(),
+})
+
 export const CustomCodeValueSchema = z.object({
   type: z.literal('customCode'),
   code: z.string(),
@@ -116,6 +122,7 @@ export const ParameterizationRuleSchema = RuleBaseSchema.extend({
   selector: ReplacerSelectorSchema,
   value: z.discriminatedUnion('type', [
     VariableValueSchema,
+    DataFileValueSchema,
     CustomCodeValueSchema,
     StringValueSchema,
   ]),

--- a/src/views/DataFile/DataFile.tsx
+++ b/src/views/DataFile/DataFile.tsx
@@ -1,5 +1,5 @@
 import { Badge, Flex } from '@radix-ui/themes'
-import { useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
 import { View } from '@/components/Layout/View'
@@ -7,12 +7,27 @@ import { getFileNameWithoutExtension } from '@/utils/file'
 import { useDataFilePreview } from './DataFile.hooks'
 import { DataFileControls } from './DataFileControls'
 import { DataFileTable } from './DataFileTable'
+import { useEffect } from 'react'
+import { useToast } from '@/store/ui/useToast'
+import { getRoutePath } from '@/routeMap'
 
 export function DataFile() {
   const { fileName } = useParams()
+  const navigate = useNavigate()
+  const showToast = useToast()
   invariant(fileName, 'fileName is required')
 
-  const { data: preview, isLoading } = useDataFilePreview(fileName)
+  const { data: preview, isLoading, isError } = useDataFilePreview(fileName)
+
+  useEffect(() => {
+    if (isError) {
+      showToast({
+        title: 'Failed to load data file',
+        status: 'error',
+      })
+      navigate(getRoutePath('home'))
+    }
+  }, [isError, navigate, showToast])
 
   return (
     <View

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
@@ -1,0 +1,80 @@
+import { Code } from '@radix-ui/themes'
+import { ControlledSelect, FieldGroup } from '@/components/Form'
+import { ParameterizationRule } from '@/types/rules'
+import { useFormContext } from 'react-hook-form'
+import { useGeneratorStore } from '@/store/generator'
+import { useMemo } from 'react'
+import { useDataFilePreview } from '@/views/DataFile/DataFile.hooks'
+
+export function FileSelect() {
+  const {
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext<ParameterizationRule>()
+
+  const fileName = watch('value.fileName')
+  const propertyName = watch('value.propertyName')
+  const files = useGeneratorStore((store) => store.files)
+  const { data: preview, isLoading } = useDataFilePreview(fileName)
+
+  const fileOptions = useMemo(() => {
+    return files.map((file) => ({
+      value: file.name,
+      label: (
+        <Code size="2" truncate variant="ghost">
+          {file.name}
+        </Code>
+      ),
+    }))
+  }, [files])
+
+  const propsOptions = useMemo(() => {
+    return preview?.props.map((prop) => ({
+      value: prop,
+      label: (
+        <Code size="2" truncate variant="ghost">
+          {prop}
+        </Code>
+      ),
+    }))
+  }, [preview])
+
+  return (
+    <>
+      <FieldGroup name="value.fileName" errors={errors} label="Data file">
+        <ControlledSelect
+          options={fileOptions}
+          control={control}
+          name="value.fileName"
+          selectProps={{
+            // Automatically open the select when switching to data file value type
+            // in new parameterization rule
+            defaultOpen: !fileName,
+          }}
+          contentProps={{
+            css: { maxWidth: 'var(--radix-select-trigger-width)' },
+            position: 'popper',
+          }}
+        />
+      </FieldGroup>
+      <FieldGroup name="value.fileName" errors={errors} label="Property">
+        <ControlledSelect
+          options={propsOptions || []}
+          control={control}
+          name="value.propertyName"
+          selectProps={{
+            disabled: isLoading,
+            // Automatically open the select when selecting data file
+            // in new parameterization rule
+            defaultOpen: !!fileName && !propertyName,
+          }}
+          contentProps={{
+            css: { maxWidth: 'var(--radix-select-trigger-width)' },
+            position: 'popper',
+          }}
+        />
+      </FieldGroup>
+    </>
+  )
+}

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
@@ -58,7 +58,12 @@ export function FileSelect() {
           }}
         />
       </FieldGroup>
-      <FieldGroup name="value.fileName" errors={errors} label="Property">
+      <FieldGroup
+        name="value.fileName"
+        errors={errors}
+        label="Key"
+        hint="Key from a random row in the data file"
+      >
         <ControlledSelect
           options={propsOptions || []}
           control={control}

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/FileSelect.tsx
@@ -62,7 +62,7 @@ export function FileSelect() {
         name="value.fileName"
         errors={errors}
         label="Key"
-        hint="Key from a random row in the data file"
+        hint="Used to retrieve a value from a randomly selected row in the data file"
       >
         <ControlledSelect
           options={propsOptions || []}

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/ValueEditor.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/ValueEditor.tsx
@@ -6,6 +6,7 @@ import { useGeneratorStore } from '@/store/generator'
 import { exhaustive } from '@/utils/typescript'
 import { VariableSelect } from './VariableSelect'
 import { CustomCode } from './CustomCode'
+import { FileSelect } from './FileSelect'
 
 export function ValueEditor() {
   const {
@@ -13,17 +14,17 @@ export function ValueEditor() {
     formState: { errors },
   } = useFormContext<ParameterizationRule>()
 
-  const variablesExist = useGeneratorStore(
-    (state) => state.variables.length > 0
-  )
-
-  const variablesLabel = variablesExist
-    ? 'Variables'
-    : 'Variables (add in test options)'
+  const hasVariables = useGeneratorStore((state) => state.variables.length > 0)
+  const hasFiles = useGeneratorStore((state) => state.files.length > 0)
 
   const VALUE_TYPE_OPTIONS = [
     { value: 'string', label: 'Text value' },
-    { value: 'variable', label: variablesLabel, disabled: !variablesExist },
+    { value: 'variable', label: 'Variable', disabled: !hasVariables },
+    {
+      value: 'dataFileValue',
+      label: 'Value from data file',
+      disabled: !hasFiles,
+    },
     { value: 'customCode', label: 'Custom code' },
   ]
 
@@ -59,6 +60,9 @@ function ValueTypeSwitch() {
       )
     case 'variable':
       return <VariableSelect />
+
+    case 'dataFileValue':
+      return <FileSelect />
 
     case 'customCode':
       return <CustomCode />

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/ValueEditor.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/ValueEditor.tsx
@@ -22,7 +22,7 @@ export function ValueEditor() {
     { value: 'variable', label: 'Variable', disabled: !hasVariables },
     {
       value: 'dataFileValue',
-      label: 'Value from data file',
+      label: 'Data file',
       disabled: !hasFiles,
     },
     { value: 'customCode', label: 'Custom code' },

--- a/src/views/Generator/RuleEditor/ParameterizationEditor/VariableSelect.tsx
+++ b/src/views/Generator/RuleEditor/ParameterizationEditor/VariableSelect.tsx
@@ -1,4 +1,4 @@
-import { Code, Flex, Text } from '@radix-ui/themes'
+import { Code, Flex } from '@radix-ui/themes'
 import { ControlledSelect, FieldGroup } from '@/components/Form'
 import { ParameterizationRule } from '@/types/rules'
 import { useFormContext } from 'react-hook-form'
@@ -13,12 +13,12 @@ export function VariableSelect() {
       value: variable.name,
       label: (
         <Flex gap="1" align="center">
-          <Code size="2" truncate>
+          <Code size="2" truncate variant="ghost" color="blue">
             {variable.name}
           </Code>
-          <Text truncate size="1" css={{ flex: '1' }}>
+          <Code truncate size="1" variant="ghost" css={{ flex: '1' }}>
             {variable.value}
-          </Text>
+          </Code>
         </Flex>
       ),
     }))

--- a/src/views/Generator/TestOptions/DataFiles.tsx
+++ b/src/views/Generator/TestOptions/DataFiles.tsx
@@ -4,7 +4,7 @@ import { useGeneratorStore } from '@/store/generator'
 import { useStudioUIStore } from '@/store/ui'
 import { TestData } from '@/types/testData'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CheckboxGroup, Text } from '@radix-ui/themes'
+import { CheckboxGroup, Text, Tooltip } from '@radix-ui/themes'
 import { useCallback, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 
@@ -30,6 +30,7 @@ export function DataFiles() {
   const options = [...availableFiles.values()].map((file) => ({
     label: file.displayName,
     value: file.fileName,
+    inUse: files.some(({ name }) => name === file.fileName),
   }))
   const value = watch('files').map(({ name }) => name)
 
@@ -72,9 +73,18 @@ export function DataFiles() {
             ref={filesField.ref}
           >
             {options.map((option) => (
-              <CheckboxGroup.Item key={option.value} value={option.value}>
-                {option.label}
-              </CheckboxGroup.Item>
+              <Tooltip
+                content="File is referenced in a rule"
+                key={option.value}
+                hidden={!option.inUse}
+              >
+                <CheckboxGroup.Item
+                  value={option.value}
+                  disabled={option.inUse}
+                >
+                  {option.label}
+                </CheckboxGroup.Item>
+              </Tooltip>
             ))}
           </CheckboxGroup.Root>
         </FieldGroup>

--- a/src/views/Generator/TestOptions/VariablesEditor.tsx
+++ b/src/views/Generator/TestOptions/VariablesEditor.tsx
@@ -136,7 +136,10 @@ function VariableRow({
         </FieldGroup>
       </Table.Cell>
       <Table.Cell>
-        <Tooltip content="Variable is in use by rule" hidden={!isVariableInUse}>
+        <Tooltip
+          content="Variable is referenced in a rule"
+          hidden={!isVariableInUse}
+        >
           <IconButton disabled={isVariableInUse} onClick={() => remove(index)}>
             <TrashIcon width="18" height="18" />
           </IconButton>

--- a/src/views/Generator/TestOptions/VariablesEditor.tsx
+++ b/src/views/Generator/TestOptions/VariablesEditor.tsx
@@ -1,13 +1,6 @@
 import { useCallback, useEffect } from 'react'
 import { TrashIcon } from '@radix-ui/react-icons'
-import {
-  Button,
-  IconButton,
-  TextField,
-  Text,
-  Code,
-  Tooltip,
-} from '@radix-ui/themes'
+import { Button, IconButton, TextField, Text, Tooltip } from '@radix-ui/themes'
 import { useGeneratorStore } from '@/store/generator'
 import {
   useForm,
@@ -66,9 +59,7 @@ export function VariablesEditor() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Text size="2" as="p" mb="2">
-        Define custom variables and use them in your custom code rules, for
-        example:
-        <Code>{'VARS["variable_0"]'}</Code>.
+        Define variables and use them in your test rules.
       </Text>
       <Table.Root size="1" variant="surface">
         <Table.Header>

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
@@ -116,6 +116,13 @@ function ParameterizationValue({ rule }: { rule: ParameterizationRule }) {
           {rule.value.variableName}
         </Strong>
       )
+    case 'dataFileValue':
+      return (
+        <>
+          <Strong>{rule.value.propertyName}</Strong> from{' '}
+          <Strong>{rule.value.fileName}</Strong>
+        </>
+      )
     case 'customCode':
       return null
     default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a way to select value from file in Parameterization rule editor - this PR and the finishing UI touches are the biggest missing piece stopping us from making the feature public.

## How to Test
1. Enable the `data-files` feature
2. Import a JSON/CSV file
3. Open a generator
4. Add the file in `Test options` <- the UI will be updated
5. Add a parameterization rule and select `Data file` in selector
6. Verify that the generated script works



## Screenshots (if appropriate):
<img width="1404" alt="image" src="https://github.com/user-attachments/assets/35222829-8de9-47c5-a618-f1c06b2f66bf" />


