### PR TITLE
fix: App not opening after closing on macOS

### DIFF
--- a/src/handlers/auth/index.ts
+++ b/src/handlers/auth/index.ts
@@ -1,12 +1,13 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { ipcMain } from 'electron'
 import { UserProfiles, Profile, StackInfo } from '@/schemas/profile'
 import { SignInResult } from '@/types/auth'
 import log from 'electron-log/main'
 import { AuthHandler, ChangeStackResponse, SignOutResponse } from './types'
 import { getProfileData, saveProfileData } from './fs'
 import { SignInStateMachine } from './states'
+import { browserWindowFromEvent } from '@/utils/electron'
 
-export function initialize(browserWindow: BrowserWindow) {
+export function initialize() {
   ipcMain.handle(AuthHandler.GetProfiles, async (): Promise<UserProfiles> => {
     const profile = await getProfileData()
 
@@ -15,7 +16,8 @@ export function initialize(browserWindow: BrowserWindow) {
 
   let pending: SignInStateMachine | null = null
 
-  ipcMain.handle(AuthHandler.SignIn, async (): Promise<SignInResult> => {
+  ipcMain.handle(AuthHandler.SignIn, async (event): Promise<SignInResult> => {
+    const browserWindow = browserWindowFromEvent(event)
     try {
       if (pending !== null) {
         pending.abort()

--- a/src/handlers/cloud/index.ts
+++ b/src/handlers/cloud/index.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, shell } from 'electron'
+import { ipcMain, shell } from 'electron'
 import { CloudHandlers, RawScript, Script } from './types'
 import { RunInCloudStateMachine } from './states'
 import { basename, extname, isAbsolute, join } from 'path'
@@ -6,6 +6,7 @@ import { SCRIPTS_PATH } from '@/constants/workspace'
 import { getTempScriptName } from '@/script'
 import { rm, writeFile } from 'fs/promises'
 import { logError } from '@/utils/errors'
+import { browserWindowFromEvent } from '@/utils/electron'
 
 async function createTempFile(script: RawScript) {
   const tempFileName = getTempScriptName()
@@ -38,10 +39,11 @@ function toScriptFile(script: Script) {
   }
 }
 
-export function initialize(browserWindow: BrowserWindow) {
+export function initialize() {
   let stateMachine: RunInCloudStateMachine | null = null
 
-  ipcMain.handle(CloudHandlers.Run, async (_event, script: Script) => {
+  ipcMain.handle(CloudHandlers.Run, async (event, script: Script) => {
+    const browserWindow = browserWindowFromEvent(event)
     const file = await toScriptFile(script)
 
     const absolutePath = !isAbsolute(file.path)

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,11 +1,7 @@
-import { BrowserWindow } from 'electron'
 import * as auth from './auth'
 import * as cloud from './cloud'
 
-interface Services {
-  browserWindow: BrowserWindow
-}
-export function initialize({ browserWindow }: Services) {
-  auth.initialize(browserWindow)
-  cloud.initialize(browserWindow)
+export function initialize() {
+  auth.initialize()
+  cloud.initialize()
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import {
   findOpenPort,
   getAppIcon,
   getPlatform,
+  browserWindowFromEvent,
 } from './utils/electron'
 import invariant from 'tiny-invariant'
 import { MAX_DATA_FILE_SIZE, INVALID_FILENAME_CHARS } from './constants/files'
@@ -117,6 +118,7 @@ if (require('electron-squirrel-startup')) {
 }
 
 initializeLogger()
+handlers.initialize()
 
 // Used to convert `.json` files into the appropriate file extension for the Generator
 async function migrateJsonGenerator() {
@@ -208,10 +210,6 @@ const createWindow = async () => {
       preload: path.join(__dirname, 'preload.js'),
       devTools: process.env.NODE_ENV === 'development',
     },
-  })
-
-  handlers.initialize({
-    browserWindow: mainWindow,
   })
 
   configureApplicationMenu()
@@ -800,18 +798,6 @@ async function applySettings(
     appSettings.appearance = modifiedSettings.appearance
     nativeTheme.themeSource = appSettings.appearance.theme
   }
-}
-
-const browserWindowFromEvent = (
-  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent
-) => {
-  const browserWindow = BrowserWindow.fromWebContents(event.sender)
-
-  if (!browserWindow) {
-    throw new Error('failed to obtain browserWindow')
-  }
-
-  return browserWindow
 }
 
 const launchProxyAndAttachEmitter = async (browserWindow: BrowserWindow) => {

--- a/src/utils/electron.ts
+++ b/src/utils/electron.ts
@@ -1,6 +1,6 @@
 import { AddToastPayload } from '@/types/toast'
 import { platform, arch } from 'os'
-import { app, nativeImage, WebContents } from 'electron'
+import { app, BrowserWindow, nativeImage, WebContents } from 'electron'
 import net from 'net'
 import path from 'path'
 
@@ -69,4 +69,16 @@ export function getAppIcon(isDev: boolean) {
     : path.join(process.resourcesPath, 'icons', 'logo.png')
 
   return nativeImage.createFromPath(iconPath)
+}
+
+export const browserWindowFromEvent = (
+  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent
+) => {
+  const browserWindow = BrowserWindow.fromWebContents(event.sender)
+
+  if (!browserWindow) {
+    throw new Error('failed to obtain browserWindow')
+  }
+
+  return browserWindow
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When closing app and trying to open it from menu bar on macOS, the app would crash with error:

![screencapture 2025-03-19 at 11 44 50](https://github.com/user-attachments/assets/10d8fe1b-607c-4f07-b2ea-8f2dfa545d1e)

This happens because we try to initialize handlers again after resuming app, but closing into menu bar doesn't clear handlers. 

To solve it:
- Removed handler initialization dependency on `browserWindow`, read from event instead
- Moved handler initialization into root of main.ts

## Steps to reproduce
1. Start studio
2. Close studio by clicking "x" in the app window
3. Start studio from menu bar

Expected behavior:
App should reopen

Actual behavior:
Nothing happens, error in terminal

## How to Test

Verify all auth/cloud related functionality works as expected.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
