### PR TITLE
fix: Add parameterization rule custom code preview

### DIFF
--- a/src/views/Generator/TestRuleContainer/TestRule/CustomCodeContent.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/CustomCodeContent.tsx
@@ -1,0 +1,30 @@
+import { EyeOpenIcon } from '@radix-ui/react-icons'
+import { Strong, Text, Tooltip } from '@radix-ui/themes'
+
+import { CustomCodeRule } from '@/types/rules'
+
+export function CustomCodeContent({ rule }: { rule: CustomCodeRule }) {
+  return (
+    <>
+      Insert <CodeSnippetPreview snippet={rule.snippet} />{' '}
+      <Strong>{rule.placement === 'before' ? 'before' : 'after'}</Strong>{' '}
+      request
+    </>
+  )
+}
+
+export function CodeSnippetPreview({ snippet }: { snippet: string }) {
+  return (
+    <Tooltip
+      content={
+        <pre>
+          <code>{snippet}</code>
+        </pre>
+      }
+    >
+      <Text>
+        <EyeOpenIcon /> <Strong>snippet</Strong>
+      </Text>
+    </Tooltip>
+  )
+}

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleInlineContent.tsx
@@ -1,21 +1,8 @@
-import {
-  BorderLeftIcon,
-  BorderRightIcon,
-  EyeOpenIcon,
-} from '@radix-ui/react-icons'
-import { Badge, Tooltip } from '@radix-ui/themes'
-
-import {
-  CorrelationRule,
-  CustomCodeRule,
-  TestRule,
-  ParameterizationRule,
-} from '@/types/rules'
+import { TestRule, Filter } from '@/types/rules'
 import { exhaustive } from '@/utils/typescript'
 
 import { TestRuleFilter } from './TestRuleFilter'
 import { TestRuleSelector } from './TestRuleSelector'
