### PR TITLE
fix: Render error when extracting JSON and Arrays in correlation rule

### DIFF
--- a/src/views/Generator/RuleEditor/CorrelationEditor.tsx
+++ b/src/views/Generator/RuleEditor/CorrelationEditor.tsx
@@ -91,7 +91,9 @@ export function CorrelationEditor() {
         {extractedValue && (
           <Text size="2">
             <Text color="gray">Extracted value:</Text>{' '}
-            <Code>{extractedValue}</Code>
+            <pre>
+              <Code>{JSON.stringify(extractedValue, null, 2)}</Code>
+            </pre>
           </Text>
         )}
         {!extractedValue && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue that would cause a rendering error when trying to display the result of extraction with JSON or Array content on a correlation rule.



https://github.com/user-attachments/assets/a2f5dc89-46e1-43f0-95b4-165dc95d4d5c




<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open a generator
- Create a new correlation rule
- Try extracting a JSON or Array property
- Check that the result is properly rendered

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/9f568cd0-b00a-46f1-91c6-1810479623e7



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/542

<!-- Thanks for your contribution! 🙏🏼 -->
