### PR TITLE
fix: parameterization custom code is not defined

### DIFF
--- a/src/rules/parameterization.test.ts
+++ b/src/rules/parameterization.test.ts
@@ -9,7 +9,6 @@ import {
   jsonRule,
   urlRule,
 } from '@/test/fixtures/parameterizationRules'
-import { prettify } from '@/utils/prettify'
 import { generateSequentialInt } from './utils'
 
 let idGenerator = generateSequentialInt()
@@ -154,7 +153,7 @@ describe('applyParameterization', () => {
     })
   })
 
-  it('supports custom code', async () => {
+  it('supports custom code', () => {
     const requestSnippet = createRequestSnippet(
       createProxyData({
         request: createRequest({
@@ -167,12 +166,6 @@ describe('applyParameterization', () => {
       customCodeReplaceProjectId,
       idGenerator
     ).apply(requestSnippet)
-
-    expect(await prettify(updatedRequest.before[0] ?? '')).toBe(
-      await prettify(
-        `function getParameterizationValue0() { ${customCodeReplaceProjectId.value.code} }`
-      )
-    )
 
     expect(updatedRequest.data.request.url).toBe(
       'http://example.com/api/v1/project_id=${getParameterizationValue0()}'

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -63,16 +63,6 @@ export function createParameterizationRuleInstance(
         return updatedRequestSnippet
       }
 
-      const beforeSnippet = getBeforeSnippet(rule, state.uniqueId)
-
-      if (beforeSnippet) {
-        state.snippedInjected = true
-
-        return {
-          ...updatedRequestSnippet,
-          before: [...updatedRequestSnippet.before, beforeSnippet],
-        }
-      }
       return updatedRequestSnippet
     },
   }
@@ -93,16 +83,6 @@ function getRuleValue(rule: ParameterizationRule, id: number) {
 
     default:
       return exhaustive(value)
-  }
-}
-
-function getBeforeSnippet(rule: ParameterizationRule, id: number) {
-  switch (rule.value.type) {
-    case 'customCode':
-      return getCustomCodeSnippet(rule.value.code, id)
-
-    default:
-      return
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where the parameterization custom code is declared inside a group making it unavailable in subsequent groups.

```.ts
...
group("Group 2", function () {
   function getParameterizationValue0() { ... }
})

group("Group 1", function () {
   // getParameterizationValue0 is not available here
})
```

To fix this issue, custom codes generated by parameterization were moved to upper scope.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Create a couple of parameterization rules with custom code
- Check that the code is generated outside of groups

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/457

<!-- Thanks for your contribution! 🙏🏼 -->
