### PR TITLE
feat: Ability to control proxy status

### DIFF
--- a/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
+++ b/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
@@ -1,6 +1,12 @@
 import { css } from '@emotion/react'
-import { Link1Icon, LinkBreak1Icon, LinkNone1Icon } from '@radix-ui/react-icons'
-import { Box, Flex, Tooltip } from '@radix-ui/themes'
+import {
+  Link1Icon,
+  LinkBreak1Icon,
+  LinkNone1Icon,
+  PlayIcon,
+  Cross1Icon,
+} from '@radix-ui/react-icons'
+import { Box, DropdownMenu, IconButton, Tooltip } from '@radix-ui/themes'
 
 import type { ProxyStatus } from '@/types'
 import { exhaustive } from '@/utils/typescript'
@@ -16,22 +22,39 @@ export function ProxyStatusIndicator() {
   const status = useProxyStatus()
 
   return (
-    <Tooltip content={`Proxy status: ${status}`} side="right">
-      <Flex position="relative">
-        <ProxyStatusIcon status={status} />
-        <Box
-          position="absolute"
-          width="6px"
-          height="6px"
-          bottom="0"
-          right="0"
-          css={css`
-            background-color: ${COLOR_MAP[status]};
-            border-radius: 50%;
-          `}
-        />
-      </Flex>
-    </Tooltip>
+    <DropdownMenu.Root>
+      <Tooltip content={`Proxy status: ${status}`} side="right">
+        <DropdownMenu.Trigger>
+          <IconButton
+            variant="ghost"
+            color="gray"
+            area-label="Proxy status"
+            css={{ position: 'relative', display: 'flex' }}
+          >
+            <ProxyStatusIcon status={status} />
+            <Box
+              position="absolute"
+              width="6px"
+              height="6px"
+              bottom="6px"
+              right="6px"
+              css={css`
+                background-color: ${COLOR_MAP[status]};
+                border-radius: 50%;
+              `}
+            />
+          </IconButton>
+        </DropdownMenu.Trigger>
+      </Tooltip>
+      <DropdownMenu.Content side="right">
+        <DropdownMenu.Item disabled={['online', 'starting'].includes(status)}>
+          <PlayIcon /> Start
+        </DropdownMenu.Item>
+        <DropdownMenu.Item disabled={['offline', 'starting'].includes(status)}>
+          <Cross1Icon /> Stop
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
   )
 }
 

--- a/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
+++ b/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
@@ -1,12 +1,6 @@
 import { css } from '@emotion/react'
-import {
-  Link1Icon,
-  LinkBreak1Icon,
-  LinkNone1Icon,
-  PlayIcon,
-  Cross1Icon,
-} from '@radix-ui/react-icons'
-import { Box, DropdownMenu, IconButton, Tooltip } from '@radix-ui/themes'
+import { Link1Icon, LinkBreak1Icon, LinkNone1Icon } from '@radix-ui/react-icons'
+import { Box, Flex, IconButton, Tooltip } from '@radix-ui/themes'
 
 import type { ProxyStatus } from '@/types'
 import { exhaustive } from '@/utils/typescript'
@@ -29,46 +23,40 @@ export function ProxyStatusIndicator() {
     return window.studio.proxy.stopProxy()
   }
 
+  const getTooltipContent = () => {
+    if (status === 'online') {
+      return 'Stop proxy'
+    }
+    if (status === 'offline') {
+      return 'Start proxy'
+    }
+    return 'Proxy is starting'
+  }
+
   return (
-    <DropdownMenu.Root>
-      <Tooltip content={`Proxy status: ${status}`} side="right">
-        <DropdownMenu.Trigger>
-          <IconButton
-            variant="ghost"
-            color="gray"
-            area-label="Proxy status"
-            css={{ position: 'relative', display: 'flex' }}
-          >
-            <ProxyStatusIcon status={status} />
-            <Box
-              position="absolute"
-              width="6px"
-              height="6px"
-              bottom="6px"
-              right="6px"
-              css={css`
-                background-color: ${COLOR_MAP[status]};
-                border-radius: 50%;
-              `}
-            />
-          </IconButton>
-        </DropdownMenu.Trigger>
-      </Tooltip>
-      <DropdownMenu.Content side="right">
-        <DropdownMenu.Item
-          onClick={handleProxyStart}
-          disabled={['online', 'starting'].includes(status)}
-        >
-          <PlayIcon /> Start
-        </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={handleProxyStop}
-          disabled={['offline', 'starting'].includes(status)}
-        >
-          <Cross1Icon /> Stop
-        </DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
+    <Tooltip content={getTooltipContent()} side="right">
+      <IconButton
+        variant="ghost"
+        color="gray"
+        onClick={status === 'online' ? handleProxyStop : handleProxyStart}
+        disabled={status === 'starting'}
+      >
+        <Flex position="relative">
+          <ProxyStatusIcon status={status} />
+          <Box
+            position="absolute"
+            width="6px"
+            height="6px"
+            bottom="0"
+            right="0"
+            css={css`
+              background-color: ${COLOR_MAP[status]};
+              border-radius: 50%;
+            `}
+          />
+        </Flex>
+      </IconButton>
+    </Tooltip>
   )
 }
 

