### PR TITLE
build: Configure oauth client and urls for production

### DIFF
--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -29,10 +29,10 @@ export default defineConfig((env) => {
   const define = {
     ...getBuildDefine(forgeEnv),
     ...getDotEnv({
-      GRAFANA_CLIENT_ID: '<tbd>',
-      K6_API_URL: 'https://api.k6.io/v6',
-      MOCK_PERSONAL_API_TOKEN: 'I AM NOT A REAL TOKEN!!!',
+      GRAFANA_CLIENT_ID: 'f97d2ab099ee3747cbc2',
+      K6_API_URL: 'https://api.k6.io/cloud/v6',
       GRAFANA_API_URL: 'https://grafana.com/api',
+      GRAFANA_COM_URL: 'https://grafana.com',
     }),
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR configure the app so that building it will use production environment by default.

## How to Test

Run the app, sign in in to a stack and run a test. The app should:

* Use grafana.com when signing in
* Use grafana.com when trying to sign up
* Open **_yourstack_**.grafana.net when starting a test run

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
