### PR TITLE
feat: Improve spinner visibility in Validator dialog

### DIFF
--- a/src/views/Generator/ValidatorDialog.tsx
+++ b/src/views/Generator/ValidatorDialog.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Dialog, Flex } from '@radix-ui/themes'
+import { Box, Button, Dialog, Flex, Spinner } from '@radix-ui/themes'
 import { css } from '@emotion/react'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -76,7 +76,10 @@ export function ValidatorDialog({
         <Flex direction="column">
           <Dialog.Title>
             <Flex justify="between">
-              Validator
+              <Flex align="center">
+                Validator
+                {isRunning && <Spinner ml="2" />}
+              </Flex>
               <Flex gap="3" justify="end" align="center">
                 <Dialog.Close>
                   <Button variant="outline">Close</Button>

--- a/src/views/Recorder/RequestsSection.tsx
+++ b/src/views/Recorder/RequestsSection.tsx
@@ -4,7 +4,7 @@ import { useAutoScroll } from '@/hooks/useAutoScroll'
 import { Group, ProxyData } from '@/types'
 import { groupProxyData } from '@/utils/groups'
 import { css } from '@emotion/react'
-import { Box, Flex, Heading, ScrollArea } from '@radix-ui/themes'
+import { Box, Flex, Heading, ScrollArea, Spinner } from '@radix-ui/themes'
 import { ReactNode } from 'react'
 import { ClearRequestsButton } from './ClearRequestsButton'
 import { Filter } from '@/components/WebLogView/Filter'
@@ -65,9 +65,12 @@ export function RequestsSection({
               line-height: 24px;
               font-weight: 500;
               padding: var(--space-2);
+              display: flex;
+              align-items: center;
             `}
           >
-            Requests ({filteredRequests.length})
+            Requests ({filteredRequests.length}){' '}
+            {autoScroll && <Spinner ml="2" />}
           </Heading>
           {resetProxyData && (
             <ClearRequestsButton


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

It was reported that the spinner in the validator dialog is not visible as the user's attention is usually focused on the left side of the screen. This PR adds a spinner besides the Validator title, making it easier to identify when a script is running.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

<img width="269" alt="image" src="https://github.com/user-attachments/assets/4edca157-ce60-4460-b6c3-555fa56976a0" />


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/544

<!-- Thanks for your contribution! 🙏🏼 -->
