### PR TITLE
feat: add logical operator labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^6.24.0",
         "react-select": "^5.8.3",
         "react-use": "^17.5.1",
@@ -14017,6 +14018,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^6.24.0",
     "react-select": "^5.8.3",
     "react-use": "^17.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Global } from '@emotion/react'
 import { Theme } from '@radix-ui/themes'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { enableMapSet } from 'immer'
+import { IconContext } from 'react-icons'
 
 import { DevToolsDialog } from '@/components/DevToolsDialog'
 import { SettingsDialog } from '@/components/Settings/SettingsDialog'
@@ -22,11 +23,13 @@ export function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <Theme accentColor="orange" appearance={theme}>
-        <Global styles={globalStyles} />
-        <Toasts />
-        <AppRoutes />
-        <DevToolsDialog />
-        <SettingsDialog />
+        <IconContext.Provider value={{ style: { verticalAlign: 'middle' } }}>
+          <Global styles={globalStyles} />
+          <Toasts />
+          <AppRoutes />
+          <DevToolsDialog />
+          <SettingsDialog />
+        </IconContext.Provider>
       </Theme>
     </QueryClientProvider>
   )

--- a/src/components/Form/ControlledSelect.tsx
+++ b/src/components/Form/ControlledSelect.tsx
@@ -1,8 +1,13 @@
-import { Select, Tooltip, TooltipProps } from '@radix-ui/themes'
+import { Flex, Select, Tooltip, TooltipProps } from '@radix-ui/themes'
 import { ReactNode } from 'react'
 import { Control, Controller, FieldValues, Path } from 'react-hook-form'
 
-type Option = { label: ReactNode; value: string; disabled?: boolean }
+type Option = {
+  label: ReactNode
+  value: string
+  disabled?: boolean
+  icon?: ReactNode
+}
 type GroupedOption = { label: string; options: Option[] }
 
 interface ControlledSelectProps<
@@ -16,6 +21,7 @@ interface ControlledSelectProps<
   contentProps?: Select.ContentProps
   tooltipProps?: TooltipProps
   onChange?: (value: O extends Option ? O['value'] : string) => void
+  triggerValue?: (value: string) => ReactNode
 }
 
 export function ControlledSelect<
@@ -29,6 +35,7 @@ export function ControlledSelect<
   contentProps = {},
   tooltipProps = { content: undefined, hidden: true },
   onChange,
+  triggerValue,
 }: ControlledSelectProps<T, O>) {
   return (
     <Controller
@@ -45,7 +52,9 @@ export function ControlledSelect<
               onBlur={field.onBlur}
               id={name}
               css={{ width: '100%' }}
-            />
+            >
+              {triggerValue ? triggerValue(field.value) : undefined}
+            </Select.Trigger>
           </Tooltip>
           <Select.Content {...contentProps}>
             {options.map((option) =>
@@ -58,7 +67,9 @@ export function ControlledSelect<
                       value={subOption.value}
                       disabled={subOption.disabled}
                     >
-                      {subOption.label}
+                      <Flex justify="between" align="center" gap="1">
+                        {option.label} {subOption.icon}
+                      </Flex>
                     </Select.Item>
                   ))}
                 </Select.Group>
@@ -68,7 +79,9 @@ export function ControlledSelect<
                   value={option.value}
                   disabled={option.disabled}
                 >
-                  {option.label}
+                  <Flex justify="between" align="center" gap="1">
+                    {option.label} {option.icon}
+                  </Flex>
                 </Select.Item>
               )
             )}

--- a/src/utils/operatorLabels.tsx
+++ b/src/utils/operatorLabels.tsx
@@ -1,0 +1,80 @@
+import {
+  TbBracketsContain,
+  TbBracketsOff,
+  TbEqual,
+  TbEqualNot,
+  TbMathEqualGreater,
+  TbMathEqualLower,
+  TbMathGreater,
+  TbMathLower,
+} from 'react-icons/tb'
+
+import { exhaustive } from './typescript'
+
+export function getLogicalOperatorLabelAndIcon(
+  operator:
+    | 'equals'
+    | 'notEquals'
+    | 'contains'
+    | 'notContains'
+    | 'greaterThan'
+    | 'greaterThanOrEqual'
+    | 'lessThan'
+    | 'lessThanOrEqual',
+  iconSize = 15
+) {
+  switch (operator) {
+    case 'equals': {
+      return {
+        label: 'Equal to',
+        icon: <TbEqual size={iconSize} />,
+      }
+    }
+    case 'notEquals': {
+      return {
+        label: 'Not equal to',
+        icon: <TbEqualNot size={iconSize} />,
+      }
+    }
+    case 'contains': {
+      return {
+        label: 'Contains',
+        icon: <TbBracketsContain size={iconSize} />,
+      }
+    }
+    case 'notContains': {
+      return {
+        label: 'Does not contain',
+        icon: <TbBracketsOff size={iconSize} />,
+      }
+    }
+    case 'greaterThan': {
+      return {
+        label: 'Greater than',
+        icon: <TbMathGreater size={iconSize} />,
+      }
+    }
+    case 'greaterThanOrEqual': {
+      return {
+        label: 'Greater than or equal to',
+        icon: <TbMathEqualGreater size={iconSize} />,
+      }
+    }
+    case 'lessThan': {
+      return {
+        label: 'Less than',
+        icon: <TbMathLower size={iconSize} />,
+      }
+    }
+    case 'lessThanOrEqual': {
+      return {
+        label: 'Less than or equal to',
+        icon: <TbMathEqualLower size={iconSize} />,
+      }
+    }
+
+    default: {
+      return exhaustive(operator)
+    }
+  }
+}

