### PR TITLE
fix: Keep request inspector open when switching from script tab

### DIFF
--- a/src/views/Generator/GeneratorTabs/RequestList/RequestList.tsx
+++ b/src/views/Generator/GeneratorTabs/RequestList/RequestList.tsx
@@ -1,5 +1,4 @@
 import { Flex, ScrollArea } from '@radix-ui/themes'
-import { useShallowCompareEffect } from 'react-use'
 
 import { EmptyMessage } from '@/components/EmptyMessage'
 import { WebLogView } from '@/components/WebLogView'
@@ -63,11 +62,6 @@ export function RequestList({
     filter,
     setShowAllowlistDialog,
   })
-
-  // Preserve the selected request when modifying rules
-  useShallowCompareEffect(() => {
-    onSelectRequest(null)
-  }, [requests])
 
   return (
     <Flex direction="column" height="100%">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In generator, switching to requests from script tab with a request inspector open would close request inspector panel. Looks like hook added is no longer necessary after layout change.


## How to Test

Verify request inspector remains open when switching between generator tabs. Verify it inspector closes when switching between other generators or views.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Resolves https://github.com/grafana/k6-studio/issues/602

<!-- Thanks for your contribution! 🙏🏼 -->
