### PR TITLE
fix: Highlight URL search matches in request inspector

### DIFF
--- a/src/components/WebLogView/Filter.hooks.ts
+++ b/src/components/WebLogView/Filter.hooks.ts
@@ -78,6 +78,7 @@ const basicSearchKeys: Array<FuseOptionKey<ProxyData>> = [
   'request.host',
   'request.method',
   'response.statusCode',
+  'request.url',
 ]
 
 const fullSearchKeys: Array<FuseOptionKey<ProxyData>> = [

--- a/src/components/WebLogView/RequestDetails/Headers.tsx
+++ b/src/components/WebLogView/RequestDetails/Headers.tsx
@@ -15,14 +15,19 @@ export function Headers({
       <Strong>General</Strong>
       <DataList.Item>
         <DataList.Label>Request URL</DataList.Label>
-        <DataList.Value>{data.request.url}</DataList.Value>
+        <DataList.Value>
+          <HighlightedText text={data.request.url} matches={matches} />
+        </DataList.Value>
       </DataList.Item>
 
       <DataList.Item>
         <DataList.Label>Request method</DataList.Label>
-        <DataList.Value>{data.request.method}</DataList.Value>
+        <DataList.Value>
+          <HighlightedText text={data.request.method} matches={matches} />
+        </DataList.Value>
       </DataList.Item>
 
+      <Strong>Headers</Strong>
       {data.request.headers.map(([key, value], index) => (
         <DataList.Item key={`${key}_${index}`}>
           <DataList.Label>

--- a/src/components/WebLogView/ResponseDetails/Headers.tsx
+++ b/src/components/WebLogView/ResponseDetails/Headers.tsx
@@ -20,6 +20,7 @@ export function Headers({
         <DataList.Value>{data.response?.statusCode}</DataList.Value>
       </DataList.Item>
 
+      <Strong>Headers</Strong>
       {headers.map(([key, value], index) => (
         <DataList.Item key={`${key}_${index}`}>
           <DataList.Label>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Highlight URL and method in request inspector when searching
- Add "headers" heading to separate general info from headers (similar to devtools)

## How to Test

Search and verify matches are highlighted as expected.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
![screencapture 2025-03-19 at 15 46 24](https://github.com/user-attachments/assets/e4b050c0-6b6f-4973-8844-b5fb3f450519)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Resolves https://github.com/grafana/k6-studio/issues/520

<!-- Thanks for your contribution! 🙏🏼 -->
