### PR TITLE
fix(Validator): Scripts with no k6/execution import cannot be run

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -206,7 +206,14 @@ const enhanceScript = async (scriptContent: string) => {
 
   if (httpImportIndex !== -1) {
     scriptLines.splice(httpImportIndex + 1, 0, groupSnippet)
+
+    // TODO: improve check for k6/execution and k6/http imports
+    if (!scriptContent.includes('k6/execution')) {
+      scriptLines.unshift('import execution from "k6/execution"')
+    }
+
     const modifiedScriptContent = scriptLines.join('\n')
+
     return modifiedScriptContent
   } else {
     throw new Error('http import line not found in script')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