--- a/src/views/Generator/RuleEditor/VerificationEditor/ValueEditor.utils.ts
+++ b/src/views/Generator/RuleEditor/VerificationEditor/ValueEditor.utils.ts
@@ -3,6 +3,7 @@ import {
   BodyVerificationRuleSchema,
 } from '@/schemas/generator'
 import { VerificationRule } from '@/types/rules'
+import { getLogicalOperatorLabelAndIcon } from '@/utils/operatorLabels'
 import { exhaustive } from '@/utils/typescript'
 
 export const VALUE_LABELS: Record<VerificationRule['value']['type'], string> = {
@@ -12,11 +13,11 @@ export const VALUE_LABELS: Record<VerificationRule['value']['type'], string> = {
   number: 'Number',
 }
 
-export const OPERATOR_LABELS: Record<VerificationRule['operator'], string> = {
-  equals: 'Equals',
-  notEquals: 'Does not equal',
-  contains: 'Contains',
-  notContains: 'Does not contain',
+export const OPERATOR_LABELS = {
+  equals: getLogicalOperatorLabelAndIcon('equals'),
+  notEquals: getLogicalOperatorLabelAndIcon('notEquals'),
+  contains: getLogicalOperatorLabelAndIcon('contains'),
+  notContains: getLogicalOperatorLabelAndIcon('notContains'),
 }
 
 export function getAvailableOperators(target: VerificationRule['target']) {
@@ -59,6 +60,6 @@ export function getValueTypeOptions(
 export function getOperatorOptions(target: VerificationRule['target']) {
   return getAvailableOperators(target).map((val) => ({
     value: val,
-    label: OPERATOR_LABELS[val],
+    ...OPERATOR_LABELS[val],
   }))
 }

--- a/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/ThresholdRow.tsx
@@ -84,6 +84,11 @@ export function ThresholdRow({ field, index, remove }: ThresholdRowProps) {
             control={control}
             name={`thresholds.${index}.condition`}
             options={THRESHOLD_CONDITIONS_OPTIONS}
+            triggerValue={(val) =>
+              THRESHOLD_CONDITIONS_OPTIONS.find(
+                (option) => option.value === val
+              )?.icon
+            }
           />
         </FieldGroup>
       </Table.Cell>

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
@@ -1,5 +1,6 @@
 import { ThresholdMetricSchema } from '@/schemas/generator'
 import { ThresholdMetric, ThresholdStatstic } from '@/types/testOptions'
+import { getLogicalOperatorLabelAndIcon } from '@/utils/operatorLabels'
 import { exhaustive } from '@/utils/typescript'
 
 type ThresholdMetricMap = {
@@ -74,12 +75,30 @@ export const THRESHOLD_METRICS_OPTIONS = ThresholdMetricSchema.options.map(
 )
 
 export const THRESHOLD_CONDITIONS_OPTIONS = [
-  { label: '<', value: '<' },
-  { label: '<=', value: '<=' },
-  { label: '>', value: '>' },
-  { label: '>=', value: '>=' },
-  { label: '===', value: '===' },
-  { label: '!=', value: '!=' },
+  {
+    value: '<',
+    ...getLogicalOperatorLabelAndIcon('lessThan'),
+  },
+  {
+    value: '<=',
+    ...getLogicalOperatorLabelAndIcon('lessThanOrEqual'),
+  },
+  {
+    value: '>',
+    ...getLogicalOperatorLabelAndIcon('greaterThan'),
+  },
+  {
+    value: '>=',
+    ...getLogicalOperatorLabelAndIcon('greaterThanOrEqual'),
+  },
+  {
+    value: '===',
+    ...getLogicalOperatorLabelAndIcon('equals'),
+  },
+  {
+    value: '!=',
+    ...getLogicalOperatorLabelAndIcon('notEquals'),
+  },
 ]
 
 type StatisticOption = { label: string; value: ThresholdStatstic }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, we use symbols (< > ===) for threshold operators and labels for verification rules, this PR makes it consistent by using label and icon combination in both components. 

- Because of limited space in thresholds, only the icon will be shown once value is selected.
- For verification operator, we always show both label and icon. 
- I've included react-icons library to get access to more icons.

![screencapture 2025-03-21 at 15 26 17@2x](https://github.com/user-attachments/assets/0d9ea0f8-ecc9-4058-9b77-efa8c8c7dfa1)

![screencapture 2025-03-21 at 15 26 22@2x](https://github.com/user-attachments/assets/7aeba112-9fae-47da-af9a-2e5f9b2a3fea)

![screencapture 2025-03-21 at 15 26 37@2x](https://github.com/user-attachments/assets/d76eda2c-27bc-4443-ab05-138fcb402239)


## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