-import { VerificationContent } from './VerificationContent'
 
 interface TestRuleInlineContentProps {
   rule: TestRule
@@ -24,58 +11,21 @@ interface TestRuleInlineContentProps {
 export function TestRuleInlineContent({ rule }: TestRuleInlineContentProps) {
   switch (rule.type) {
     case 'correlation':
-      return <CorrelationContent rule={rule} />
+      return <RulePreview rule={rule} filter={rule.extractor.filter} />
     case 'customCode':
-      return <CustomCodeContent rule={rule} />
     case 'parameterization':
-      return <ParameterizationContent rule={rule} />
     case 'verification':
-      return <VerificationContent rule={rule} />
+      return <RulePreview rule={rule} filter={rule.filter} />
     default:
       return exhaustive(rule)
   }
 }
 
-function CorrelationContent({ rule }: { rule: CorrelationRule }) {
+function RulePreview({ rule, filter }: { rule: TestRule; filter: Filter }) {
   return (
     <>
-      <TestRuleFilter filter={rule.extractor.filter} />
+      <TestRuleFilter filter={filter} />
       <TestRuleSelector rule={rule} />
-    </>
-  )
-}
-
-function ParameterizationContent({ rule }: { rule: ParameterizationRule }) {
-  return (
-    <>
-      <TestRuleFilter filter={rule.filter} />
-      <TestRuleSelector rule={rule} />
-    </>
-  )
-}
-
-function CustomCodeContent({ rule }: { rule: CustomCodeRule }) {
-  return (
-    <>
-      <TestRuleFilter filter={rule.filter} />{' '}
-      <Tooltip
-        content={`${rule.placement === 'after' ? 'After' : 'Before'} matched requests`}
-      >
-        <Badge color="gray">
-          {rule.placement === 'after' ? (
-            <BorderRightIcon />
-          ) : (
-            <BorderLeftIcon />
-          )}
-          {rule.placement}
-        </Badge>
-      </Tooltip>
-      <Tooltip content={<code>{rule.snippet}</code>}>
-        <Badge color="gray">
-          <EyeOpenIcon />
-          Snippet
-        </Badge>
-      </Tooltip>
     </>
   )
 }

--- a/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/TestRuleSelector.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { Link1Icon } from '@radix-ui/react-icons'
-import { Badge, Strong, Tooltip } from '@radix-ui/themes'
+import { Badge, Strong, Text, Tooltip } from '@radix-ui/themes'
 import { useRef } from 'react'
 
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
@@ -8,11 +8,15 @@ import {
   CorrelationRule,
   ParameterizationRule,
   ReplacerSelector,
+  TestRule,
 } from '@/types/rules'
 import { exhaustive } from '@/utils/typescript'
 
+import { CodeSnippetPreview, CustomCodeContent } from './CustomCodeContent'
+import { VerificationContent } from './VerificationContent'
+
 interface TestRuleSelectorProps {
-  rule: CorrelationRule | ParameterizationRule
+  rule: TestRule
 }
 
 export function TestRuleSelector({ rule }: TestRuleSelectorProps) {
@@ -20,7 +24,7 @@ export function TestRuleSelector({ rule }: TestRuleSelectorProps) {
   const hasEllipsis = useOverflowCheck(ref)
 
   return (
-    <Tooltip content={<SelectorContent rule={rule} />} hidden={!hasEllipsis}>
+    <Tooltip content={<TooltipContent rule={rule} />} hidden={!hasEllipsis}>
       <Badge
         ref={ref}
         color="gray"
@@ -30,6 +34,9 @@ export function TestRuleSelector({ rule }: TestRuleSelectorProps) {
           text-overflow: ellipsis;
           white-space: nowrap;
           display: inline-block;
+          svg {
+            vertical-align: middle;
+          }
         `}
       >
         <SelectorContent rule={rule} />
@@ -38,16 +45,24 @@ export function TestRuleSelector({ rule }: TestRuleSelectorProps) {
   )
 }
 
-function SelectorContent({
-  rule,
-}: {
-  rule: CorrelationRule | ParameterizationRule
-}) {
+const TooltipContent = ({ rule }: { rule: TestRule }) => {
+  return (
+    <Text css={{ svg: { verticalAlign: 'middle' } }}>
+      <SelectorContent rule={rule} />
+    </Text>
+  )
+}
+
+function SelectorContent({ rule }: { rule: TestRule }) {
   switch (rule.type) {
     case 'correlation':
       return <CorrelationSelectorContetent rule={rule} />
     case 'parameterization':
       return <ParameterizationSelectorContent rule={rule} />
+    case 'verification':
+      return <VerificationContent rule={rule} />
+    case 'customCode':
+      return <CustomCodeContent rule={rule} />
     default:
       return exhaustive(rule)
   }
@@ -112,8 +127,7 @@ function ParameterizationValue({ rule }: { rule: ParameterizationRule }) {
     case 'variable':
       return (
         <Strong css={{ whiteSpace: 'nowrap' }}>
-          <Link1Icon css={{ verticalAlign: 'middle', display: 'inline' }} />{' '}
-          {rule.value.variableName}
+          <Link1Icon /> {rule.value.variableName}
         </Strong>
       )
     case 'dataFileValue':
@@ -124,7 +138,7 @@ function ParameterizationValue({ rule }: { rule: ParameterizationRule }) {
         </>
       )
     case 'customCode':
-      return null
+      return <CodeSnippetPreview snippet={rule.value.code} />
     default:
       return exhaustive(rule.value)
   }

--- a/src/views/Generator/TestRuleContainer/TestRule/VerificationContent.tsx
+++ b/src/views/Generator/TestRuleContainer/TestRule/VerificationContent.tsx
@@ -1,19 +1,14 @@
 import { DiscIcon, Link1Icon } from '@radix-ui/react-icons'
-import { Badge, Strong } from '@radix-ui/themes'
+import { Strong } from '@radix-ui/themes'
 
 import { VerificationRule } from '@/types/rules'
 import { exhaustive } from '@/utils/typescript'
 
-import { TestRuleFilter } from './TestRuleFilter'
-
 export function VerificationContent({ rule }: { rule: VerificationRule }) {
   return (
     <>
-      <TestRuleFilter filter={rule.filter} />
-      <Badge color="gray">
-        Verify <Strong>{rule.target}</Strong>{' '}
-        <OperatorLabel operator={rule.operator} /> <ValueLabel rule={rule} />
-      </Badge>
+      Verify <Strong>{rule.target}</Strong>{' '}
+      <OperatorLabel operator={rule.operator} /> <ValueLabel rule={rule} />
     </>
   )
 }
@@ -40,9 +35,8 @@ function ValueLabel({ rule }: { rule: VerificationRule }) {
   switch (rule.value.type) {
     case 'recordedValue':
       return (
-        <Strong css={{ whiteSpace: 'nowrap' }}>
-          <DiscIcon css={{ verticalAlign: 'middle', display: 'inline' }} />{' '}
-          recorded value
+        <Strong>
+          <DiscIcon /> recorded value
         </Strong>
       )
     case 'string':
@@ -52,8 +46,7 @@ function ValueLabel({ rule }: { rule: VerificationRule }) {
     case 'variable':
       return (
         <Strong>
-          <Link1Icon css={{ verticalAlign: 'middle', display: 'inline' }} />{' '}
-          {rule.value.variableName}
+          <Link1Icon /> {rule.value.variableName}
         </Strong>
       )
     default:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add missing parameterization rule code preview
- Wrap code preview tooltip in `<pre>` to preserve newlines
- Match preview styles between custom code and other rules
- Refactor preview components


Before:

![screencapture 2025-03-27 at 12 24 49](https://github.com/user-attachments/assets/d4e3af83-155d-4a9a-988c-9dbc288b8dfb)


After:

![screencapture 2025-03-27 at 12 24 26](https://github.com/user-attachments/assets/e8ecd25d-8ea4-492e-8225-e0be8853100a)


## How to Test

Verify we have preview for all rule and selector combinations
Verify preview tooltip is displayed when preview is truncated


<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Resolves https://github.com/grafana/k6-studio/issues/601

<!-- Thanks for your contribution! 🙏🏼 -->
