### PR TITLE
fix: race condition when migrating to k6g

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,7 @@ import { ChildProcessWithoutNullStreams } from 'child_process'
 import { COPYFILE_EXCL } from 'constants'
 
 import * as handlers from './handlers'
+import { existsSync } from 'fs'
 
 if (process.env.NODE_ENV !== 'development') {
   // handle auto updates
@@ -119,6 +120,8 @@ initializeLogger()
 
 // Used to convert `.json` files into the appropriate file extension for the Generator
 async function migrateJsonGenerator() {
+  if (!existsSync(GENERATORS_PATH)) return
+
   const items = await readdir(GENERATORS_PATH, { withFileTypes: true })
   const files = items.filter(
     (f) => f.isFile() && path.extname(f.name) === '.json'
@@ -256,13 +259,13 @@ const createWindow = async () => {
 app.whenReady().then(
   async () => {
     await createSplashWindow()
-    await migrateJsonGenerator()
     await initSettings()
     appSettings = await getSettings()
     nativeTheme.themeSource = appSettings.appearance.theme
 
     await sendReport(appSettings.telemetry.usageReport)
     await setupProjectStructure()
+    await migrateJsonGenerator()
     await createWindow()
   },
   (error) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where k6 Studio is unable to open on a fresh install.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Remove (or rename) the k6-studio directory in the Documents folder
- Launch k6 Studio
- Check that no error occurs

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/569

<!-- Thanks for your contribution! 🙏🏼 -->
