### PR TITLE
feat: Add support for Load Zones in Test Options

### DIFF
--- a/src/store/features/useFeaturesStore.ts
+++ b/src/store/features/useFeaturesStore.ts
@@ -9,7 +9,6 @@ interface FeaturesStore {
 
 const defaultFeatures: Record<Feature, boolean> = {
   'dummy-feature': false,
-  'load-zones': false,
 }
 
 export const useFeaturesStore = create<FeaturesStore>()(

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,1 +1,1 @@
-export type Feature = 'dummy-feature' | 'load-zones'
+export type Feature = 'dummy-feature'

--- a/src/views/Generator/TestOptions/TestOptions.tsx
+++ b/src/views/Generator/TestOptions/TestOptions.tsx
@@ -8,7 +8,6 @@ import { VariablesEditor } from '../TestData/VariablesEditor'
 import { PopoverDialog } from '@/components/PopoverDialogs'
 import { Thresholds } from './Thresholds'
 import { LoadZones } from './LoadZones'
-import { Feature } from '@/components/Feature'
 import { useState } from 'react'
 
 export function TestOptions() {
@@ -35,9 +34,7 @@ export function TestOptions() {
             <Tabs.Trigger value="loadProfile">Load profile</Tabs.Trigger>
             <Tabs.Trigger value="thresholds">Thresholds</Tabs.Trigger>
             <Tabs.Trigger value="thinkTime">Think time</Tabs.Trigger>
-            <Feature feature="load-zones">
-              <Tabs.Trigger value="loadZones">Load zones</Tabs.Trigger>
-            </Feature>
+            <Tabs.Trigger value="loadZones">Load zones</Tabs.Trigger>
           </Tabs.List>
           <ScrollArea
             scrollbars="vertical"
@@ -58,11 +55,9 @@ export function TestOptions() {
               <Tabs.Content value="thresholds">
                 <Thresholds />
               </Tabs.Content>
-              <Feature feature="load-zones">
-                <Tabs.Content value="loadZones">
-                  <LoadZones />
-                </Tabs.Content>
-              </Feature>
+              <Tabs.Content value="loadZones">
+                <LoadZones />
+              </Tabs.Content>
             </Box>
           </ScrollArea>
         </Tabs.Root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR removes the feature flag for the Load Zones feature, making it fully available for users.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open a Generator > Test Options
- Add and remove load zones
- Check that load zones are generated in the script
- (Optionally) Test the script in Grafana Cloud

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/455

<!-- Thanks for your contribution! 🙏🏼 -->