--- a/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
+++ b/src/components/Layout/ActivityBar/ProxyStatusIndicator.tsx
@@ -21,6 +21,14 @@ const COLOR_MAP: Record<ProxyStatus, string> = {
 export function ProxyStatusIndicator() {
   const status = useProxyStatus()
 
+  const handleProxyStart = () => {
+    return window.studio.proxy.launchProxy()
+  }
+
+  const handleProxyStop = () => {
+    return window.studio.proxy.stopProxy()
+  }
+
   return (
     <DropdownMenu.Root>
       <Tooltip content={`Proxy status: ${status}`} side="right">
@@ -47,10 +55,16 @@ export function ProxyStatusIndicator() {
         </DropdownMenu.Trigger>
       </Tooltip>
       <DropdownMenu.Content side="right">
-        <DropdownMenu.Item disabled={['online', 'starting'].includes(status)}>
+        <DropdownMenu.Item
+          onClick={handleProxyStart}
+          disabled={['online', 'starting'].includes(status)}
+        >
           <PlayIcon /> Start
         </DropdownMenu.Item>
-        <DropdownMenu.Item disabled={['offline', 'starting'].includes(status)}>
+        <DropdownMenu.Item
+          onClick={handleProxyStop}
+          disabled={['offline', 'starting'].includes(status)}
+        >
           <Cross1Icon /> Stop
         </DropdownMenu.Item>
       </DropdownMenu.Content>

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,7 @@ const PROXY_RETRY_LIMIT = 5
 let proxyRetryCount = 0
 let currentClientRoute = '/'
 let wasAppClosedByClient = false
+let wasProxyStoppedByClient = false
 export let appSettings = defaultSettings
 
 let currentBrowserProcess: Process | ChildProcessWithoutNullStreams | null
@@ -324,6 +325,7 @@ ipcMain.handle('proxy:start', async (event) => {
 
 ipcMain.on('proxy:stop', () => {
   console.info('proxy:stop event received')
+  wasProxyStoppedByClient = true
   return stopProxyProcess()
 })
 
@@ -826,12 +828,21 @@ const launchProxyAndAttachEmitter = async (browserWindow: BrowserWindow) => {
 
   return launchProxy(browserWindow, appSettings.proxy, {
     onReady: () => {
+      wasProxyStoppedByClient = false
       proxyEmitter.emit('status:change', 'online')
       proxyEmitter.emit('ready')
     },
     onFailure: async () => {
-      if (appShuttingDown || proxyStatus === 'starting') {
-        // don't restart the proxy if the app is shutting down or if it's already restarting
+      if (wasProxyStoppedByClient) {
+        proxyEmitter.emit('status:change', 'offline')
+      }
+
+      if (
+        appShuttingDown ||
+        wasProxyStoppedByClient ||
+        proxyStatus === 'starting'
+      ) {
+        // don't restart the proxy if the app is shutting down, manually stopped by client or already restarting
         return
       }
 

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -139,6 +139,10 @@ function WarningMessage({
     (state) => state.openSettingsDialog
   )
 
+  const handleProxyStart = () => {
+    return window.studio.proxy.launchProxy()
+  }
+
   if (isBrowserInstalled === false) {
     return (
       <Callout.Root>
@@ -169,7 +173,8 @@ function WarningMessage({
         <Callout.Text>
           <strong>Proxy is offline</strong>
           <br />
-          Check proxy configuration in{' '}
+          <TextButton onClick={handleProxyStart}>Start proxy</TextButton> or
+          check proxy configuration in{' '}
           <TextButton onClick={() => openSettingsDialog('proxy')}>
             Settings
           </TextButton>

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -139,10 +139,6 @@ function WarningMessage({
     (state) => state.openSettingsDialog
   )
 
-  const handleOpenSettings = () => {
-    openSettingsDialog('recorder')
-  }
-
   if (isBrowserInstalled === false) {
     return (
       <Callout.Root>
@@ -154,7 +150,11 @@ function WarningMessage({
           <br />
           Google Chrome needs to be installed on your machine for the recording
           functionality to work. If the browser is installed, specify the path
-          in <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
+          in{' '}
+          <TextButton onClick={() => openSettingsDialog('recorder')}>
+            Settings
+          </TextButton>
+          .
         </Callout.Text>
       </Callout.Root>
     )
@@ -170,7 +170,10 @@ function WarningMessage({
           <strong>Proxy is offline</strong>
           <br />
           Check proxy configuration in{' '}
-          <TextButton onClick={handleOpenSettings}>Settings</TextButton>.
+          <TextButton onClick={() => openSettingsDialog('proxy')}>
+            Settings
+          </TextButton>
+          .
         </Callout.Text>
       </Callout.Root>
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR implements the ability for users to control the proxy (start or stop) through the sidebar.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

Start and stop the proxy on the sidebar and check that the status changes as expected.

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/27957710-f564-40d7-8c6d-78790ca63f32



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/329

<!-- Thanks for your contribution! 🙏🏼 -->
