### PR TITLE
feat: migrate generator extension json -> k6g

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,16 +120,22 @@ initializeLogger()
 // Used to convert `.json` files into the appropriate file extension for the Generator
 async function migrateJsonGenerator() {
   const items = await readdir(GENERATORS_PATH, { withFileTypes: true })
-  const files = items.filter((f) => f.isFile() && path.extname(f.name) === '.json')
+  const files = items.filter(
+    (f) => f.isFile() && path.extname(f.name) === '.json'
+  )
 
   await Promise.all(
     files.map(async (f) => {
-      const oldPath = path.join(GENERATORS_PATH, f.name)
-      const newPath = path.join(
-        GENERATORS_PATH,
-        path.parse(f.name).name + '.k6g'
-      )
-      await rename(oldPath, newPath)
+      try {
+        const oldPath = path.join(GENERATORS_PATH, f.name)
+        const newPath = path.join(
+          GENERATORS_PATH,
+          path.parse(f.name).name + '.k6g'
+        )
+        await rename(oldPath, newPath)
+      } catch (error) {
+        log.error(error)
+      }
     })
   )
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,13 +123,13 @@ async function migrateJsonGenerator() {
   const files = items.filter((f) => f.isFile() && path.extname(f.name) === '.json')
 
   await Promise.all(
-    files.map((f) => {
+    files.map(async (f) => {
       const oldPath = path.join(GENERATORS_PATH, f.name)
       const newPath = path.join(
         GENERATORS_PATH,
         path.parse(f.name).name + '.k6g'
       )
-      return rename(oldPath, newPath)
+      await rename(oldPath, newPath)
     })
   )
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ async function migrateJsonGenerator() {
       const oldPath = path.join(GENERATORS_PATH, f.name)
       const newPath = path.join(
         GENERATORS_PATH,
-        path.parse(f.name).name + '.k6gen'
+        path.parse(f.name).name + '.k6g'
       )
       await rename(oldPath, newPath)
     })
@@ -508,7 +508,7 @@ ipcMain.handle('generator:create', async (_, recordingPath: string) => {
   const fileName = await createFileWithUniqueName({
     data: JSON.stringify(generator, null, 2),
     directory: GENERATORS_PATH,
-    ext: '.k6gen',
+    ext: '.k6g',
     prefix: 'Generator',
   })
 
@@ -929,7 +929,7 @@ function getStudioFileFromPath(filePath: string): StudioFile | undefined {
 
   if (
     filePath.startsWith(GENERATORS_PATH) &&
-    path.extname(filePath) === '.k6gen'
+    path.extname(filePath) === '.k6g'
   ) {
     return {
       type: 'generator',

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,9 +119,8 @@ initializeLogger()
 
 // Used to convert `.json` files into the appropriate file extension for the Generator
 async function migrateJsonGenerator() {
-  const files = (
-    await readdir(GENERATORS_PATH, { withFileTypes: true })
-  ).filter((f) => f.isFile() && path.extname(f.name) === '.json')
+  const items = await readdir(GENERATORS_PATH, { withFileTypes: true })
+  const files = items.filter((f) => f.isFile() && path.extname(f.name) === '.json')
 
   await Promise.all(
     files.map(async (f) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,13 +123,13 @@ async function migrateJsonGenerator() {
   const files = items.filter((f) => f.isFile() && path.extname(f.name) === '.json')
 
   await Promise.all(
-    files.map(async (f) => {
+    files.map((f) => {
       const oldPath = path.join(GENERATORS_PATH, f.name)
       const newPath = path.join(
         GENERATORS_PATH,
         path.parse(f.name).name + '.k6g'
       )
-      await rename(oldPath, newPath)
+      return rename(oldPath, newPath)
     })
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
The extension for generator files has been changed from `.json` to `.k6g`.

To facilitate migrations, json files in the Generator folder are automatically transformed into k6g

## How to Test

<!--- Please describe in detail how you tested your changes -->
Open the app, check that your old Generators now have the `.k6g` extension.
**note:** you might want to backup your project folder until this gets merged

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
