### PR TITLE
chore: Use text value comparison as default option for body verification rules

### DIFF
--- a/src/schemas/generator/v2/rules.ts
+++ b/src/schemas/generator/v2/rules.ts
@@ -164,8 +164,8 @@ export const BodyVerificationRuleSchema = BaseVerificationRuleSchema.extend({
   target: z.literal(VerificationTarget.enum.body),
   operator: VerificationOperator,
   value: z.discriminatedUnion('type', [
-    RecordedValueSchema,
     StringValueSchema,
+    RecordedValueSchema,
     VariableValueSchema,
   ]),
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

From internal feedback: in verification rule, comparing response body to recording could lead to massive script, we still want to provide this option, but not as a default when `Response body` is selected as `Target`. Instead, select `Text value` as default.

## How to Test

1. Create a new verification rule
2. Change `Target` to `Response body`
3. Verify `Text value` option is pre-selected.


## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![screencapture 2025-03-24 at 13 59 08](https://github.com/user-attachments/assets/a5333824-7519-406c-85e2-f3120b4c95e9)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
