### PR TITLE
feat: Make it possible to open Settings with specific tab selected

### DIFF
--- a/src/components/Layout/ActivityBar/SettingsButton.tsx
+++ b/src/components/Layout/ActivityBar/SettingsButton.tsx
@@ -3,7 +3,9 @@ import { GearIcon } from '@radix-ui/react-icons'
 import { Tooltip, IconButton } from '@radix-ui/themes'
 
 export function SettingsButton() {
-  const setIsOpen = useStudioUIStore((state) => state.setIsSettingsDialogOpen)
+  const openSettingsDialog = useStudioUIStore(
+    (state) => state.openSettingsDialog
+  )
 
   return (
     <Tooltip content="Settings" side="right">
@@ -11,7 +13,7 @@ export function SettingsButton() {
         area-label="Settings"
         color="gray"
         variant="ghost"
-        onClick={() => setIsOpen(true)}
+        onClick={() => openSettingsDialog()}
       >
         <GearIcon />
       </IconButton>

--- a/src/components/Settings/types.ts
+++ b/src/components/Settings/types.ts
@@ -1,0 +1,6 @@
+export type SettingsTabValue =
+  | 'proxy'
+  | 'recorder'
+  | 'usageReport'
+  | 'appearance'
+  | 'logs'

--- a/src/store/ui/useStudioUIStore.ts
+++ b/src/store/ui/useStudioUIStore.ts
@@ -1,3 +1,4 @@
+import { SettingsTabValue } from '@/components/Settings/types'
 import { FolderContent, ProxyStatus, StudioFile } from '@/types'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
@@ -5,6 +6,7 @@ import { immer } from 'zustand/middleware/immer'
 interface State extends FolderContent {
   proxyStatus: ProxyStatus
   isSettingsDialogOpen: boolean
+  selectedSettingsTab: SettingsTabValue
 }
 
 interface Actions {
@@ -12,7 +14,8 @@ interface Actions {
   removeFile: (file: StudioFile) => void
   setFolderContent: (content: FolderContent) => void
   setProxyStatus: (status: ProxyStatus) => void
-  setIsSettingsDialogOpen: (isOpen: boolean) => void
+  openSettingsDialog: (tab?: SettingsTabValue) => void
+  closeSettingsDialog: () => void
 }
 
 export type StudioUIStore = State & Actions
@@ -25,6 +28,7 @@ export const useStudioUIStore = create<StudioUIStore>()(
     dataFiles: new Map(),
     proxyStatus: 'offline',
     isSettingsDialogOpen: false,
+    selectedSettingsTab: 'proxy',
 
     addFile: (file) =>
       set((state) => {
@@ -73,9 +77,15 @@ export const useStudioUIStore = create<StudioUIStore>()(
       set((state) => {
         state.proxyStatus = status
       }),
-    setIsSettingsDialogOpen: (isOpen) =>
+    openSettingsDialog: (tab) =>
       set((state) => {
-        state.isSettingsDialogOpen = isOpen
+        state.selectedSettingsTab = tab || 'proxy'
+        state.isSettingsDialogOpen = true
+      }),
+    closeSettingsDialog: () =>
+      set((state) => {
+        state.isSettingsDialogOpen = false
+        state.selectedSettingsTab = 'proxy'
       }),
   }))
 )

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -135,12 +135,12 @@ function WarningMessage({
   proxyStatus,
   isBrowserInstalled,
 }: WarningMessageProps) {
-  const setIsSettingsDialogOpen = useStudioUIStore(
-    (state) => state.setIsSettingsDialogOpen
+  const openSettingsDialog = useStudioUIStore(
+    (state) => state.openSettingsDialog
   )
 
   const handleOpenSettings = () => {
-    setIsSettingsDialogOpen(true)
+    openSettingsDialog('recorder')
   }
 
   if (isBrowserInstalled === false) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

This PR changes how the state of the Settings dialog is controlled, allowing it to open with a specific tab selected. This change improves usability in the Recording screen when a browser can't be found or when a browser fails to launch (https://github.com/grafana/k6-studio/pull/535)

## How to Test

- Mock this line to `return false`
https://github.com/grafana/k6-studio/blob/cb5a7758f8b17d692f46b410835603eaec458aa6/src/main.ts#L531
- Open the Recorder and click "Settings"
- Check that the Recorder tab is automatically selected

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/51827e98-8caa-41a0-b577-1be88c504e84



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/525

<!-- Thanks for your contribution! 🙏🏼 -->
