### PR TITLE
feat: Implement keyboard shortcuts for saving generator

### DIFF
--- a/src/hooks/useSaveShortcut.ts
+++ b/src/hooks/useSaveShortcut.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+const useSaveShortcut = (saveCallback: () => Promise<void>) => {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+        event.preventDefault()
+        return saveCallback()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [saveCallback])
+}
+
+export default useSaveShortcut

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -21,6 +21,7 @@ import { getFileNameWithoutExtension } from '@/utils/file'
 import log from 'electron-log/renderer'
 import { ProxyData } from '@/types'
 import { Details } from '@/components/WebLogView/Details'
+import useSaveShortcut from '@/hooks/useSaveShortcut'
 
 export function Generator() {
   const setGeneratorFile = useGeneratorStore((store) => store.setGeneratorFile)
@@ -99,6 +100,8 @@ export function Generator() {
     const generator = selectGeneratorData(useGeneratorStore.getState())
     return saveGenerator(generator)
   }
+
+  useSaveShortcut(handleSaveGenerator)
 
   const handleSaveGeneratorDialog = async () => {
     await handleSaveGenerator()

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -128,7 +128,11 @@ export function Generator() {
   return (
     <View
       title="Generator"
-      subTitle={getFileNameWithoutExtension(fileName)}
+      subTitle={
+        <>
+          {getFileNameWithoutExtension(fileName)} {isDirty && '(edited)'}
+        </>
+      }
       actions={
         <GeneratorControls onSave={handleSaveGenerator} isDirty={isDirty} />
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements logic to save the generator using the cmd+s / ctrl+s shortcut.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open a generator
- Make some changes such as enabling/disabling rules
- Save it using cmd+s or ctrl+s

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/541

<!-- Thanks for your contribution! 🙏🏼 -->
