### PR TITLE
fix: Filter field hint and placeholder incorrectly refer to URL as path

### DIFF
--- a/src/views/Generator/RuleEditor/FilterField.tsx
+++ b/src/views/Generator/RuleEditor/FilterField.tsx
@@ -19,11 +19,11 @@ export function FilterField({
     <FieldGroup
       name={fieldName}
       label="Filter"
-      hint="Only requests with this string in their path will be affected. Regex supported."
+      hint="Filter requests by URL (regex supported)"
       errors={errors}
     >
       <TextField.Root
-        placeholder="Filter by path"
+        placeholder="Filter by URL"
         css={{ marginBottom: 'var(--space-2)' }}
         id={fieldName}
         {...register(fieldName)}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
