### PR TITLE
feat: Add support for content preview in request payload

### DIFF
--- a/src/components/WebLogView/ContentPreview.tsx
+++ b/src/components/WebLogView/ContentPreview.tsx
@@ -92,5 +92,4 @@ export function ContentPreview({
 const isMedia = (format: string) =>
   ['audio', 'font', 'image', 'video'].includes(format)
 
-const isPreviewable = (format: string) =>
-  !['javascript', 'css'].includes(format)
+const isPreviewable = (format: string) => ['html', 'json'].includes(format)

--- a/src/components/WebLogView/ContentPreview.tsx
+++ b/src/components/WebLogView/ContentPreview.tsx
@@ -92,4 +92,5 @@ export function ContentPreview({
 const isMedia = (format: string) =>
   ['audio', 'font', 'image', 'video'].includes(format)
 
-const isPreviewable = (format: string) => ['html', 'json'].includes(format)
+const isPreviewable = (format: string) =>
+  !['javascript', 'css'].includes(format)

--- a/src/components/WebLogView/ContentPreview.tsx
+++ b/src/components/WebLogView/ContentPreview.tsx
@@ -1,0 +1,104 @@
+import { Flex, SegmentedControl, Box, ScrollArea } from '@radix-ui/themes'
+import { useState, useEffect } from 'react'
+
+import { ProxyData } from '@/types'
+
+import { ReadOnlyEditor } from '../Monaco/ReadOnlyEditor'
+
+import { useGoToContentMatch } from './Details.hooks'
+import { Preview } from './ResponseDetails/Preview'
+import { Raw } from './ResponseDetails/Raw'
+import { parseContent } from './ResponseDetails/ResponseDetails.utils'
+
+type ContentPreviewProps = {
+  content: string
+  contentType: string
+  format: string
+  data: ProxyData
+}
+
+export function ContentPreview({
+  data,
+  format,
+  content,
+  contentType,
+}: ContentPreviewProps) {
+  const [selectedTab, setSelectedTab] = useState('content')
+  const { searchString, index, reset } = useGoToContentMatch()
+  const rawFormat = format === 'json' ? 'json-raw' : format
+  const rawContent = parseContent(rawFormat, data)
+
+  useEffect(() => {
+    setSelectedTab('content')
+  }, [format])
+
+  // Reset search string on unmount
+  useEffect(() => {
+    return reset
+  }, [reset])
+
+  if (isMedia(format)) {
+    return (
+      <Box height="100%">
+        <Preview format={format} content={content} contentType={contentType} />
+      </Box>
+    )
+  }
+
+  return (
+    <Flex direction="column" gap="2" height="100%">
+      <Flex gap="2" justify="end" px="2">
+        <SegmentedControl.Root
+          value={selectedTab}
+          radius="small"
+          size="1"
+          variant="classic"
+          onValueChange={(value) => setSelectedTab(value)}
+        >
+          <SegmentedControl.Item value="raw">Raw</SegmentedControl.Item>
+          <SegmentedControl.Item value="content">Content</SegmentedControl.Item>
+          {isPreviewable(format) && (
+            <SegmentedControl.Item value="preview">
+              Preview
+            </SegmentedControl.Item>
+          )}
+        </SegmentedControl.Root>
+      </Flex>
+      <Box flexGrow="1">
+        <ScrollArea>
+          <Box px="2" height="100%">
+            {selectedTab === 'preview' && (
+              <Preview
+                format={format}
+                content={content}
+                contentType={contentType}
+              />
+            )}
+            {selectedTab === 'raw' && (
+              <Raw
+                content={rawContent ?? ''}
+                format={format}
+                searchString={searchString}
+                searchIndex={index}
+              />
+            )}
+            {selectedTab === 'content' && (
+              <ReadOnlyEditor
+                language={format}
+                value={content}
+                searchString={searchString}
+                searchIndex={index}
+              />
+            )}
+          </Box>
+        </ScrollArea>
+      </Box>
+    </Flex>
+  )
+}
+
+const isMedia = (format: string) =>
+  ['audio', 'font', 'image', 'video'].includes(format)
+
+const isPreviewable = (format: string) =>
+  !['javascript', 'css'].includes(format)

--- a/src/components/WebLogView/ContentPreview.tsx
+++ b/src/components/WebLogView/ContentPreview.tsx
@@ -1,32 +1,27 @@
 import { Flex, SegmentedControl, Box, ScrollArea } from '@radix-ui/themes'
 import { useState, useEffect } from 'react'
 
-import { ProxyData } from '@/types'
-
 import { ReadOnlyEditor } from '../Monaco/ReadOnlyEditor'
 
 import { useGoToContentMatch } from './Details.hooks'
 import { Preview } from './ResponseDetails/Preview'
 import { Raw } from './ResponseDetails/Raw'
-import { parseContent } from './ResponseDetails/ResponseDetails.utils'
 
 type ContentPreviewProps = {
   content: string
   contentType: string
   format: string
-  data: ProxyData
+  rawContent: string | undefined
 }
 
 export function ContentPreview({
-  data,
   format,
   content,
+  rawContent,
   contentType,
 }: ContentPreviewProps) {
   const [selectedTab, setSelectedTab] = useState('content')
   const { searchString, index, reset } = useGoToContentMatch()
-  const rawFormat = format === 'json' ? 'json-raw' : format
-  const rawContent = parseContent(rawFormat, data)
 
   useEffect(() => {
     setSelectedTab('content')

--- a/src/components/WebLogView/ContentPreview.tsx
+++ b/src/components/WebLogView/ContentPreview.tsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react'
 
 import { ReadOnlyEditor } from '../Monaco/ReadOnlyEditor'
 
-import { useGoToContentMatch } from './Details.hooks'
 import { Preview } from './ResponseDetails/Preview'
 import { Raw } from './ResponseDetails/Raw'
 
@@ -12,6 +11,8 @@ type ContentPreviewProps = {
   contentType: string
   format: string
   rawContent: string | undefined
+  searchIndex: number
+  searchString?: string
 }
 
 export function ContentPreview({
@@ -19,18 +20,14 @@ export function ContentPreview({
   content,
   rawContent,
   contentType,
+  searchIndex,
+  searchString,
 }: ContentPreviewProps) {
   const [selectedTab, setSelectedTab] = useState('content')
-  const { searchString, index, reset } = useGoToContentMatch()
 
   useEffect(() => {
     setSelectedTab('content')
   }, [format])
-
-  // Reset search string on unmount
-  useEffect(() => {
-    return reset
-  }, [reset])
 
   if (isMedia(format)) {
     return (
@@ -74,7 +71,7 @@ export function ContentPreview({
                 content={rawContent ?? ''}
                 format={format}
                 searchString={searchString}
-                searchIndex={index}
+                searchIndex={searchIndex}
               />
             )}
             {selectedTab === 'content' && (
@@ -82,7 +79,7 @@ export function ContentPreview({
                 language={format}
                 value={content}
                 searchString={searchString}
-                searchIndex={index}
+                searchIndex={searchIndex}
               />
             )}
           </Box>

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -7,21 +7,16 @@ import { getContentType } from '@/utils/headers'
 import { ContentPreview } from '../ContentPreview'
 import { useGoToPayloadMatch } from '../Details.hooks'
 import { Raw } from '../ResponseDetails/Raw'
+import { toFormat } from '../ResponseDetails/ResponseDetails.utils'
 
 import { FormPayloadPreview } from './FormPayloadPreview'
-import { getRawJSONParams, parseParams } from './utils'
+import { getRawContent, parseParams } from './utils'
 
 export function Payload({ data }: { data: ProxyData }) {
   const content = parseParams(data)
   const contentType = getContentType(data.request?.headers ?? [])
+  const format = toFormat(contentType) || 'text/plain'
   const { searchString, index, reset } = useGoToPayloadMatch()
-
-  function getRawContent() {
-    if (content && contentType === 'application/json') {
-      return getRawJSONParams(content)
-    }
-    return content
-  }
 
   // Reset payload search on unmount
   useEffect(() => {
@@ -53,9 +48,9 @@ export function Payload({ data }: { data: ProxyData }) {
 
   return (
     <ContentPreview
-      format="json"
+      format={format}
       content={content}
-      rawContent={getRawContent()}
+      rawContent={getRawContent(content)}
       contentType={contentType || 'text/plain'}
       searchIndex={index}
       searchString={searchString}

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react'
 import { ProxyData } from '@/types'
 import { getContentType } from '@/utils/headers'
 
-import { ReadOnlyEditor } from '../../Monaco/ReadOnlyEditor'
+import { ContentPreview } from '../ContentPreview'
 import { useGoToPayloadMatch } from '../Details.hooks'
 import { Raw } from '../ResponseDetails/Raw'
 
@@ -45,11 +45,11 @@ export function Payload({ data }: { data: ProxyData }) {
   }
 
   return (
-    <ReadOnlyEditor
-      language="javascript"
-      value={content}
-      searchString={searchString}
-      searchIndex={index}
+    <ContentPreview
+      data={data}
+      format="json"
+      content={content}
+      contentType={contentType || 'text/plain'}
     />
   )
 }

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -61,7 +61,7 @@ export function Payload({ data }: { data: ProxyData }) {
   }
 
   const peviewContentType = getContentTypeForContentPreview()
-  const format = toFormat(peviewContentType) || 'text/plain'
+  const format = toFormat(peviewContentType) || 'plaintext'
 
   return (
     <ContentPreview

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -57,6 +57,8 @@ export function Payload({ data }: { data: ProxyData }) {
       content={content}
       rawContent={getRawContent()}
       contentType={contentType || 'text/plain'}
+      searchIndex={index}
+      searchString={searchString}
     />
   )
 }

--- a/src/components/WebLogView/RequestDetails/Payload.tsx
+++ b/src/components/WebLogView/RequestDetails/Payload.tsx
@@ -9,12 +9,19 @@ import { useGoToPayloadMatch } from '../Details.hooks'
 import { Raw } from '../ResponseDetails/Raw'
 
 import { FormPayloadPreview } from './FormPayloadPreview'
-import { parseParams } from './utils'
+import { getRawJSONParams, parseParams } from './utils'
 
 export function Payload({ data }: { data: ProxyData }) {
   const content = parseParams(data)
   const contentType = getContentType(data.request?.headers ?? [])
   const { searchString, index, reset } = useGoToPayloadMatch()
+
+  function getRawContent() {
+    if (content && contentType === 'application/json') {
+      return getRawJSONParams(content)
+    }
+    return content
+  }
 
   // Reset payload search on unmount
   useEffect(() => {
@@ -46,9 +53,9 @@ export function Payload({ data }: { data: ProxyData }) {
 
   return (
     <ContentPreview
-      data={data}
       format="json"
       content={content}
+      rawContent={getRawContent()}
       contentType={contentType || 'text/plain'}
     />
   )

--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -52,7 +52,7 @@ function queryStringToJSONString(str: string) {
   return JSON.stringify(Object.fromEntries(new URLSearchParams(str)))
 }
 
-function isJsonString(str: string) {
+export function isJsonString(str: string) {
   try {
     JSON.parse(str)
     return true

--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -61,8 +61,6 @@ function isJsonString(str: string) {
   }
 }
 
-export function getRawJSONParams(content: string) {
-  // TODO: https://github.com/grafana/k6-studio/issues/277
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  return stringify(JSON.parse(safeAtob(content)), 0)
+export function getRawContent(content: string) {
+  return content.replace(/\s+/g, '')
 }

--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -60,3 +60,9 @@ function isJsonString(str: string) {
     return false
   }
 }
+
+export function getRawJSONParams(content: string) {
+  // TODO: https://github.com/grafana/k6-studio/issues/277
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  return stringify(JSON.parse(safeAtob(content)), 0)
+}

--- a/src/components/WebLogView/ResponseDetails/Content.tsx
+++ b/src/components/WebLogView/ResponseDetails/Content.tsx
@@ -17,7 +17,7 @@ export function Content({ data }: { data: ProxyData }) {
   const rawContent = parseContent(rawFormat, data)
   const { searchString, index, reset } = useGoToContentMatch()
 
-  // Reset payload search on unmount
+  // Reset search string on unmount
   useEffect(() => {
     return reset
   }, [reset])

--- a/src/components/WebLogView/ResponseDetails/Content.tsx
+++ b/src/components/WebLogView/ResponseDetails/Content.tsx
@@ -1,9 +1,11 @@
 import { Flex } from '@radix-ui/themes'
+import { useEffect } from 'react'
 
 import { ProxyData } from '@/types'
 import { getContentType } from '@/utils/headers'
 
 import { ContentPreview } from '../ContentPreview'
+import { useGoToContentMatch } from '../Details.hooks'
 
 import { parseContent, toFormat } from './ResponseDetails.utils'
 
@@ -13,6 +15,12 @@ export function Content({ data }: { data: ProxyData }) {
   const content = parseContent(format, data)
   const rawFormat = format === 'json' ? 'json-raw' : format
   const rawContent = parseContent(rawFormat, data)
+  const { searchString, index, reset } = useGoToContentMatch()
+
+  // Reset payload search on unmount
+  useEffect(() => {
+    return reset
+  }, [reset])
 
   if (!contentType || !content || !format) {
     return (
@@ -28,6 +36,8 @@ export function Content({ data }: { data: ProxyData }) {
       content={content}
       rawContent={rawContent}
       contentType={contentType}
+      searchIndex={index}
+      searchString={searchString}
     />
   )
 }

--- a/src/components/WebLogView/ResponseDetails/Content.tsx
+++ b/src/components/WebLogView/ResponseDetails/Content.tsx
@@ -1,34 +1,16 @@
-import { Box, Flex, ScrollArea, SegmentedControl } from '@radix-ui/themes'
-import { useEffect, useState } from 'react'
+import { Flex } from '@radix-ui/themes'
 
-import { ReadOnlyEditor } from '@/components/Monaco/ReadOnlyEditor'
 import { ProxyData } from '@/types'
 import { getContentType } from '@/utils/headers'
 
-import { useGoToContentMatch } from '../Details.hooks'
+import { ContentPreview } from '../ContentPreview'
 
-import { Preview } from './Preview'
-import { Raw } from './Raw'
 import { parseContent, toFormat } from './ResponseDetails.utils'
 
 export function Content({ data }: { data: ProxyData }) {
-  const [selectedTab, setSelectedTab] = useState('content')
-  const { searchString, index, reset } = useGoToContentMatch()
-
   const contentType = getContentType(data.response?.headers ?? [])
   const format = toFormat(contentType)
   const content = parseContent(format, data)
-  const rawFormat = format === 'json' ? 'json-raw' : format
-  const rawContent = parseContent(rawFormat, data)
-
-  // Reset search string on unmount
-  useEffect(() => {
-    return reset
-  }, [reset])
-
-  useEffect(() => {
-    setSelectedTab('content')
-  }, [format])
 
   if (!contentType || !content || !format) {
     return (
@@ -38,68 +20,12 @@ export function Content({ data }: { data: ProxyData }) {
     )
   }
 
-  const contentProps = {
-    content,
-    contentType,
-    format,
-  }
-
-  if (isMedia(format)) {
-    return (
-      <Box height="100%">
-        <Preview {...contentProps} />
-      </Box>
-    )
-  }
-
   return (
-    <Flex direction="column" gap="2" height="100%">
-      <Flex gap="2" justify="end" px="2">
-        <SegmentedControl.Root
-          value={selectedTab}
-          radius="small"
-          size="1"
-          variant="classic"
-          onValueChange={(value) => setSelectedTab(value)}
-        >
-          <SegmentedControl.Item value="raw">Raw</SegmentedControl.Item>
-          <SegmentedControl.Item value="content">Content</SegmentedControl.Item>
-          {isPreviewable(format) && (
-            <SegmentedControl.Item value="preview">
-              Preview
-            </SegmentedControl.Item>
-          )}
-        </SegmentedControl.Root>
-      </Flex>
-      <Box flexGrow="1">
-        <ScrollArea>
-          <Box px="2" height="100%">
-            {selectedTab === 'preview' && <Preview {...contentProps} />}
-            {selectedTab === 'raw' && (
-              <Raw
-                content={rawContent ?? ''}
-                format={format}
-                searchString={searchString}
-                searchIndex={index}
-              />
-            )}
-            {selectedTab === 'content' && (
-              <ReadOnlyEditor
-                language={format}
-                value={content}
-                searchString={searchString}
-                searchIndex={index}
-              />
-            )}
-          </Box>
-        </ScrollArea>
-      </Box>
-    </Flex>
+    <ContentPreview
+      data={data}
+      format={format}
+      content={content}
+      contentType={contentType}
+    />
   )
 }
-
-const isMedia = (format: string) =>
-  ['audio', 'font', 'image', 'video'].includes(format)
-
-const isPreviewable = (format: string) =>
-  !['javascript', 'css'].includes(format)

--- a/src/components/WebLogView/ResponseDetails/Content.tsx
+++ b/src/components/WebLogView/ResponseDetails/Content.tsx
@@ -11,6 +11,8 @@ export function Content({ data }: { data: ProxyData }) {
   const contentType = getContentType(data.response?.headers ?? [])
   const format = toFormat(contentType)
   const content = parseContent(format, data)
+  const rawFormat = format === 'json' ? 'json-raw' : format
+  const rawContent = parseContent(rawFormat, data)
 
   if (!contentType || !content || !format) {
     return (
@@ -22,9 +24,9 @@ export function Content({ data }: { data: ProxyData }) {
 
   return (
     <ContentPreview
-      data={data}
       format={format}
       content={content}
+      rawContent={rawContent}
       contentType={contentType}
     />
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for users to inspect raw data and preview JSON for request payloads, similar behaviour that exist in responses.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Inspect POST/PUT/DELETE/PATCH requests that contain JSON payload
- Check that the JSON preview and raw content is available

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/c1ac4df2-9b5d-4f84-859e-d1bfce6dab46




## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/324

<!-- Thanks for your contribution! 🙏🏼 -->
