### PR TITLE
fix: Renaming generator with unsaved changes creates extra file

### DIFF
--- a/src/components/FileTree/File.hooks.ts
+++ b/src/components/FileTree/File.hooks.ts
@@ -14,7 +14,7 @@ export function useRenameFile(file: StudioFile) {
   return useMutation({
     mutationFn: (newName: string) =>
       window.studio.ui.renameFile(file.fileName, newName, file.type),
-    onSuccess: async (_, newName) => {
+    onSuccess: (_, newName) => {
       // There's a slight delay between the add and remove callbacks being triggered,
       // causing the UI to flicker because it thinks the renamed file is actually
       // a new file. To prevent this, we optimistically update the file list.
@@ -39,12 +39,6 @@ export function useRenameFile(file: StudioFile) {
       }
 
       navigate(getViewPath(file.type, newName), { replace: true })
-
-      if (file.type === 'generator') {
-        await queryClient.invalidateQueries({
-          queryKey: ['generator', file.fileName],
-        })
-      }
     },
   })
 }

--- a/src/components/FileTree/File.hooks.ts
+++ b/src/components/FileTree/File.hooks.ts
@@ -1,16 +1,20 @@
 import { useStudioUIStore } from '@/store/ui'
 import { StudioFile } from '@/types'
-import { getFileNameWithoutExtension } from '@/utils/file'
+import { getFileNameWithoutExtension, getViewPath } from '@/utils/file'
+import { queryClient } from '@/utils/query'
 import { useMutation } from '@tanstack/react-query'
+import { useNavigate, useParams } from 'react-router-dom'
 
 export function useRenameFile(file: StudioFile) {
+  const { fileName: selectedFileName } = useParams()
+  const navigate = useNavigate()
   const addFile = useStudioUIStore((state) => state.addFile)
   const removeFile = useStudioUIStore((state) => state.removeFile)
 
   return useMutation({
     mutationFn: (newName: string) =>
       window.studio.ui.renameFile(file.fileName, newName, file.type),
-    onSuccess: (_, newName) => {
+    onSuccess: async (_, newName) => {
       // There's a slight delay between the add and remove callbacks being triggered,
       // causing the UI to flicker because it thinks the renamed file is actually
       // a new file. To prevent this, we optimistically update the file list.
@@ -19,8 +23,26 @@ export function useRenameFile(file: StudioFile) {
         displayName: getFileNameWithoutExtension(newName),
         fileName: newName,
       }
+
       removeFile(file)
       addFile(updatedFile)
+
+      if (file.type === 'generator') {
+        queryClient.setQueryData(
+          ['generator', newName],
+          queryClient.getQueryData(['generator', file.fileName])
+        )
+      }
+
+      if (selectedFileName === file.fileName) {
+        navigate(getViewPath(file.type, newName), { replace: true })
+      }
+
+      if (file.type === 'generator') {
+        await queryClient.invalidateQueries({
+          queryKey: ['generator', file.fileName],
+        })
+      }
     },
   })
 }

--- a/src/components/FileTree/File.hooks.ts
+++ b/src/components/FileTree/File.hooks.ts
@@ -27,6 +27,10 @@ export function useRenameFile(file: StudioFile) {
       removeFile(file)
       addFile(updatedFile)
 
+      if (selectedFileName !== file.fileName) {
+        return
+      }
+
       if (file.type === 'generator') {
         queryClient.setQueryData(
           ['generator', newName],
@@ -34,9 +38,7 @@ export function useRenameFile(file: StudioFile) {
         )
       }
 
-      if (selectedFileName === file.fileName) {
-        navigate(getViewPath(file.type, newName), { replace: true })
-      }
+      navigate(getViewPath(file.type, newName), { replace: true })
 
       if (file.type === 'generator') {
         await queryClient.invalidateQueries({

--- a/src/components/FileTree/File.tsx
+++ b/src/components/FileTree/File.tsx
@@ -90,7 +90,7 @@ function EditableFile({
     setEditMode(false)
 
     if (isSelected) {
-      navigate(getViewPath(file.type, newFileName))
+      navigate(getViewPath(file.type, newFileName), { replace: true })
     }
   }
 


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/506

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test
1. Open a generator
2. Change its configuration (the easiest thing to do might be disabling a rule)
3. Try renaming the file - it should work without creating an extra file

