### PR TITLE
fix: Query params list style is inconsistent with other tabs

### DIFF
--- a/src/components/WebLogView/RequestDetails/QueryParams.tsx
+++ b/src/components/WebLogView/RequestDetails/QueryParams.tsx
@@ -1,7 +1,6 @@
-import { Flex } from '@radix-ui/themes'
+import { DataList, Flex } from '@radix-ui/themes'
 
 import { Request } from '@/types'
-import { Table } from '@/components/Table'
 import { SearchMatch } from '@/types/fuse'
 import { HighlightedText } from '@/components/HighlightedText'
 
@@ -20,34 +19,21 @@ export function QueryParams({
     )
   }
   return (
-    <Table.Root size="1" variant="surface">
-      <Table.Header>
-        <Table.Row>
-          <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
-          <Table.ColumnHeaderCell>Value</Table.ColumnHeaderCell>
-        </Table.Row>
-      </Table.Header>
-
-      <Table.Body>
-        {request.query.map(([key, value]) => (
-          <Table.Row key={key}>
-            <Table.Cell>
-              <HighlightedText
-                text={key}
-                matches={matches}
-                highlightAllMatches
-              />
-            </Table.Cell>
-            <Table.Cell>
-              <HighlightedText
-                text={value}
-                matches={matches}
-                highlightAllMatches
-              />
-            </Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table.Root>
+    <DataList.Root size="1" trim="both">
+      {request.query.map(([key, value]) => (
+        <DataList.Item key={key}>
+          <DataList.Label>
+            <HighlightedText text={key} matches={matches} highlightAllMatches />
+          </DataList.Label>
+          <DataList.Value>
+            <HighlightedText
+              text={value}
+              matches={matches}
+              highlightAllMatches
+            />
+          </DataList.Value>
+        </DataList.Item>
+      ))}
+    </DataList.Root>
   )
 }

--- a/src/components/WebLogView/RequestDetails/RequestDetails.tsx
+++ b/src/components/WebLogView/RequestDetails/RequestDetails.tsx
@@ -64,7 +64,9 @@ export function RequestDetails({ data }: RequestDetailsProps) {
       </Tabs.Content>
 
       <Tabs.Content value="queryParams">
-        <QueryParams request={data.request} matches={requestMatches} />
+        <Box p="2" height="100%">
+          <QueryParams request={data.request} matches={requestMatches} />
+        </Box>
       </Tabs.Content>
     </Tabs.Root>
   )


### PR DESCRIPTION
## Screenshots:
#### Before
<img width="494" alt="image" src="https://github.com/user-attachments/assets/c8ddb64f-d3a7-4c7c-b7e7-480784baf31b" />

#### After
<img width="491" alt="image" src="https://github.com/user-attachments/assets/b12e4278-c35a-4106-81a7-a41f7c9bfc60" />
