### PR TITLE
internal(Load Zones): Generate code for load zones

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -95,7 +95,7 @@ describe('Code generation', () => {
               cloud: {
                 loadZones: {
                   distribution: 'even',
-                  loadZones: [],
+                  zones: [],
                 },
               },
             },
@@ -134,7 +134,7 @@ describe('Code generation', () => {
         cloud: {
           loadZones: {
             distribution: 'even',
-            loadZones: [],
+            zones: [],
           },
         },
       },

--- a/src/codegen/options.test.ts
+++ b/src/codegen/options.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { generateOptions, generateThresholds } from './options'
+import {
+  generateLoadZones,
+  generateOptions,
+  generateThresholds,
+} from './options'
 import {
   LoadProfileExecutorOptions,
   TestOptions,
   Threshold,
 } from '@/types/testOptions'
 import { createThreshold } from '@/test/factories/threshold'
+import { createLoadZone } from '@/test/factories/loadZones'
 
 describe('Code generation - options', () => {
   it('should generate load profile for shared-iterations executor', () => {
@@ -117,4 +122,22 @@ describe('Code generation - thresholds', () => {
 
     expect(generateThresholds(thresholds)).toEqual(expectedResult)
   })
+})
+
+describe('Code generation - load zones', () => {
+  it('should generate load zones correctly', () => {
+    const loadZones = [
+      createLoadZone({ loadZone: 'amazon:us:columbus', percent: 50 }),
+      createLoadZone({ loadZone: 'amazon:br:sao paulo', percent: 50 }),
+    ]
+
+    const expectedResult = {
+      'amazon:us:columbus': { loadZone: 'amazon:us:columbus', percent: 50 },
+      'amazon:br:sao paulo': { loadZone: 'amazon:br:sao paulo', percent: 50 },
+    }
+
+    expect(generateLoadZones(loadZones)).toEqual(expectedResult)
+  })
+
+  it('should not generate load zones if none were added', () => {})
 })

--- a/src/codegen/options.test.ts
+++ b/src/codegen/options.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  generateLoadZones,
+  generateCloudOptions,
   generateOptions,
   generateThresholds,
 } from './options'
 import {
   LoadProfileExecutorOptions,
+  LoadZoneData,
   TestOptions,
   Threshold,
 } from '@/types/testOptions'
@@ -124,20 +125,40 @@ describe('Code generation - thresholds', () => {
   })
 })
 
-describe('Code generation - load zones', () => {
+describe('Code generation - cloud options', () => {
   it('should generate load zones correctly', () => {
-    const loadZones = [
-      createLoadZone({ loadZone: 'amazon:us:columbus', percent: 50 }),
-      createLoadZone({ loadZone: 'amazon:br:sao paulo', percent: 50 }),
-    ]
-
-    const expectedResult = {
-      'amazon:us:columbus': { loadZone: 'amazon:us:columbus', percent: 50 },
-      'amazon:br:sao paulo': { loadZone: 'amazon:br:sao paulo', percent: 50 },
+    const loadZones: LoadZoneData = {
+      distribution: 'even',
+      zones: [
+        createLoadZone({ loadZone: 'amazon:us:columbus', percent: 50 }),
+        createLoadZone({ loadZone: 'amazon:br:sao paulo', percent: 50 }),
+      ],
     }
 
-    expect(generateLoadZones(loadZones)).toEqual(expectedResult)
+    const expectedResult = {
+      cloud: {
+        distribution: {
+          "'amazon:us:columbus'": {
+            loadZone: 'amazon:us:columbus',
+            percent: 50,
+          },
+          "'amazon:br:sao paulo'": {
+            loadZone: 'amazon:br:sao paulo',
+            percent: 50,
+          },
+        },
+      },
+    }
+
+    expect(generateCloudOptions({ loadZones })).toEqual(expectedResult)
   })
 
-  it('should not generate load zones if none were added', () => {})
+  it('should not generate cloud object when load zones are not selected', () => {
+    const loadZones: LoadZoneData = {
+      distribution: 'even',
+      zones: [],
+    }
+
+    expect(generateCloudOptions({ loadZones })).toEqual({})
+  })
 })

--- a/src/codegen/options.ts
+++ b/src/codegen/options.ts
@@ -1,14 +1,16 @@
-import { TestOptions, Threshold } from '@/types/testOptions'
+import { LoadZoneData, TestOptions, Threshold } from '@/types/testOptions'
 import { stringify } from './codegen.utils'
 import { omit } from 'lodash-es'
 
 export function generateOptions({
   loadProfile,
   thresholds,
+  cloud,
 }: TestOptions): string {
   const options = omit(loadProfile, ['executor'])
   const data = {
     ...options,
+    ...(cloud && generateCloudOptions(cloud)),
     ...(thresholds.length > 0 && {
       thresholds: generateThresholds(thresholds),
     }),
@@ -38,6 +40,26 @@ export function generateThresholds(thresholds: Threshold[]) {
     } else {
       result[key].push(thresholdValue)
     }
+  })
+
+  return result
+}
+
+export function generateCloudOptions({ loadZones }: TestOptions['cloud']) {
+  if (loadZones.loadZones.length === 0) return {}
+
+  return {
+    cloud: {
+      distribution: generateLoadZones(loadZones),
+    },
+  }
+}
+
+export function generateLoadZones({ loadZones }: LoadZoneData) {
+  const result: Record<string, { loadZone: string; percent: number }> = {}
+
+  loadZones.forEach(({ loadZone, percent }) => {
+    result[`'${loadZone}'`] = { loadZone, percent }
   })
 
   return result

--- a/src/codegen/options.ts
+++ b/src/codegen/options.ts
@@ -46,16 +46,16 @@ export function generateThresholds(thresholds: Threshold[]) {
 }
 
 export function generateCloudOptions({ loadZones }: TestOptions['cloud']) {
-  if (loadZones.loadZones.length === 0) return {}
+  if (loadZones.zones.length === 0) return {}
 
   return {
     cloud: {
-      distribution: generateLoadZones(loadZones),
+      distribution: generateLoadZones(loadZones.zones),
     },
   }
 }
 
-export function generateLoadZones({ loadZones }: LoadZoneData) {
+export function generateLoadZones(loadZones: LoadZoneData['zones']) {
   const result: Record<string, { loadZone: string; percent: number }> = {}
 
   loadZones.forEach(({ loadZone, percent }) => {

--- a/src/schemas/generator/v0/index.ts
+++ b/src/schemas/generator/v0/index.ts
@@ -26,7 +26,7 @@ export function migrate(generator: GeneratorSchema): v1.GeneratorSchema {
       ...generator.options,
       thresholds: [],
       cloud: {
-        loadZones: { distribution: 'even', loadZones: [] },
+        loadZones: { distribution: 'even', zones: [] },
       },
     },
     testData: { ...generator.testData, files: [] },

--- a/src/schemas/generator/v1/loadZone.ts
+++ b/src/schemas/generator/v1/loadZone.ts
@@ -36,7 +36,7 @@ export const LoadZoneItemSchema = z.object({
 
 export const LoadZoneSchema = z.object({
   distribution: z.enum(['even', 'manual']),
-  loadZones: z.array(LoadZoneItemSchema).refine(
+  zones: z.array(LoadZoneItemSchema).refine(
     (data) => {
       if (data.length === 0) {
         return true

--- a/src/schemas/generator/v1/loadZone.ts
+++ b/src/schemas/generator/v1/loadZone.ts
@@ -27,7 +27,11 @@ export const AvailableLoadZonesSchema = z.enum([
 export const LoadZoneItemSchema = z.object({
   id: z.string(),
   loadZone: AvailableLoadZonesSchema,
-  percent: z.number().int().min(1, { message: 'Invalid percentage' }).max(100),
+  percent: z
+    .number({ message: 'Invalid percentage' })
+    .int()
+    .min(1, { message: 'Invalid percentage' })
+    .max(100, { message: 'Invalid percentage' }),
 })
 
 export const LoadZoneSchema = z.object({
@@ -38,12 +42,19 @@ export const LoadZoneSchema = z.object({
         return true
       }
 
-      const totalPercentage = data.reduce(
-        (sum, { percent }) => sum + percent,
-        0
-      )
+      const totalPercentage = currentLoadZonePercentage(data)
       return totalPercentage === 100
     },
-    { message: 'The sum of all distribution percentages must be 100' }
+    (data) => {
+      const totalPercentage = currentLoadZonePercentage(data)
+      return {
+        message: `Total percentage must be 100, currently ${totalPercentage}`,
+        path: ['root'],
+      }
+    }
   ),
 })
+
+function currentLoadZonePercentage(data: { percent: number }[]) {
+  return data.reduce((sum, { percent }) => sum + percent, 0)
+}

--- a/src/schemas/generator/v1/testOptions.ts
+++ b/src/schemas/generator/v1/testOptions.ts
@@ -73,5 +73,5 @@ export const TestOptionsSchema = z.object({
     .object({
       loadZones: LoadZoneSchema,
     })
-    .default({ loadZones: { distribution: 'even', loadZones: [] } }),
+    .default({ loadZones: { distribution: 'even', zones: [] } }),
 })

--- a/src/store/generator/slices/testOptions/loadZones.ts
+++ b/src/store/generator/slices/testOptions/loadZones.ts
@@ -12,7 +12,7 @@ interface Actions {
 export type LoadZoneStore = State & Actions
 
 export const createLoadZoneSlice: ImmerStateCreator<LoadZoneStore> = (set) => ({
-  loadZones: { distribution: 'even', loadZones: [] },
+  loadZones: { distribution: 'even', zones: [] },
   setLoadZones: (loadZones: LoadZoneData) =>
     set((state) => {
       state.loadZones = loadZones

--- a/src/test/factories/generator.ts
+++ b/src/test/factories/generator.ts
@@ -24,7 +24,7 @@ export function createGeneratorData(
       cloud: {
         loadZones: {
           distribution: 'even',
-          loadZones: [],
+          zones: [],
         },
       },
     },
@@ -106,7 +106,7 @@ export function createGeneratorState(
 
     loadZones: {
       distribution: 'even',
-      loadZones: [],
+      zones: [],
     },
     setLoadZones: vi.fn(),
 

--- a/src/test/factories/loadZones.ts
+++ b/src/test/factories/loadZones.ts
@@ -1,0 +1,10 @@
+import { LoadZoneItem } from '@/types/testOptions'
+
+export function createLoadZone(loadZone?: Partial<LoadZoneItem>): LoadZoneItem {
+  return {
+    id: crypto.randomUUID(),
+    loadZone: 'amazon:us:columbus',
+    percent: 50,
+    ...loadZone,
+  }
+}

--- a/src/utils/generator.ts
+++ b/src/utils/generator.ts
@@ -22,7 +22,7 @@ export function createNewGeneratorFile(recordingPath = ''): GeneratorFileData {
       cloud: {
         loadZones: {
           distribution: 'even',
-          loadZones: [],
+          zones: [],
         },
       },
     },

--- a/src/views/Generator/TestOptions/LoadZones/LoadZoneRow.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZoneRow.tsx
@@ -12,7 +12,7 @@ import { LOAD_ZONES_REGIONS_OPTIONS } from './LoadZones.utils'
 
 type LoadZoneRowProps = {
   index: number
-  field: FieldArrayWithId<LoadZoneData, 'loadZones', 'id'>
+  field: FieldArrayWithId<LoadZoneData, 'zones', 'id'>
   remove: UseFieldArrayRemove
 }
 
@@ -24,13 +24,13 @@ export function LoadZoneRow({ field, index, remove }: LoadZoneRowProps) {
     watch,
   } = useFormContext<LoadZoneData>()
 
-  const { distribution, loadZones } = watch()
+  const { distribution, zones } = watch()
 
   // Disable load zone options that are already in use
   const getLoadZoneOptions = () => {
     return LOAD_ZONES_REGIONS_OPTIONS.map((option) => ({
       ...option,
-      disabled: loadZones.some(
+      disabled: zones.some(
         (zone, i) => zone.loadZone === option.value && i !== index
       ),
     }))
@@ -39,23 +39,23 @@ export function LoadZoneRow({ field, index, remove }: LoadZoneRowProps) {
   return (
     <Table.Row key={field.id}>
       <Table.Cell>
-        <FieldGroup errors={errors} name={`loadZones.${index}.loadZone`} mb="0">
+        <FieldGroup errors={errors} name={`zones.${index}.loadZone`} mb="0">
           <ControlledSelect
             control={control}
-            name={`loadZones.${index}.loadZone`}
+            name={`zones.${index}.loadZone`}
             options={getLoadZoneOptions()}
           />
         </FieldGroup>
       </Table.Cell>
       <Table.Cell>
-        <FieldGroup errors={errors} name={`loadZones.${index}.percent`} mb="0">
+        <FieldGroup errors={errors} name={`zones.${index}.percent`} mb="0">
           <TextField.Root
             type="number"
             min="1"
             max="100"
             placeholder="value"
             disabled={distribution === 'even'}
-            {...register(`loadZones.${index}.percent`, { valueAsNumber: true })}
+            {...register(`zones.${index}.percent`, { valueAsNumber: true })}
           >
             <TextField.Slot side="right">%</TextField.Slot>
           </TextField.Root>

--- a/src/views/Generator/TestOptions/LoadZones/LoadZoneRow.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZoneRow.tsx
@@ -51,6 +51,8 @@ export function LoadZoneRow({ field, index, remove }: LoadZoneRowProps) {
         <FieldGroup errors={errors} name={`loadZones.${index}.percent`} mb="0">
           <TextField.Root
             type="number"
+            min="1"
+            max="100"
             placeholder="value"
             disabled={distribution === 'even'}
             {...register(`loadZones.${index}.percent`, { valueAsNumber: true })}

--- a/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
@@ -48,10 +48,10 @@ export function LoadZones() {
 
   const { append, remove, fields } = useFieldArray<LoadZoneData>({
     control,
-    name: 'loadZones',
+    name: 'zones',
   })
 
-  const { distribution, loadZones: usedLoadZones } = watch()
+  const { distribution, zones: usedLoadZones } = watch()
 
   const handleOpenDocs = (event: React.MouseEvent) => {
     event.preventDefault()
@@ -93,7 +93,7 @@ export function LoadZones() {
     fields.forEach((_, index) => {
       // ensure only integers are used
       const percent = index < remainder ? basePercent + 1 : basePercent
-      setValue(`loadZones.${index}.percent`, percent)
+      setValue(`zones.${index}.percent`, percent)
     })
   }, [distribution, fields, setValue])
 
@@ -125,7 +125,7 @@ export function LoadZones() {
           </Text>
         </FieldGroup>
 
-        {errors.loadZones?.root && <LoadZonePercentageError />}
+        {errors.zones?.root && <LoadZonePercentageError />}
 
         <Table.Root size="1" variant="surface" layout="fixed">
           <Table.Header>
@@ -186,7 +186,7 @@ function LoadZonePercentageError() {
         <Cross1Icon />
       </Callout.Icon>
 
-      <Callout.Text>{errors.loadZones?.root?.message}</Callout.Text>
+      <Callout.Text>{errors.zones?.root?.message}</Callout.Text>
     </Callout.Root>
   )
 }

--- a/src/views/Generator/TestOptions/LoadZones/LoadZones.utils.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZones.utils.tsx
@@ -75,9 +75,7 @@ export const LOAD_ZONES_REGIONS_OPTIONS = loadZoneOptionsMap.map(
   })
 )
 
-export const findUnusedLoadZone = (
-  usedLoadZones: LoadZoneData['loadZones']
-) => {
+export const findUnusedLoadZone = (usedLoadZones: LoadZoneData['zones']) => {
   const usedLoadZonesNames = usedLoadZones.map((item) => item.loadZone)
 
   return (
@@ -87,9 +85,7 @@ export const findUnusedLoadZone = (
   )
 }
 
-export const getRemainingPercentage = (
-  loadZones: LoadZoneData['loadZones']
-) => {
+export const getRemainingPercentage = (loadZones: LoadZoneData['zones']) => {
   const totalPercentage = loadZones.reduce(
     (sum, { percent }) => sum + percent,
     0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR continues the implementation of the Load Zones features and includes:

- improved error messaging
- renamed `loadZones.loadZones` in the generator to `loadZones.zones` for better DX
- code generation

The following are still pending:

🛠️ some type of messaging is needed in the Load Zones tab when users are not authenticated with Cloud
🛠️ improve UX in regards to the Even/Manual button as raised in https://github.com/grafana/k6-studio/pull/518

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- enable the "load-zones" feature
- add/remove load zones and check that the code is properly generated
- (optional) run the script in Grafana cloud

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/ab05f917-3c80-4b12-8241-e6d985e44b3d


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
