### PR TITLE
fix(browser): Values from password inputs are shown in plain text in the event log

### DIFF
--- a/extension/src/frontend/index.ts
+++ b/extension/src/frontend/index.ts
@@ -95,6 +95,7 @@ function handleTextAreaChange(target: HTMLTextAreaElement) {
     timestamp: Date.now(),
     selector: generateSelector(target),
     value: target.value,
+    sensitive: false,
     tab: '',
   })
 }
@@ -147,6 +148,7 @@ function handleInputChange(target: HTMLInputElement) {
     timestamp: Date.now(),
     selector: generateSelector(target),
     value: target.value,
+    sensitive: target.type === 'password',
     tab: '',
   })
 }

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -58,7 +58,7 @@ export function EventDescription({
         <>
           Changed input of{' '}
           <Selector value={event.selector} onHighlight={onHighlight} /> to{' '}
-          <code>{event.value}</code>
+          <code>{`"${event.sensitive ? '••••' : event.value}"`}</code>
         </>
       )
 

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -4,6 +4,7 @@ import { BrowserEvent } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 
 import { ClickDescription } from './ClickDescription'
+import { InputChangedDescription } from './InputChangedDescription'
 import { PageNavigationDescription } from './PageNavigationDescription'
 import { Selector } from './Selector'
 
@@ -54,13 +55,7 @@ export function EventDescription({
       return <ClickDescription event={event} onHighlight={onHighlight} />
 
     case 'input-changed':
-      return (
-        <>
-          Changed input of{' '}
-          <Selector value={event.selector} onHighlight={onHighlight} /> to{' '}
-          <code>{`"${event.sensitive ? '••••' : event.value}"`}</code>
-        </>
-      )
+      return <InputChangedDescription event={event} onHighlight={onHighlight} />
 
     case 'check-changed':
       return (

--- a/src/components/BrowserEventList/EventDescription/InputChangedDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/InputChangedDescription.tsx
@@ -1,0 +1,93 @@
+import { css } from '@emotion/react'
+import { EyeNoneIcon, EyeOpenIcon } from '@radix-ui/react-icons'
+import { ReactNode, useState } from 'react'
+
+import { InputChangedEvent } from '@/schemas/recording'
+
+import { Selector } from './Selector'
+
+const valueStyles = css`
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+`
+
+const buttonStyles = css`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+
+  opacity: 1;
+
+  &:hover {
+    opacity: 0.7;
+  }
+
+  & > svg {
+    width: 0.9em;
+    height: 0.9em;
+  }
+`
+
+interface SensitiveValueProps {
+  sensitive: boolean
+  value: ReactNode
+}
+
+function MaskedValue({ sensitive, value }: SensitiveValueProps) {
+  const [showValue, setShowValue] = useState(!sensitive)
+
+  if (!sensitive) {
+    return (
+      <>
+        {'"'}
+        {value}
+        {'"'}
+      </>
+    )
+  }
+
+  return (
+    <span css={valueStyles}>
+      {'"'}
+      <span>
+        {showValue && value}
+        {!showValue && '••••'}
+      </span>
+      <button
+        css={buttonStyles}
+        aria-pressed={showValue}
+        aria-label={showValue ? 'Hide masked value' : 'Show masked value'}
+        onClick={() => setShowValue(!showValue)}
+      >
+        {showValue && <EyeNoneIcon />}
+        {!showValue && <EyeOpenIcon />}
+      </button>
+      {'"'}
+    </span>
+  )
+}
+
+interface InputChangedDescriptionProps {
+  event: InputChangedEvent
+  onHighlight: (selector: string | null) => void
+}
+
+export function InputChangedDescription({
+  event,
+  onHighlight,
+}: InputChangedDescriptionProps) {
+  return (
+    <>
+      Changed input of{' '}
+      <Selector value={event.selector} onHighlight={onHighlight} /> to{' '}
+      <code>
+        <MaskedValue sensitive={event.sensitive} value={event.value} />
+      </code>
+    </>
+  )
+}

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -36,6 +36,7 @@ const InputChangedEventSchema = BrowserEventBaseSchema.extend({
   tab: z.string(),
   selector: z.string(),
   value: z.string(),
+  sensitive: z.boolean(),
 })
 
 const CheckChangedEventSchema = BrowserEventBaseSchema.extend({


### PR DESCRIPTION
## Description

For security reasons, it's a bad idea to display passwords in plain text in the event log. 

The data is still recorded, but this way we at least stop the password from being leaked by someone looking over the shoulder.

## How to Test

1. Go to a page with a _proper_ password input (unlike those in quickpizza).
2. Change the value of the password input.
3. Check the browser event log.
4. The logged event should have its value masked.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/5a845531-a7a8-455a-aadd-96adafdfe099



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
