### PR TITLE
internal: Fixed requests to access secrets.

### DIFF
--- a/src/handlers/auth/states.ts
+++ b/src/handlers/auth/states.ts
@@ -7,7 +7,7 @@ import {
   SignInResult,
   Stack,
 } from '@/types/auth'
-import { safeStorage, shell } from 'electron'
+import { shell } from 'electron'
 import { waitFor } from '../utils'
 import { fetchPersonalToken } from '@/services/k6'
 import { getProfileData, saveProfileData } from './fs'
@@ -243,10 +243,6 @@ export class SignInStateMachine extends EventEmitter<StateEventMap> {
       }
     }
 
-    const encryptedToken = safeStorage
-      .encryptString(apiTokenResponse.token)
-      .toString('base64')
-
     const profileData = await getProfileData()
 
     const stackInfo: StackInfo = {
@@ -263,7 +259,7 @@ export class SignInStateMachine extends EventEmitter<StateEventMap> {
       version: '1.0',
       tokens: {
         ...profileData.tokens,
-        [stack.id]: encryptedToken,
+        [stack.id]: apiTokenResponse.token,
       },
       profiles: {
         ...profileData.profiles,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes encryption using `safeStorage` because the user was constantly prompted to give permission for the application to use it.


> #### Note: this is technically a breaking change. You will need to sign in and out before using the account in the upcoming cloud run feature.

## How to Test

Login to a stack.


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
