### PR TITLE
fix: It's possible to start a recording with no supported browser installed

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,14 @@ import { Global } from '@emotion/react'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { enableMapSet } from 'immer'
 
-import { useTheme } from './hooks/useTheme'
+import { DevToolsDialog } from '@/components/DevToolsDialog'
+import { SettingsDialog } from '@/components/Settings/SettingsDialog'
+import { Toasts } from '@/components/Toast/Toasts'
+import { useCloseSplashScreen } from '@/hooks/useCloseSplashScreen'
+import { useTheme } from '@/hooks/useTheme'
+import { queryClient } from '@/utils/query'
 import { globalStyles } from './globalStyles'
 import { AppRoutes } from './AppRoutes'
-import { Toasts } from './components/Toast/Toasts'
-import { queryClient } from './utils/query'
-import { useCloseSplashScreen } from './hooks/useCloseSplashScreen'
-import { DevToolsDialog } from './components/DevToolsDialog'
 
 enableMapSet()
 
@@ -24,6 +25,7 @@ export function App() {
         <Toasts />
         <AppRoutes />
         <DevToolsDialog />
+        <SettingsDialog />
       </Theme>
     </QueryClientProvider>
   )

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -15,7 +15,7 @@ const createUserDataDir = async () => {
   return mkdtemp(path.join(os.tmpdir(), 'k6-studio-'))
 }
 
