### PR TITLE
refactor(Split main): Move HAR handlers out of main.ts

### DIFF
--- a/src/handlers/har/index.ts
+++ b/src/handlers/har/index.ts
@@ -7,10 +7,14 @@ import { HarWithOptionalResponse } from '@/types/har'
 import { browserWindowFromEvent } from '@/utils/electron'
 import { createFileWithUniqueName } from '@/utils/fileSystem'
 
+import { HarHandler } from './types'
+
 export function initialize() {
   ipcMain.handle(
-    'har:save',
+    HarHandler.SaveFile,
     async (_, data: HarWithOptionalResponse, prefix: string) => {
+      console.info(`${HarHandler.SaveFile} event received`)
+
       const fileName = await createFileWithUniqueName({
         data: JSON.stringify(data, null, 2),
         directory: RECORDINGS_PATH,
@@ -23,9 +27,10 @@ export function initialize() {
   )
 
   ipcMain.handle(
-    'har:open',
+    HarHandler.OpenFile,
     async (_, fileName: string): Promise<HarWithOptionalResponse> => {
-      console.info('har:open event received')
+      console.info(`${HarHandler.OpenFile} event received`)
+
       const data = await readFile(path.join(RECORDINGS_PATH, fileName), {
         encoding: 'utf-8',
         flag: 'r',
@@ -35,8 +40,8 @@ export function initialize() {
     }
   )
 
-  ipcMain.handle('har:import', async (event) => {
-    console.info('har:import event received')
+  ipcMain.handle(HarHandler.ImportFile, async (event) => {
+    console.info(`${HarHandler.ImportFile} event received`)
 
     const browserWindow = browserWindowFromEvent(event)
 

--- a/src/handlers/har/index.ts
+++ b/src/handlers/har/index.ts
@@ -1,0 +1,63 @@
+import { ipcMain, dialog } from 'electron'
+import { readFile, copyFile } from 'fs/promises'
+import path from 'path'
+
+import { RECORDINGS_PATH } from '@/constants/workspace'
+import { HarWithOptionalResponse } from '@/types/har'
+import { browserWindowFromEvent } from '@/utils/electron'
+import { createFileWithUniqueName } from '@/utils/fileSystem'
+
+export function initialize() {
+  ipcMain.handle(
+    'har:save',
+    async (_, data: HarWithOptionalResponse, prefix: string) => {
+      const fileName = await createFileWithUniqueName({
+        data: JSON.stringify(data, null, 2),
+        directory: RECORDINGS_PATH,
+        ext: '.har',
+        prefix,
+      })
+
+      return fileName
+    }
+  )
+
+  ipcMain.handle(
+    'har:open',
+    async (_, fileName: string): Promise<HarWithOptionalResponse> => {
+      console.info('har:open event received')
+      const data = await readFile(path.join(RECORDINGS_PATH, fileName), {
+        encoding: 'utf-8',
+        flag: 'r',
+      })
+
+      return JSON.parse(data)
+    }
+  )
+
+  ipcMain.handle('har:import', async (event) => {
+    console.info('har:import event received')
+
+    const browserWindow = browserWindowFromEvent(event)
+
+    const dialogResult = await dialog.showOpenDialog(browserWindow, {
+      message: 'Import HAR file',
+      properties: ['openFile'],
+      defaultPath: RECORDINGS_PATH,
+      filters: [{ name: 'HAR', extensions: ['har'] }],
+    })
+
+    const filePath = dialogResult.filePaths[0]
+
+    if (dialogResult.canceled || !filePath) {
+      return
+    }
+
+    await copyFile(
+      filePath,
+      path.join(RECORDINGS_PATH, path.basename(filePath))
+    )
+
+    return path.basename(filePath)
+  })
+}

--- a/src/handlers/har/preload.ts
+++ b/src/handlers/har/preload.ts
@@ -1,0 +1,26 @@
+import { ipcRenderer } from 'electron'
+
+import { HarWithOptionalResponse } from '@/types/har'
+
+import { HarHandler } from './types'
+
+export function saveFile(data: HarWithOptionalResponse, prefix: string) {
+  return ipcRenderer.invoke(
+    HarHandler.SaveFile,
+    data,
+    prefix
+  ) as Promise<string>
+}
+
+export function openFile(filePath: string) {
+  return ipcRenderer.invoke(
+    HarHandler.OpenFile,
+    filePath
+  ) as Promise<HarWithOptionalResponse>
+}
+
+export function importFile() {
+  return ipcRenderer.invoke(HarHandler.ImportFile) as Promise<
+    string | undefined
+  >
+}

--- a/src/handlers/har/types.ts
+++ b/src/handlers/har/types.ts
@@ -1,0 +1,5 @@
+export enum HarHandler {
+  SaveFile = 'har:save',
+  OpenFile = 'har:open',
+  ImportFile = 'har:import',
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,7 +1,9 @@
 import * as auth from './auth'
 import * as cloud from './cloud'
+import * as har from './har'
 
 export function initialize() {
   auth.initialize()
   cloud.initialize()
+  har.initialize()
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,6 @@ import {
 } from './settings'
 import { ProxyStatus, StudioFile } from './types'
 import { GeneratorFileData } from './types/generator'
-import { HarWithOptionalResponse } from './types/har'
 import { AppSettings } from './types/settings'
 import { DataFilePreview } from './types/testData'
 import { sendReport } from './usageReport'
@@ -459,57 +458,6 @@ ipcMain.handle(
     }
   }
 )
-
-// HAR
-ipcMain.handle(
-  'har:save',
-  async (_, data: HarWithOptionalResponse, prefix: string) => {
-    const fileName = await createFileWithUniqueName({
-      data: JSON.stringify(data, null, 2),
-      directory: RECORDINGS_PATH,
-      ext: '.har',
-      prefix,
-    })
-
-    return fileName
-  }
-)
-
-ipcMain.handle(
-  'har:open',
-  async (_, fileName: string): Promise<HarWithOptionalResponse> => {
-    console.info('har:open event received')
-    const data = await readFile(path.join(RECORDINGS_PATH, fileName), {
-      encoding: 'utf-8',
-      flag: 'r',
-    })
-
-    return JSON.parse(data)
-  }
-)
-
-ipcMain.handle('har:import', async (event) => {
-  console.info('har:import event received')
-
-  const browserWindow = browserWindowFromEvent(event)
-
-  const dialogResult = await dialog.showOpenDialog(browserWindow, {
-    message: 'Import HAR file',
-    properties: ['openFile'],
-    defaultPath: RECORDINGS_PATH,
-    filters: [{ name: 'HAR', extensions: ['har'] }],
-  })
-
-  const filePath = dialogResult.filePaths[0]
-
-  if (dialogResult.canceled || !filePath) {
-    return
-  }
-
-  await copyFile(filePath, path.join(RECORDINGS_PATH, path.basename(filePath)))
-
-  return path.basename(filePath)
-})
 
 // Generator
 ipcMain.handle('generator:create', async (_, recordingPath: string) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,7 @@ import {
   getPlatform,
   browserWindowFromEvent,
 } from './utils/electron'
+import { createFileWithUniqueName } from './utils/fileSystem'
 import { createNewGeneratorFile } from './utils/generator'
 import { exhaustive, isNodeJsErrnoException } from './utils/typescript'
 import { setupProjectStructure } from './utils/workspace'
@@ -998,44 +999,4 @@ const cleanUpProxies = async () => {
   processList.forEach((proc) => {
     kill(proc.pid)
   })
-}
-
-const createFileWithUniqueName = async ({
-  directory,
-  data,
-  prefix,
-  ext,
-}: {
-  directory: string
-  data: string
-  prefix: string
-  ext: string
-}): Promise<string> => {
-  const timestamp = new Date().toISOString().split('T')[0] ?? ''
-  const template = `${prefix ? `${prefix} - ` : ''}${timestamp}${ext}`
-
-  // Start from 2 as it follows the the OS behavior for duplicate files
-  let fileVersion = 2
-  let uniqueFileName = template
-  let fileCreated = false
-
-  do {
-    try {
-      // ax+ flag will throw an error if the file already exists
-      await writeFile(path.join(directory, uniqueFileName), data, {
-        flag: 'ax+',
-      })
-      fileCreated = true
-    } catch (error) {
-      if (isNodeJsErrnoException(error) && error.code !== 'EEXIST') {
-        throw error
-      }
-
-      const { name, ext } = path.parse(template)
-      uniqueFileName = `${name} (${fileVersion})${ext}`
-      fileVersion++
-    }
-  } while (!fileCreated)
-
-  return uniqueFileName
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,11 +4,11 @@ import { ipcRenderer, contextBridge } from 'electron'
 
 import * as auth from './handlers/auth/preload'
 import * as cloud from './handlers/cloud/preload'
+import * as har from './handlers/har/preload'
 import { createListener } from './handlers/utils'
 import * as Sentry from './sentry'
 import { ProxyData, K6Log, K6Check, ProxyStatus, StudioFile } from './types'
 import { GeneratorFileData } from './types/generator'
-import { HarWithOptionalResponse } from './types/har'
 import { AppSettings } from './types/settings'
 import { DataFilePreview } from './types/testData'
 import { AddToastPayload } from './types/toast'
@@ -92,21 +92,6 @@ const script = {
   },
   onScriptCheck: (callback: (data: K6Check[]) => void) => {
     return createListener('script:check', callback)
-  },
-} as const
-
-const har = {
-  saveFile: (
-    data: HarWithOptionalResponse,
-    prefix: string
-  ): Promise<string> => {
-    return ipcRenderer.invoke('har:save', data, prefix)
-  },
-  openFile: (filePath: string): Promise<HarWithOptionalResponse> => {
-    return ipcRenderer.invoke('har:open', filePath)
-  },
-  importFile: (): Promise<string | undefined> => {
-    return ipcRenderer.invoke('har:import')
   },
 } as const
 

--- a/src/utils/fileSystem.ts
+++ b/src/utils/fileSystem.ts
@@ -1,0 +1,44 @@
+import { writeFile } from 'fs/promises'
+import path from 'path'
+
+import { isNodeJsErrnoException } from './typescript'
+
+export async function createFileWithUniqueName({
+  directory,
+  data,
+  prefix,
+  ext,
+}: {
+  directory: string
+  data: string
+  prefix: string
+  ext: string
+}): Promise<string> {
+  const timestamp = new Date().toISOString().split('T')[0] ?? ''
+  const template = `${prefix ? `${prefix} - ` : ''}${timestamp}${ext}`
+
+  // Start from 2 as it follows the the OS behavior for duplicate files
+  let fileVersion = 2
+  let uniqueFileName = template
+  let fileCreated = false
+
+  do {
+    try {
+      // ax+ flag will throw an error if the file already exists
+      await writeFile(path.join(directory, uniqueFileName), data, {
+        flag: 'ax+',
+      })
+      fileCreated = true
+    } catch (error) {
+      if (isNodeJsErrnoException(error) && error.code !== 'EEXIST') {
+        throw error
+      }
+
+      const { name, ext } = path.parse(template)
+      uniqueFileName = `${name} (${fileVersion})${ext}`
+      fileVersion++
+    }
+  } while (!fileCreated)
+
+  return uniqueFileName
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR kicks off the work of decoupling the `main.ts` file by separating the IPC handlers into their own namespace/folders. This work will be broken down into many pieces so it's easier to review and validate the changes.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

Validate the following:

- Opening a HAR file works as expected
- Stopping a recording saves a HAR file successfully
- Importing a HAR file into an existing generator works as expected

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
