### PR TITLE
feat: Pre-select first host in rercording

### DIFF
--- a/src/store/generator/slices/recording.utils.ts
+++ b/src/store/generator/slices/recording.utils.ts
@@ -20,7 +20,19 @@ export function groupHostsByParty(hosts: string[]) {
 }
 
 export function isHostThirdParty(host: string) {
-  const hostPatterns = ['.google.com', '.googleapis.com', '.gstatic.com']
+  const hostPatterns = [
+    '.google.com',
+    '.googleapis.com',
+    '.gstatic.com',
+    '.googleusercontent.com',
+    '.googleadservices.com',
+    '.doubleclick.net',
+    '.google-analytics.com',
+    '.googletagmanager.com',
+    '.googlesyndication.com',
+    '.googletagservices.com',
+    '.recaptcha.net',
+  ]
   return hostPatterns.some((pattern) => host.includes(pattern))
 }
 

--- a/src/store/generator/slices/recording.utils.ts
+++ b/src/store/generator/slices/recording.utils.ts
@@ -1,4 +1,4 @@
-import { uniq, orderBy } from 'lodash-es'
+import { uniq } from 'lodash-es'
 
 import { ProxyData } from '@/types'
 
@@ -6,13 +6,22 @@ export function extractUniqueHosts(requests: ProxyData[]) {
   return uniq(requests.map((request) => request.request.host).filter(Boolean))
 }
 