-function getBrowserPath() {
+export function getBrowserPath() {
   const { recorder } = appSettings
 
   if (recorder.detectBrowserPath) {

--- a/src/components/Form/FileUploadInput.tsx
+++ b/src/components/Form/FileUploadInput.tsx
@@ -1,6 +1,7 @@
 import { Flex, TextField, Button } from '@radix-ui/themes'
 import { FieldGroup } from './FieldGroup'
 import { Controller, FieldErrors } from 'react-hook-form'
+import { css } from '@emotion/react'
 
 type FileUploadInputProps = {
   name: string
@@ -34,29 +35,26 @@ export const FileUploadInput = ({
             hint={hint}
             hintType="text"
           >
-            <TextField.Root
-              type="text"
-              disabled={disabled}
-              onChange={field.onChange}
-              name={field.name}
-              // TODO: https://github.com/grafana/k6-studio/issues/277
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              value={field.value}
-            />
+            <Flex gap="2" width="100%">
+              <TextField.Root
+                css={css`
+                  flex: 1;
+                `}
+                type="text"
+                disabled={disabled}
+                onChange={field.onChange}
+                name={field.name}
+                // TODO: https://github.com/grafana/k6-studio/issues/277
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                value={field.value}
+              />
+              <Button disabled={disabled} onClick={onSelectFile} type="button">
+                {buttonText}
+              </Button>
+            </Flex>
           </FieldGroup>
         )}
       />
-
-      <Button
-        ml="2"
-        disabled={disabled}
-        onClick={onSelectFile}
-        style={{
-          marginTop: 48,
-        }}
-      >
-        {buttonText}
-      </Button>
     </Flex>
   )
 }

--- a/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
+++ b/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
@@ -1,11 +1,10 @@
 import { css } from '@emotion/react'
 import { Link1Icon, LinkBreak1Icon, LinkNone1Icon } from '@radix-ui/react-icons'
 import { Box, Flex, Tooltip } from '@radix-ui/themes'
-import { useEffect } from 'react'
 
-import { useStudioUIStore } from '@/store/ui'
 import type { ProxyStatus } from '@/types'
 import { exhaustive } from '@/utils/typescript'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
 
 const COLOR_MAP: Record<ProxyStatus, string> = {
   ['online']: 'var(--green-9)',
@@ -14,19 +13,7 @@ const COLOR_MAP: Record<ProxyStatus, string> = {
 }
 
 export function ProxyStatusIndicator() {
-  const status = useStudioUIStore((state) => state.proxyStatus)
-  const setProxyStatus = useStudioUIStore((state) => state.setProxyStatus)
-
-  useEffect(() => {
-    ;(async function fetchProxyStatus() {
-      const status = await window.studio.proxy.getProxyStatus()
-      setProxyStatus(status)
-    })()
-
-    return window.studio.proxy.onProxyStatusChange((status) =>
-      setProxyStatus(status)
-    )
-  }, [setProxyStatus])
+  const status = useProxyStatus()
 
   return (
     <Tooltip content={`Proxy status: ${status}`} side="right">

--- a/src/components/Layout/ActivityBar/SettingsButton.tsx
+++ b/src/components/Layout/ActivityBar/SettingsButton.tsx
@@ -1,25 +1,20 @@
-import { SettingsDialog } from '@/components/Settings/SettingsDialog'
+import { useStudioUIStore } from '@/store/ui'
 import { GearIcon } from '@radix-ui/react-icons'
 import { Tooltip, IconButton } from '@radix-ui/themes'
-import { useState } from 'react'
 
 export function SettingsButton() {
-  const [open, setOpen] = useState(false)
+  const setIsOpen = useStudioUIStore((state) => state.setIsSettingsDialogOpen)
 
   return (
-    <>
-      <Tooltip content="Settings" side="right">
-        <IconButton
-          area-label="Settings"
-          color="gray"
-          variant="ghost"
-          onClick={() => setOpen(true)}
-        >
-          <GearIcon />
-        </IconButton>
-      </Tooltip>
-
-      <SettingsDialog open={open} onOpenChange={setOpen} />
-    </>
+    <Tooltip content="Settings" side="right">
+      <IconButton
+        area-label="Settings"
+        color="gray"
+        variant="ghost"
+        onClick={() => setIsOpen(true)}
+      >
+        <GearIcon />
+      </IconButton>
+    </Tooltip>
   )
 }

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -57,7 +57,7 @@ export const RecorderSettings = () => {
         name="recorder.browserPath"
         onSelectFile={handleSelectFile}
         buttonText="Select executable"
-        hint="The location of the browser executable (Grafana k6 Studio currently supports Chrome)"
+        hint="The location of the browser executable (Google Chrome needs to be installed on your machine for the recording functionality to work)"
         disabled={recorder.detectBrowserPath}
       />
     </SettingsSection>

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -57,7 +57,7 @@ export const RecorderSettings = () => {
         name="recorder.browserPath"
         onSelectFile={handleSelectFile}
         buttonText="Select executable"
-        hint="The location of the browser executable (Google Chrome needs to be installed on your machine for the recording functionality to work)"
+        hint="Google Chrome needs to be installed on your machine for the recording functionality to work"
         disabled={recorder.detectBrowserPath}
       />
     </SettingsSection>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -14,12 +14,8 @@ import { TelemetrySettings } from './TelemetrySettings'
 import { ButtonWithTooltip } from '../ButtonWithTooltip'
 import { AppearanceSettings } from './AppearanceSettings'
 import { LogsSettings } from './LogsSettings'
-import { useSaveSettings, useSettings } from './Settings.hooks'
-
-type SettingsDialogProps = {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}
+import { useStudioUIStore } from '@/store/ui'
+import { useSaveSettings, useSettings } from '@/hooks/useSettings'
 
 const tabs = [
   { label: 'Proxy', value: 'proxy', component: ProxySettings },
@@ -41,10 +37,12 @@ const tabs = [
   },
 ]
 
-export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
+export const SettingsDialog = () => {
   const { data: settings } = useSettings()
+  const isOpen = useStudioUIStore((state) => state.isSettingsDialogOpen)
+  const setIsOpen = useStudioUIStore((state) => state.setIsSettingsDialogOpen)
   const { mutateAsync: saveSettings, isPending } = useSaveSettings(() => {
-    onOpenChange(false)
+    setIsOpen(false)
   })
   const [selectedTab, setSelectedTab] = useState('proxy')
 
@@ -71,11 +69,11 @@ export const SettingsDialog = ({ open, onOpenChange }: SettingsDialogProps) => {
   const handleOpenChange = () => {
     reset(settings)
     setSelectedTab('proxy')
-    onOpenChange(!open)
+    setIsOpen(!isOpen)
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
       <Dialog.Content
         maxWidth="800px"
         maxHeight="640px"

--- a/src/components/TextButton.tsx
+++ b/src/components/TextButton.tsx
@@ -8,6 +8,7 @@ export function TextButton({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       data-accent-color=""
       className="rt-Text rt-reset rt-Link rt-underline-auto"

--- a/src/hooks/useProxyStatus.ts
+++ b/src/hooks/useProxyStatus.ts
@@ -1,0 +1,20 @@
+import { useStudioUIStore } from '@/store/ui'
+import { useEffect } from 'react'
+
+export function useProxyStatus() {
+  const status = useStudioUIStore((state) => state.proxyStatus)
+  const setProxyStatus = useStudioUIStore((state) => state.setProxyStatus)
+
+  useEffect(() => {
+    ;(async function fetchProxyStatus() {
+      const status = await window.studio.proxy.getProxyStatus()
+      setProxyStatus(status)
+    })()
+
+    return window.studio.proxy.onProxyStatusChange((status) =>
+      setProxyStatus(status)
+    )
+  }, [setProxyStatus])
+
+  return status
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -28,6 +28,6 @@ export function useSaveSettings(onSuccess?: () => void) {
 export function useBrowserCheck() {
   return useQuery({
     queryKey: ['settings', 'browserCheck'],
-    queryFn: window.studio.ui.checkBrowserPath,
+    queryFn: window.studio.ui.detectBrowser,
   })
 }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -24,3 +24,10 @@ export function useSaveSettings(onSuccess?: () => void) {
     },
   })
 }
+
+export function useBrowserCheck() {
+  return useQuery({
+    queryKey: ['settings', 'browserCheck'],
+    queryFn: window.studio.ui.checkBrowserPath,
+  })
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -509,7 +509,7 @@ ipcMain.on('ui:toggle-theme', () => {
   nativeTheme.themeSource = nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
 })
 
-ipcMain.handle('ui:check-browser-path', () => {
+ipcMain.handle('ui:detect-browser', () => {
   try {
     const browserPath = getBrowserPath()
     return browserPath !== ''

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ import { Process } from '@puppeteer/browsers'
 import { watch, FSWatcher } from 'chokidar'
 
 import { launchProxy, type ProxyProcess } from './proxy'
-import { launchBrowser } from './browser'
+import { getBrowserPath, launchBrowser } from './browser'
 import { runScript, showScriptSelectDialog, type K6Process } from './script'
 import { setupProjectStructure } from './utils/workspace'
 import {
@@ -503,6 +503,17 @@ ipcMain.handle(
 // UI
 ipcMain.on('ui:toggle-theme', () => {
   nativeTheme.themeSource = nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
+})
+
+ipcMain.handle('ui:check-browser-path', () => {
+  try {
+    const browserPath = getBrowserPath()
+    return browserPath !== ''
+  } catch {
+    log.error('Failed to find browser executable')
+  }
+
+  return false
 })
 
 ipcMain.handle('ui:delete-file', async (_, file: StudioFile) => {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -129,6 +129,9 @@ const ui = {
   toggleTheme: () => {
     ipcRenderer.send('ui:toggle-theme')
   },
+  checkBrowserPath: (): Promise<boolean> => {
+    return ipcRenderer.invoke('ui:check-browser-path')
+  },
   openContainingFolder: (file: StudioFile) => {
     ipcRenderer.send('ui:open-folder', file)
   },

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -129,8 +129,8 @@ const ui = {
   toggleTheme: () => {
     ipcRenderer.send('ui:toggle-theme')
   },
-  checkBrowserPath: (): Promise<boolean> => {
-    return ipcRenderer.invoke('ui:check-browser-path')
+  detectBrowser: (): Promise<boolean> => {
+    return ipcRenderer.invoke('ui:detect-browser')
   },
   openContainingFolder: (file: StudioFile) => {
     ipcRenderer.send('ui:open-folder', file)

--- a/src/store/ui/useStudioUIStore.ts
+++ b/src/store/ui/useStudioUIStore.ts
@@ -4,6 +4,7 @@ import { immer } from 'zustand/middleware/immer'
 
 interface State extends FolderContent {
   proxyStatus: ProxyStatus
+  isSettingsDialogOpen: boolean
 }
 
 interface Actions {
@@ -11,6 +12,7 @@ interface Actions {
   removeFile: (file: StudioFile) => void
   setFolderContent: (content: FolderContent) => void
   setProxyStatus: (status: ProxyStatus) => void
+  setIsSettingsDialogOpen: (isOpen: boolean) => void
 }
 
 export type StudioUIStore = State & Actions
@@ -22,6 +24,7 @@ export const useStudioUIStore = create<StudioUIStore>()(
     scripts: new Map(),
     dataFiles: new Map(),
     proxyStatus: 'offline',
+    isSettingsDialogOpen: false,
 
     addFile: (file) =>
       set((state) => {
@@ -69,6 +72,10 @@ export const useStudioUIStore = create<StudioUIStore>()(
     setProxyStatus: (status) =>
       set((state) => {
         state.proxyStatus = status
+      }),
+    setIsSettingsDialogOpen: (isOpen) =>
+      set((state) => {
+        state.isSettingsDialogOpen = isOpen
       }),
   }))
 )

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -18,6 +18,7 @@ import { useProxyStatus } from '@/hooks/useProxyStatus'
 import { useStudioUIStore } from '@/store/ui'
 import { TextButton } from '@/components/TextButton'
 import { useBrowserCheck } from '@/hooks/useSettings'
+import { ProxyStatus } from '@/types'
 
 interface EmptyStateProps {
   isLoading: boolean
@@ -117,7 +118,7 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
           </Flex>
         </FieldGroup>
         <WarningMessage
-          isProxyOnline={proxyStatus === 'online'}
+          proxyStatus={proxyStatus}
           isBrowserInstalled={isBrowserInstalled}
         />
       </form>
@@ -126,12 +127,12 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
 }
 
 interface WarningMessageProps {
-  isProxyOnline: boolean
+  proxyStatus: ProxyStatus
   isBrowserInstalled?: boolean
 }
 
 function WarningMessage({
-  isProxyOnline,
+  proxyStatus,
   isBrowserInstalled,
 }: WarningMessageProps) {
   const setIsSettingsDialogOpen = useStudioUIStore(
@@ -159,7 +160,7 @@ function WarningMessage({
     )
   }
 
-  if (!isProxyOnline) {
+  if (proxyStatus === 'offline') {
     return (
       <Callout.Root>
         <Callout.Icon>
@@ -172,6 +173,17 @@ function WarningMessage({
           <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
         </Callout.Text>
       </Callout.Root>
+    )
+  }
+
+  if (proxyStatus === 'starting') {
+    return (
+      <Flex gap="1" align="center">
+        <Spinner />
+        <Text size="1" color="gray">
+          Proxy is starting
+        </Text>
+      </Flex>
     )
   }
 

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CrossCircledIcon, DiscIcon } from '@radix-ui/react-icons'
+import { DiscIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
 import {
   Button,
   Callout,
@@ -45,7 +45,7 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
     },
     shouldFocusError: false,
   })
-  const canRecord = proxyStatus === 'online' && isBrowserInstalled
+  const canRecord = proxyStatus === 'online' && isBrowserInstalled === true
 
   const onSubmit = ({ url }: RecorderEmptyStateFields) => {
     if (isLoading || !canRecord) {
@@ -116,12 +116,10 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
             </Button>
           </Flex>
         </FieldGroup>
-        {canRecord && (
-          <WarningMessage
-            isProxyOnline={proxyStatus === 'online'}
-            isBrowserInstalled={isBrowserInstalled}
-          />
-        )}
+        <WarningMessage
+          isProxyOnline={proxyStatus === 'online'}
+          isBrowserInstalled={isBrowserInstalled}
+        />
       </form>
     </Flex>
   )
@@ -129,7 +127,7 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
 
 interface WarningMessageProps {
   isProxyOnline: boolean
-  isBrowserInstalled: boolean
+  isBrowserInstalled?: boolean
 }
 
 function WarningMessage({
@@ -144,25 +142,11 @@ function WarningMessage({
     setIsSettingsDialogOpen(true)
   }
 
-  if (!isProxyOnline) {
+  if (isBrowserInstalled === false) {
     return (
       <Callout.Root>
         <Callout.Icon>
-          <CrossCircledIcon />
-        </Callout.Icon>
-        <Callout.Text>
-          Proxy is offline. Check proxy configuration in{' '}
-          <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
-        </Callout.Text>
-      </Callout.Root>
-    )
-  }
-
-  if (!isBrowserInstalled) {
-    return (
-      <Callout.Root>
-        <Callout.Icon>
-          <CrossCircledIcon />
+          <ExclamationTriangleIcon />
         </Callout.Icon>
         <Callout.Text>
           <strong>Supported browser not found</strong>
@@ -170,6 +154,22 @@ function WarningMessage({
           Google Chrome needs to be installed on your machine for the recording
           functionality to work. If the browser is installed, specify the path
           in <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
+        </Callout.Text>
+      </Callout.Root>
+    )
+  }
+
+  if (!isProxyOnline) {
+    return (
+      <Callout.Root>
+        <Callout.Icon>
+          <ExclamationTriangleIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          <strong>Proxy is offline</strong>
+          <br />
+          Check proxy configuration in{' '}
+          <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
         </Callout.Text>
       </Callout.Root>
     )


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/515

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test
For the browser stuff, mock the handler in main.
To test the proxy warning, kill the proxy process.

## Screenshots (if appropriate):
<img width="1304" alt="Screenshot 2025-03-05 at 14 57 32" src="https://github.com/user-attachments/assets/5c80f9ac-6677-4f43-a727-34915c997354" />
<img width="1304" alt="Screenshot 2025-03-05 at 14 53 40" src="https://github.com/user-attachments/assets/d545828b-ae5d-475a-8f1b-b3bccac00c04" />
<img width="1304" alt="Screenshot 2025-03-05 at 14 53 19" src="https://github.com/user-attachments/assets/144ef8b0-ff49-48bb-ae4b-a9e433bae880" />

