### PR TITLE
feat: Add a way to import data files directly from Test Data popover

### DIFF
--- a/src/hooks/useImportDataFile.ts
+++ b/src/hooks/useImportDataFile.ts
@@ -7,7 +7,16 @@ export function useImportDataFile() {
 
   return useCallback(async () => {
     try {
-      await window.studio.data.importFile()
+      const fileName = await window.studio.data.importFile()
+
+      if (fileName) {
+        showToast({
+          title: `Imported ${fileName}`,
+          status: 'success',
+        })
+      }
+
+      return fileName
     } catch (error) {
       showToast({
         title: 'Failed to import data file',

--- a/src/hooks/useImportDataFile.ts
+++ b/src/hooks/useImportDataFile.ts
@@ -1,9 +1,13 @@
-import { useToast } from '@/store/ui/useToast'
-import log from 'electron-log/renderer'
 import { useCallback } from 'react'
+import log from 'electron-log/renderer'
+
+import { useStudioUIStore } from '@/store/ui'
+import { useToast } from '@/store/ui/useToast'
+import { getFileNameWithoutExtension } from '@/utils/file'
 
 export function useImportDataFile() {
   const showToast = useToast()
+  const addFile = useStudioUIStore((state) => state.addFile)
 
   return useCallback(async () => {
     try {
@@ -13,6 +17,15 @@ export function useImportDataFile() {
         showToast({
           title: `Imported ${fileName}`,
           status: 'success',
+        })
+
+        // There's a slight delay between the import handler and the add callback being triggered,
+        // causing the UI in Test data options to flicker because it thinks the imported file
+        // is actually missing. To prevent this, we optimistically update the file list.
+        addFile({
+          type: 'data-file',
+          fileName,
+          displayName: getFileNameWithoutExtension(fileName),
         })
       }
 
@@ -24,5 +37,5 @@ export function useImportDataFile() {
       })
       log.error(error)
     }
-  }, [showToast])
+  }, [addFile, showToast])
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ import { DataFilePreview } from './types/testData'
 import { parseDataFile } from './utils/dataFile'
 import { createNewGeneratorFile } from './utils/generator'
 import { GeneratorFileDataSchema } from './schemas/generator'
+import { COPYFILE_EXCL } from 'constants'
 
 if (process.env.NODE_ENV !== 'development') {
   // handle auto updates
@@ -622,7 +623,11 @@ ipcMain.handle('data-file:import', async (event) => {
   const { size } = await stat(filePath)
   invariant(size <= MAX_DATA_FILE_SIZE, 'File is too large')
 
-  await copyFile(filePath, path.join(DATA_FILES_PATH, path.basename(filePath)))
+  await copyFile(
+    filePath,
+    path.join(DATA_FILES_PATH, path.basename(filePath)),
+    COPYFILE_EXCL
+  )
 
   return path.basename(filePath)
 })

--- a/src/script.ts
+++ b/src/script.ts
@@ -151,10 +151,17 @@ export const archiveScript = (
   browserWindow: BrowserWindow
 ): Promise<string> => {
   return new Promise((resolve, reject) => {
-    const k6Args = ['archive', scriptPath, '-O', TEMP_K6_ARCHIVE_PATH]
+    const k6Args = [
+      'archive',
+      scriptPath,
+      '-O',
+      TEMP_K6_ARCHIVE_PATH,
+      '--log-format=json',
+    ]
 
     spawnK6({
       args: k6Args,
+      onStdErr: createLogsHandler(browserWindow),
       onClose: (code) => {
         if (code === 0) {
           resolve(TEMP_K6_ARCHIVE_PATH)

--- a/src/views/Generator/TestData/DataFiles.tsx
+++ b/src/views/Generator/TestData/DataFiles.tsx
@@ -5,6 +5,7 @@ import { useStudioUIStore } from '@/store/ui'
 import { DataFile } from '@/types/testData'
 import { css } from '@emotion/react'
 import {
+  ExclamationTriangleIcon,
   FilePlusIcon,
   InfoCircledIcon,
   PlusIcon,
@@ -83,22 +84,38 @@ function DataFileRow({ file, onRemove }: DataFileRowProps) {
     )
   )
 
+  const isFileMissing = useStudioUIStore(
+    (store) => !store.dataFiles.has(file.name)
+  )
+
   return (
     <Table.Row
       css={css`
         vertical-align: middle;
       `}
     >
-      <Table.Cell>{file.name}</Table.Cell>
+      <Table.Cell>
+        <Flex align="center" gap="1">
+          {isFileMissing && (
+            <Tooltip content="Data file is missing">
+              <ExclamationTriangleIcon
+                color="red"
+                aria-label="Data file is missing"
+              />
+            </Tooltip>
+          )}
+          {file.name}
+        </Flex>
+      </Table.Cell>
       <Table.Cell>Unique item per iteration</Table.Cell>
       <Table.Cell>
         <Tooltip
           content="Data file is referenced in a rule"
-          hidden={!isFileInUse}
+          hidden={!isFileInUse && !isFileMissing}
         >
           <IconButton
             aria-label="Remove"
-            disabled={isFileInUse}
+            disabled={isFileInUse && !isFileMissing}
             onClick={onRemove}
           >
             <TrashIcon width="18" height="18" />

--- a/src/views/Generator/TestData/DataFiles.tsx
+++ b/src/views/Generator/TestData/DataFiles.tsx
@@ -1,9 +1,15 @@
 import { Table } from '@/components/Table'
+import { useImportDataFile } from '@/hooks/useImportDataFile'
 import { useGeneratorStore } from '@/store/generator'
 import { useStudioUIStore } from '@/store/ui'
 import { DataFile } from '@/types/testData'
 import { css } from '@emotion/react'
-import { InfoCircledIcon, PlusIcon, TrashIcon } from '@radix-ui/react-icons'
+import {
+  FilePlusIcon,
+  InfoCircledIcon,
+  PlusIcon,
+  TrashIcon,
+} from '@radix-ui/react-icons'
 import {
   Button,
   DropdownMenu,
@@ -14,16 +20,8 @@ import {
 } from '@radix-ui/themes'
 
 export function DataFiles() {
-  const availableFiles = useStudioUIStore((store) => store.dataFiles)
   const selectedFiles = useGeneratorStore((store) => store.files)
   const setFiles = useGeneratorStore((store) => store.setFiles)
-  const options = [...availableFiles.values()].filter(
-    (file) => !selectedFiles.find((f) => f.name === file.fileName)
-  )
-
-  const handleAdd = (fileName: string) => {
-    setFiles([...selectedFiles, { name: fileName }])
-  }
 
   const handleRemove = (fileName: string) => {
     setFiles(selectedFiles.filter((file) => file.name !== fileName))
@@ -58,29 +56,12 @@ export function DataFiles() {
               onRemove={() => handleRemove(file.name)}
             />
           ))}
-          {options.length > 0 && (
-            <Table.Row>
-              <Table.RowHeaderCell colSpan={3} justify="center">
-                <DropdownMenu.Root>
-                  <DropdownMenu.Trigger>
-                    <Button variant="ghost">
-                      Add data file <PlusIcon />
-                    </Button>
-                  </DropdownMenu.Trigger>
-                  <DropdownMenu.Content>
-                    {options.map((file) => (
-                      <DropdownMenu.Item
-                        key={file.fileName}
-                        onClick={() => handleAdd(file.fileName)}
-                      >
-                        {file.fileName}
-                      </DropdownMenu.Item>
-                    ))}
-                  </DropdownMenu.Content>
-                </DropdownMenu.Root>
-              </Table.RowHeaderCell>
-            </Table.Row>
-          )}
+
+          <Table.Row>
+            <Table.RowHeaderCell colSpan={3} justify="center">
+              <AddDataFileDropdown />
+            </Table.RowHeaderCell>
+          </Table.Row>
         </Table.Body>
       </Table.Root>
     </>
@@ -125,5 +106,54 @@ function DataFileRow({ file, onRemove }: DataFileRowProps) {
         </Tooltip>
       </Table.Cell>
     </Table.Row>
+  )
+}
+
+function AddDataFileDropdown() {
+  const setFiles = useGeneratorStore((store) => store.setFiles)
+  const availableFiles = useStudioUIStore((store) => store.dataFiles)
+  const selectedFiles = useGeneratorStore((store) => store.files)
+
+  const options = [...availableFiles.values()].filter(
+    (file) => !selectedFiles.find((f) => f.name === file.fileName)
+  )
+
+  const handleAdd = (fileName: string) => {
+    setFiles([...selectedFiles, { name: fileName }])
+  }
+
+  const importDataFile = useImportDataFile()
+
+  const handleImportDataFile = async () => {
+    const fileName = await importDataFile()
+
+    if (fileName) {
+      handleAdd(fileName)
+    }
+  }
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <Button variant="ghost">
+          Add data file <PlusIcon />
+        </Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        {options.map((file) => (
+          <DropdownMenu.Item
+            key={file.fileName}
+            onClick={() => handleAdd(file.fileName)}
+          >
+            {file.fileName}
+          </DropdownMenu.Item>
+        ))}
+        {options.length > 0 && <DropdownMenu.Separator />}
+        <DropdownMenu.Item onClick={handleImportDataFile}>
+          <FilePlusIcon />
+          Import new data file
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   )
 }

--- a/src/views/Generator/TestData/DataFiles.tsx
+++ b/src/views/Generator/TestData/DataFiles.tsx
@@ -136,6 +136,8 @@ function AddDataFileDropdown() {
   )
 
   const handleAdd = (fileName: string) => {
+    if (selectedFiles.find((file) => file.name === fileName)) return
+
     setFiles([...selectedFiles, { name: fileName }])
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add a way to import data files directly from the Test Data popover
* Show a toast on success

## How to Test
Try importing a data file from the test data popover

## Screenshots (if appropriate):
<img width="500" alt="image" src="https://github.com/user-attachments/assets/3f04d815-6ed2-4203-a8ae-b5d8028a94b5" />