+export function groupHostsByParty(hosts: string[]) {
+  return hosts.reduce(
+    (acc, host) => {
+      const key = isHostThirdParty(host) ? 'thirdParty' : 'firstParty'
+      return {
+        ...acc,
+        [key]: [...acc[key], host],
+      }
+    },
+    { firstParty: [], thirdParty: [] }
+  )
+}
+
 export function isHostThirdParty(host: string) {
   const hostPatterns = ['.google.com', '.googleapis.com', '.gstatic.com']
   return hostPatterns.some((pattern) => host.includes(pattern))
-}
-
-export function orderThirdPartyHostsLast(hosts: string[]) {
-  return orderBy(hosts, isHostThirdParty)
 }
 
 export function shouldResetAllowList({

--- a/src/store/generator/slices/recording.utils.ts
+++ b/src/store/generator/slices/recording.utils.ts
@@ -1,4 +1,4 @@
-import { uniq, intersection, difference } from 'lodash-es'
+import { uniq, orderBy } from 'lodash-es'
 
 import { ProxyData } from '@/types'
 
@@ -11,12 +11,8 @@ export function isHostThirdParty(host: string) {
   return hostPatterns.some((pattern) => host.includes(pattern))
 }
 
-export function reorderHosts(hosts: string[]) {
-  const matchedHosts = hosts.filter((host) => isHostThirdParty(host))
-  const hostsToGoLast = intersection(hosts, matchedHosts)
-  const hostsToGoFirst = difference(hosts, hostsToGoLast)
-
-  return [...hostsToGoFirst, ...hostsToGoLast]
+export function orderThirdPartyHostsLast(hosts: string[]) {
+  return orderBy(hosts, isHostThirdParty)
 }
 
 export function shouldResetAllowList({

--- a/src/store/generator/slices/recording.utils.ts
+++ b/src/store/generator/slices/recording.utils.ts
@@ -1,9 +1,22 @@
-import { uniq } from 'lodash-es'
+import { uniq, intersection, difference } from 'lodash-es'
 
 import { ProxyData } from '@/types'
 
 export function extractUniqueHosts(requests: ProxyData[]) {
   return uniq(requests.map((request) => request.request.host).filter(Boolean))
+}
+
+export function isHostThirdParty(host: string) {
+  const hostPatterns = ['.google.com', '.googleapis.com', '.gstatic.com']
+  return hostPatterns.some((pattern) => host.includes(pattern))
+}
+
+export function reorderHosts(hosts: string[]) {
+  const matchedHosts = hosts.filter((host) => isHostThirdParty(host))
+  const hostsToGoLast = intersection(hosts, matchedHosts)
+  const hostsToGoFirst = difference(hosts, hostsToGoLast)
+
+  return [...hostsToGoFirst, ...hostsToGoLast]
 }
 
 export function shouldResetAllowList({

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -4,7 +4,10 @@ import { useState } from 'react'
 
 import { PopoverDialog } from '@/components/PopoverDialogs'
 import { useGeneratorStore } from '@/store/generator'
-import { extractUniqueHosts } from '@/store/generator/slices/recording.utils'
+import {
+  extractUniqueHosts,
+  reorderHosts,
+} from '@/store/generator/slices/recording.utils'
 
 import { AllowlistDialog } from './AllowlistDialog'
 
@@ -30,7 +33,8 @@ export function Allowlist() {
     (store) => store.setIncludeStaticAssets
   )
 
-  const hosts = extractUniqueHosts(requests)
+  const uniqueHosts = extractUniqueHosts(requests)
+  const hosts = reorderHosts(uniqueHosts)
 
   function handleOpenChange(open: boolean) {
     if (!open) {

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -39,6 +39,8 @@ export function Allowlist() {
   }, [requests])
 
   useEffect(() => {
+    // We only need the allowlist count when "hosts" changes
+    // This happens when the recording or the generator is changed
     const allowlistCount = useGeneratorStore.getState().allowlist.length
     if (hosts[0] !== undefined && allowlistCount === 0) {
       setAllowlist([hosts[0]])

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -1,6 +1,6 @@
 import { GlobeIcon } from '@radix-ui/react-icons'
 import { Button, Dialog, Flex } from '@radix-ui/themes'
-import { useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import { PopoverDialog } from '@/components/PopoverDialogs'
 import { useGeneratorStore } from '@/store/generator'
@@ -33,8 +33,17 @@ export function Allowlist() {
     (store) => store.setIncludeStaticAssets
   )
 
-  const uniqueHosts = extractUniqueHosts(requests)
-  const hosts = reorderHosts(uniqueHosts)
+  const hosts = useMemo(() => {
+    const uniqueHosts = extractUniqueHosts(requests)
+    return reorderHosts(uniqueHosts)
+  }, [requests])
+
+  useEffect(() => {
+    const allowlistCount = useGeneratorStore.getState().allowlist.length
+    if (hosts[0] !== undefined && allowlistCount === 0) {
+      setAllowlist([hosts[0]])
+    }
+  }, [hosts, setAllowlist])
 
   function handleOpenChange(open: boolean) {
     if (!open) {

--- a/src/views/Generator/Allowlist/Allowlist.tsx
+++ b/src/views/Generator/Allowlist/Allowlist.tsx
@@ -6,7 +6,7 @@ import { PopoverDialog } from '@/components/PopoverDialogs'
 import { useGeneratorStore } from '@/store/generator'
 import {
   extractUniqueHosts,
-  reorderHosts,
+  orderThirdPartyHostsLast,
 } from '@/store/generator/slices/recording.utils'
 
 import { AllowlistDialog } from './AllowlistDialog'
@@ -35,7 +35,7 @@ export function Allowlist() {
 
   const hosts = useMemo(() => {
     const uniqueHosts = extractUniqueHosts(requests)
-    return reorderHosts(uniqueHosts)
+    return orderThirdPartyHostsLast(uniqueHosts)
   }, [requests])
 
   useEffect(() => {

--- a/src/views/Generator/Allowlist/AllowlistCheckGroup.tsx
+++ b/src/views/Generator/Allowlist/AllowlistCheckGroup.tsx
@@ -1,0 +1,31 @@
+import { CheckboxGroup, Flex, Text } from '@radix-ui/themes'
+
+type AllowlistCheckGroupProps = {
+  hosts: string[]
+  allowlist: string[]
+  onValueChange: (allowlist: string[]) => void
+}
+
+export default function AllowlistCheckGroup({
+  hosts,
+  allowlist,
+  onValueChange,
+}: AllowlistCheckGroupProps) {
+  return (
+    <Flex p="2" pr="4" asChild overflow="hidden">
+      <CheckboxGroup.Root
+        size="2"
+        value={allowlist}
+        onValueChange={onValueChange}
+      >
+        {hosts.map((host) => (
+          <Text as="label" size="2" key={host}>
+            <Flex gap="2" align="center">
+              <CheckboxGroup.Item value={host} /> <Text truncate>{host}</Text>
+            </Flex>
+          </Text>
+        ))}
+      </CheckboxGroup.Root>
+    </Flex>
+  )
+}

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -57,7 +57,10 @@ export function AllowlistDialog({
   }, [requests, allowlist])
 
   function handleSelectAll() {
-    setAllowlist(filteredHosts)
+    const hostsToSelect = filteredHosts.filter(
+      (host) => !isHostThirdParty(host)
+    )
+    setAllowlist(hostsToSelect)
   }
 
   function handleSelectNone() {

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -76,9 +76,10 @@ export function AllowlistDialog({
     setIncludeStaticAssets(checked && staticAssetCount > 0)
   }
 
-  function shouldDisableSelectAll() {
-    return every(firstPartyFilteredHosts, (host) => includes(allowlist, host))
-  }
+  const isSelectAllDisabled = useMemo(
+    () => every(firstPartyFilteredHosts, (host) => includes(allowlist, host)),
+    [firstPartyFilteredHosts, allowlist]
+  )
 
   return (
     <>
@@ -113,7 +114,7 @@ export function AllowlistDialog({
           <Button
             size="1"
             onClick={handleSelectAll}
-            disabled={shouldDisableSelectAll()}
+            disabled={isSelectAllDisabled}
           >
             Select all
           </Button>

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -12,6 +12,7 @@ import {
   Inset,
   Separator,
 } from '@radix-ui/themes'
+import { every, includes } from 'lodash'
 import { useMemo, useState } from 'react'
 
 import { Label } from '@/components/Label'
@@ -60,7 +61,7 @@ export function AllowlistDialog({
   }, [requests, allowlist])
 
   function handleSelectAll() {
-    setAllowlist(firstPartyFilteredHosts)
+    setAllowlist([...allowlist, ...firstPartyFilteredHosts])
   }
 
   function handleSelectNone() {
@@ -73,6 +74,10 @@ export function AllowlistDialog({
 
   function handleCheckStaticAssets(checked: boolean) {
     setIncludeStaticAssets(checked && staticAssetCount > 0)
+  }
+
+  function shouldDisableSelectAll() {
+    return every(firstPartyFilteredHosts, (host) => includes(allowlist, host))
   }
 
   return (
@@ -108,7 +113,7 @@ export function AllowlistDialog({
           <Button
             size="1"
             onClick={handleSelectAll}
-            // disabled={isEqual(filteredHosts, allowlist)}
+            disabled={shouldDisableSelectAll()}
           >
             Select all
           </Button>

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -148,7 +148,7 @@ export function AllowlistDialog({
         </Inset>
       </Card>
 
-      <Flex justify="between" align="center" mb="2">
+      <Flex justify="between" align="center">
         <Label>
           <Checkbox
             onCheckedChange={handleCheckStaticAssets}

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -1,5 +1,9 @@
 import { css } from '@emotion/react'
-import { Cross2Icon, MagnifyingGlassIcon } from '@radix-ui/react-icons'
+import {
+  Cross2Icon,
+  InfoCircledIcon,
+  MagnifyingGlassIcon,
+} from '@radix-ui/react-icons'
 import {
   Button,
   Checkbox,
@@ -11,6 +15,7 @@ import {
   Card,
   Inset,
   Separator,
+  Tooltip,
 } from '@radix-ui/themes'
 import { every, includes } from 'lodash'
 import { useMemo, useState } from 'react'
@@ -132,7 +137,10 @@ export function AllowlistDialog({
       <Card size="1" mb="2">
         <Inset css={{ height: '210px' }}>
           <ScrollArea scrollbars="vertical" type="always">
-            <>
+            <Flex direction="column" pt="2">
+              {firstPartyFilteredHosts.length > 0 && (
+                <AllowlistSeparator text="Hosts" />
+              )}
               <AllowlistCheckGroup
                 allowlist={allowlist}
                 onValueChange={handleChangeHosts}
@@ -140,17 +148,10 @@ export function AllowlistDialog({
               />
               {thirdPartyFilteredHosts.length > 0 && (
                 <>
-                  <Flex align="center" px="2">
-                    <Text size="1" color="gray">
-                      3rd party hosts
-                    </Text>
-                    <Separator
-                      ml="2"
-                      css={css`
-                        flex-grow: 1;
-                      `}
-                    />
-                  </Flex>
+                  <AllowlistSeparator
+                    text="3rd party hosts"
+                    tooltip="Selecting third-party hosts may include irrelevant or sensitive data outside your control. It is recommended that only hosts directly related to your app are selected."
+                  />
                   <AllowlistCheckGroup
                     allowlist={allowlist}
                     onValueChange={handleChangeHosts}
@@ -158,7 +159,7 @@ export function AllowlistDialog({
                   />
                 </>
               )}
-            </>
+            </Flex>
           </ScrollArea>
         </Inset>
       </Card>
@@ -174,5 +175,36 @@ export function AllowlistDialog({
         </Label>
       </Flex>
     </>
+  )
+}
+
+function AllowlistSeparator({
+  text,
+  tooltip,
+}: {
+  text: string
+  tooltip?: string
+}) {
+  return (
+    <Flex align="center" px="2">
+      <Text size="1" color="gray">
+        {text}
+      </Text>
+      {tooltip && (
+        <Tooltip content={tooltip}>
+          <InfoCircledIcon
+            css={css`
+              margin-left: var(--space-1);
+            `}
+          />
+        </Tooltip>
+      )}
+      <Separator
+        ml="2"
+        css={css`
+          flex-grow: 1;
+        `}
+      />
+    </Flex>
   )
 }

--- a/src/views/Generator/Allowlist/AllowlistDialog.tsx
+++ b/src/views/Generator/Allowlist/AllowlistDialog.tsx
@@ -1,4 +1,8 @@
-import { Cross2Icon, MagnifyingGlassIcon } from '@radix-ui/react-icons'
+import {
+  Cross2Icon,
+  ExclamationTriangleIcon,
+  MagnifyingGlassIcon,
+} from '@radix-ui/react-icons'
 import {
   Button,
   Checkbox,
@@ -10,11 +14,13 @@ import {
   Text,
   Card,
   Inset,
+  Tooltip,
 } from '@radix-ui/themes'
 import { isEqual } from 'lodash-es'
 import { useMemo, useState } from 'react'
 
 import { Label } from '@/components/Label'
+import { isHostThirdParty } from '@/store/generator/slices/recording.utils'
 import { ProxyData } from '@/types'
 import { isNonStaticAssetResponse } from '@/utils/staticAssets'
 
@@ -125,9 +131,14 @@ export function AllowlistDialog({
               >
                 {filteredHosts.map((host) => (
                   <Text as="label" size="2" key={host}>
-                    <Flex gap="2">
+                    <Flex gap="2" align="center">
                       <CheckboxGroup.Item value={host} />{' '}
                       <Text truncate>{host}</Text>
+                      {isHostThirdParty(host) && (
+                        <Tooltip content="This host belongs to a third-party service">
+                          <ExclamationTriangleIcon />
+                        </Tooltip>
+                      )}
                     </Flex>
                   </Text>
                 ))}
@@ -137,7 +148,7 @@ export function AllowlistDialog({
         </Inset>
       </Card>
 
-      <Flex justify="between" align="center">
+      <Flex justify="between" align="center" mb="2">
         <Label>
           <Checkbox
             onCheckedChange={handleCheckStaticAssets}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR pre-selects the first URL in `AllowlistDialog`. This is not limited to the user inputting a host when starting a recording.

In addition to this, common domain names requested by Chrome browser are reordered to the end of the list.

![image](https://github.com/user-attachments/assets/ed32fb4b-1280-42be-ae5c-3e00211b029e)


<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open a generator that doesn't have any hosts selected
- Check that the first item in the list is selected (which should be the first host recorded in the HAR file)
- Check that hosts that belong to `googleapis.com` and `google.com` are moved to the end of the list
- Check that the user can unselected the pre-selected domain
- The pre-selected domain feature should only work when opening another generator or changing the recording within the generator window

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/43904fd4-1d90-493c-8a5a-92b9e3447de9

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/540

<!-- Thanks for your contribution! 🙏🏼 -->
