### PR TITLE
feat: Pre-fill OS and app version when reporting issues

### DIFF
--- a/src/components/Layout/ActivityBar/HelpButton.tsx
+++ b/src/components/Layout/ActivityBar/HelpButton.tsx
@@ -7,10 +7,7 @@ export function HelpButton() {
       'https://grafana.com/docs/k6-studio/'
     )
 
-  const handleReportIssue = () =>
-    window.studio.browser.openExternalLink(
-      'https://github.com/grafana/k6-studio/issues'
-    )
+  const handleReportIssue = () => window.studio.ui.reportIssue()
 
   const handleOpenApplicationLogs = () => {
     window.studio.log.openLogFolder()

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ import { HarWithOptionalResponse } from './types/har'
 import { AppSettings } from './types/settings'
 import { DataFilePreview } from './types/testData'
 import { sendReport } from './usageReport'
+import { reportNewIssue } from './utils/bugReport'
 import { parseDataFile } from './utils/dataFile'
 import {
   sendToast,
@@ -605,6 +606,10 @@ ipcMain.handle('ui:get-files', async () => {
     scripts,
     dataFiles,
   }
+})
+
+ipcMain.handle('ui:report-issue', () => {
+  return reportNewIssue()
 })
 
 ipcMain.handle(

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, shell } from 'electron'
 
 import { openLogFolder } from './logger'
+import { reportNewIssue } from './utils/bugReport'
 import { getPlatform } from './utils/electron'
 
 const isDevEnv = process.env.NODE_ENV === 'development'
@@ -36,11 +37,7 @@ const template: Electron.MenuItemConstructorOptions[] = [
       },
       {
         label: 'Report an issue',
-        click: async () => {
-          await shell.openExternal(
-            'https://github.com/grafana/k6-studio/issues'
-          )
-        },
+        click: reportNewIssue,
       },
       {
         label: 'Application logs',

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -133,6 +133,14 @@ const ui = {
     return ipcRenderer.invoke('ui:delete-file', file)
   },
   getFiles: (): Promise<GetFilesResponse> => ipcRenderer.invoke('ui:get-files'),
+  renameFile: (
+    oldFileName: string,
+    newFileName: string,
+    type: StudioFile['type']
+  ): Promise<void> => {
+    return ipcRenderer.invoke('ui:rename-file', oldFileName, newFileName, type)
+  },
+  reportIssue: (): Promise<void> => ipcRenderer.invoke('ui:report-issue'),
   onAddFile: (callback: (file: StudioFile) => void) => {
     return createListener('ui:add-file', callback)
   },
@@ -141,13 +149,6 @@ const ui = {
   },
   onToast: (callback: (toast: AddToastPayload) => void) => {
     return createListener('ui:toast', callback)
-  },
-  renameFile: (
-    oldFileName: string,
-    newFileName: string,
-    type: StudioFile['type']
-  ): Promise<void> => {
-    return ipcRenderer.invoke('ui:rename-file', oldFileName, newFileName, type)
   },
 } as const
 

--- a/src/utils/bugReport.ts
+++ b/src/utils/bugReport.ts
@@ -1,0 +1,15 @@
+import { app, shell } from 'electron'
+
+import { getPlatform } from './electron'
+
+export function reportNewIssue() {
+  const params = new URLSearchParams({
+    template: 'bug.yaml',
+    os: `${getPlatform()} ${process.getSystemVersion()}`,
+    version: app.getVersion(),
+  })
+
+  return shell.openExternal(
+    `https://github.com/grafana/k6-studio/issues/new?${params.toString()}`
+  )
+}


### PR DESCRIPTION
`Report an issue` now pre-fills the OS and version fields. 
<img width="649" alt="image" src="https://github.com/user-attachments/assets/94ecf5ca-1f1b-4365-a432-7e3d9b0b4c8e" />


Know limitations:
- There doesn't seem to be a reliable way to get the linux distro name 

Testing instructions:
- Check that `Report new issue` actually opens the new issue form with the `bug` template
- Check that the OS and Version fields are filled