### PR TITLE
feat: add support for Chromium on all platforms

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -13,6 +13,7 @@ import { appSettings } from './main'
 import { exec, spawn } from 'child_process'
 import { getPlatform } from './utils/electron'
 import log from 'electron-log/main'
+import { promisify } from 'util'
 
 const createUserDataDir = async () => {
   return mkdtemp(path.join(os.tmpdir(), 'k6-studio-'))
@@ -21,19 +22,21 @@ const createUserDataDir = async () => {
 export async function getBrowserPath() {
   const { recorder } = appSettings
 
-  if (recorder.detectBrowserPath) {
-    if (getPlatform() === 'linux' && process.arch === 'arm64') {
-      // Chrome is not available for arm64, use Chromium instead
-      return await getChromiumPath()
-    }
-
-    return computeSystemExecutablePath({
-      browser: Browser.CHROME,
-      channel: ChromeReleaseChannel.STABLE,
-    })
+  if (!recorder.detectBrowserPath) {
+    return recorder.browserPath || ''
   }
 
-  return recorder.browserPath as string
+  const chromePath = getChromePath()
+  if (chromePath) {
+    return chromePath
+  }
+
+  const chromiumPath = await getChromiumPath()
+  if (chromiumPath) {
+    return chromiumPath
+  }
+
+  throw new Error('Could not detect Chrome or Chromium browser')
 }
 
 export const launchBrowser = async (
@@ -94,19 +97,34 @@ export const launchBrowser = async (
   })
 }
 
-function getChromiumPath(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    exec('which chromium', (error, stdout, stderr) => {
-      if (error) {
-        log.error(error)
-        return reject(error)
-      }
-      if (stderr) {
-        log.error(stderr)
-        return reject(stderr)
-      }
-
-      return resolve(stdout.trim())
+function getChromePath() {
+  try {
+    return computeSystemExecutablePath({
+      browser: Browser.CHROME,
+      channel: ChromeReleaseChannel.STABLE,
     })
-  })
+  } catch (e) {
+    log.error(e)
+    return undefined
+  }
+}
+
+async function getChromiumPath() {
+  try {
+    // on Windows, the Chromium executable is called `chrome.exe`
+    const command =
+      getPlatform() === 'win' ? 'where chrome' : 'command -v chromium'
+
+    const { stdout, stderr } = await promisify(exec)(command)
+
+    if (stderr) {
+      log.error(stderr)
+      return undefined
+    }
+
+    return stdout.trim()
+  } catch (error) {
+    log.error(error)
+    return undefined
+  }
 }

--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -57,7 +57,7 @@ export const RecorderSettings = () => {
         name="recorder.browserPath"
         onSelectFile={handleSelectFile}
         buttonText="Select executable"
-        hint="Google Chrome needs to be installed on your machine for the recording functionality to work"
+        hint="Google Chrome or Chromium need to be installed on your machine for the recording functionality to work"
         disabled={recorder.detectBrowserPath}
       />
     </SettingsSection>

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -152,9 +152,10 @@ function WarningMessage({
         <Callout.Text>
           <strong>Supported browser not found</strong>
           <br />
-          Google Chrome needs to be installed on your machine for the recording
-          functionality to work. If the browser is installed, specify the path
-          in <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
+          Google Chrome or Chromium need to be installed on your machine for the
+          recording functionality to work. If the browser is installed, specify
+          the path in{' '}
+          <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
         </Callout.Text>
       </Callout.Root>
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR extends the Linux PR https://github.com/grafana/k6-studio/pull/513 and makes Chromium the second default browser for all platforms.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Install Chromium
- Change the order of browser detection in `browser.ts` to make sure Chromium is detected
- On Windows, Chromium needs to be available in the system's `$PATH` for it to be detected. Once it's added, restart your terminal and relaunch the application `npm start`

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/533

<!-- Thanks for your contribution! 🙏🏼 -->
