### PR TITLE
chore: Use ExternalLink component for docs and GitHub links

### DIFF
--- a/src/ErrorElement.tsx
+++ b/src/ErrorElement.tsx
@@ -9,11 +9,7 @@ import { css } from '@emotion/react'
 
 import GrotCrashed from '@/assets/grot-crashed.svg'
 import { ArrowLeftIcon } from '@radix-ui/react-icons'
-
-const handleCreateIssue = () =>
-  window.studio.browser.openExternalLink(
-    'https://github.com/grafana/k6-studio/issues'
-  )
+import { ExternalLink } from './components/ExternalLink'
 
 const handleOpenLogs = () => {
   window.studio.log.openLogFolder()
@@ -52,9 +48,9 @@ export function ErrorElement() {
         >
           We apologize for the inconvenience. Please help us improve our
           application by reporting this issue on{' '}
-          <RadixLink href="" onClick={handleCreateIssue}>
+          <ExternalLink href="https://github.com/grafana/k6-studio/issues">
             GitHub
-          </RadixLink>{' '}
+          </ExternalLink>{' '}
           and attaching the tail of{' '}
           <RadixLink href="" onClick={handleOpenLogs}>
             your log file

--- a/src/components/Settings/TelemetrySettings.tsx
+++ b/src/components/Settings/TelemetrySettings.tsx
@@ -1,15 +1,11 @@
-import { Flex, Text, Checkbox, Link } from '@radix-ui/themes'
+import { Flex, Text, Checkbox } from '@radix-ui/themes'
 import { Controller, useFormContext } from 'react-hook-form'
 import { SettingsSection } from './SettingsSection'
 import { AppSettings } from '@/types/settings'
+import { ExternalLink } from '../ExternalLink'
 
 export const TelemetrySettings = () => {
   const { control, register } = useFormContext<AppSettings>()
-
-  const handleLinkClick = () =>
-    window.studio.browser.openExternalLink(
-      'https://grafana.com/docs/k6-studio/set-up/usage-collection/'
-    )
 
   return (
     <SettingsSection>
@@ -17,9 +13,9 @@ export const TelemetrySettings = () => {
         <Text size="2" as="label">
           Grafana k6 Studio collects anonymous telemetry data to improve
           performance and user experience.{' '}
-          <Link href="" onClick={handleLinkClick}>
+          <ExternalLink href="https://grafana.com/docs/k6-studio/set-up/usage-collection/">
             Learn more.
-          </Link>
+          </ExternalLink>
         </Text>
       </Flex>
 

--- a/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
@@ -3,15 +3,7 @@ import { LoadZoneSchema } from '@/schemas/generator/v1/loadZone'
 import { useGeneratorStore } from '@/store/generator/useGeneratorStore'
 import { LoadZoneData } from '@/types/testOptions'
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  Text,
-  Link as RadixLink,
-  Button,
-  Switch,
-  Flex,
-  Callout,
-  Tooltip,
-} from '@radix-ui/themes'
+import { Text, Button, Switch, Flex, Callout, Tooltip } from '@radix-ui/themes'
 import { useCallback, useEffect } from 'react'
 import {
   FormProvider,
@@ -27,6 +19,7 @@ import {
   LOAD_ZONES_REGIONS_OPTIONS,
 } from './LoadZones.utils'
 import { Cross1Icon } from '@radix-ui/react-icons'
+import { ExternalLink } from '@/components/ExternalLink'
 
 export function LoadZones() {
   const loadZones = useGeneratorStore((store) => store.loadZones)
@@ -52,13 +45,6 @@ export function LoadZones() {
   })
 
   const { distribution, zones: usedLoadZones } = watch()
-
-  const handleOpenDocs = (event: React.MouseEvent) => {
-    event.preventDefault()
-    return window.studio.browser.openExternalLink(
-      'https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-load-zones/'
-    )
-  }
 
   function handleAddLoadZone(event: React.MouseEvent) {
     event.preventDefault()
@@ -103,9 +89,9 @@ export function LoadZones() {
         <Text size="2" as="p" mb="4">
           Configure the geographical zones that the load test should be run
           from. Learn more about load zones in the{' '}
-          <RadixLink href="" onClick={handleOpenDocs}>
+          <ExternalLink href="https://grafana.com/docs/grafana-cloud/testing/k6/author-run/use-load-zones/">
             docs
-          </RadixLink>
+          </ExternalLink>
           . Load zones configuration only affects tests running in the cloud.
         </Text>
 

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -2,12 +2,13 @@ import { ThresholdDataSchema } from '@/schemas/generator'
 import { useGeneratorStore } from '@/store/generator'
 
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Button, Text, Link as RadixLink } from '@radix-ui/themes'
+import { Button, Text } from '@radix-ui/themes'
 import { useCallback, useEffect } from 'react'
 import { useForm, useFieldArray, FormProvider } from 'react-hook-form'
 import { ThresholdRow } from './ThresholdRow'
 import { Table } from '@/components/Table'
 import { Threshold, ThresholdData } from '@/types/testOptions'
+import { ExternalLink } from '@/components/ExternalLink'
 
 export function Thresholds() {
   const thresholds = useGeneratorStore((store) => store.thresholds)
@@ -27,13 +28,6 @@ export function Thresholds() {
     control,
     name: 'thresholds',
   })
-
-  const handleOpenDocs = (event: React.MouseEvent) => {
-    event.preventDefault()
-    return window.studio.browser.openExternalLink(
-      'https://grafana.com/docs/k6/latest/using-k6/thresholds'
-    )
-  }
 
   function handleAddThreshold(event: React.MouseEvent) {
     event.preventDefault()
@@ -67,9 +61,9 @@ export function Thresholds() {
         <Text size="2" as="p" mb="4">
           Define pass/fail criteria for your test metrics across all URLs. Learn
           more about thresholds in the{' '}
-          <RadixLink href="" onClick={handleOpenDocs}>
+          <ExternalLink href="https://grafana.com/docs/k6/latest/using-k6/thresholds">
             docs
-          </RadixLink>
+          </ExternalLink>
           .
         </Text>
         <Table.Root size="1" variant="surface" layout="fixed">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Use the ExternalLink component for, well, external links.
This leaves just 2 places where `openExternalLink` is used directly, but since those are in a dropdown menu, I couldn't used this component.

## How to Test
Verify that the links work

