### PR TITLE
refactor(split main): Move browser handlers out of main.ts

### DIFF
--- a/forge.env.d.ts
+++ b/forge.env.d.ts
@@ -1,3 +1,5 @@
+import { k6StudioState } from '@/k6StudioState'
+
 export {} // Make this a module
 
 declare global {
@@ -14,6 +16,9 @@ declare global {
       viteDevServers: Record<string, import('vite').ViteDevServer>
     }
   }
+
+  // eslint-disable-next-line no-var
+  var k6StudioState: k6StudioState
 
   type VitePluginConfig = ConstructorParameters<
     typeof import('@electron-forge/plugin-vite').VitePlugin

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -12,6 +12,7 @@ import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
 
+import { BrowserHandler } from './handlers/browser/types'
 import { appSettings } from './main'
 import { getCertificateSPKI } from './proxy'
 import { getPlatform } from './utils/electron'
@@ -62,13 +63,13 @@ export const launchBrowser = async (
   const sendBrowserClosedEvent = (): Promise<void> => {
     // we send the browser:stopped event when the browser is closed
     // NOTE: on macos pressing the X button does not close the application so it won't be fired
-    browserWindow.webContents.send('browser:closed')
+    browserWindow.webContents.send(BrowserHandler.Closed)
     return Promise.resolve()
   }
 
   const sendBrowserLaunchFailedEvent = (error: Error) => {
     log.error(error)
-    browserWindow.webContents.send('browser:failed')
+    browserWindow.webContents.send(BrowserHandler.Failed)
   }
 
   const args = [

--- a/src/handlers/browser/index.ts
+++ b/src/handlers/browser/index.ts
@@ -1,0 +1,43 @@
+import { ipcMain, shell } from 'electron'
+
+import { launchBrowser } from '@/browser'
+import { waitForProxy } from '@/proxy'
+import { browserWindowFromEvent } from '@/utils/electron'
+
+export function initialize() {
+  ipcMain.handle('browser:start', async (event, url?: string) => {
+    console.info('browser:start event received')
+
+    await waitForProxy()
+
+    const browserWindow = browserWindowFromEvent(event)
+    k6StudioState.currentBrowserProcess = await launchBrowser(
+      browserWindow,
+      url
+    )
+    console.info('browser started')
+  })
+
+  ipcMain.on('browser:stop', async () => {
+    console.info('browser:stop event received')
+
+    const { currentBrowserProcess } = k6StudioState
+
+    if (currentBrowserProcess) {
+      // macOS & windows
+      if ('close' in currentBrowserProcess) {
+        await currentBrowserProcess.close()
+        // linux
+      } else {
+        currentBrowserProcess.kill()
+      }
+
+      k6StudioState.currentBrowserProcess = null
+    }
+  })
+
+  ipcMain.handle('browser:open:external:link', (_, url: string) => {
+    console.info('browser:open:external:link event received')
+    return shell.openExternal(url)
+  })
+}

--- a/src/handlers/browser/index.ts
+++ b/src/handlers/browser/index.ts
@@ -4,9 +4,11 @@ import { launchBrowser } from '@/browser'
 import { waitForProxy } from '@/proxy'
 import { browserWindowFromEvent } from '@/utils/electron'
 
+import { BrowserHandler } from './types'
+
 export function initialize() {
-  ipcMain.handle('browser:start', async (event, url?: string) => {
-    console.info('browser:start event received')
+  ipcMain.handle(BrowserHandler.Start, async (event, url?: string) => {
+    console.info(`${BrowserHandler.Start} event received`)
 
     await waitForProxy()
 
@@ -18,8 +20,8 @@ export function initialize() {
     console.info('browser started')
   })
 
-  ipcMain.on('browser:stop', async () => {
-    console.info('browser:stop event received')
+  ipcMain.on(BrowserHandler.Stop, async () => {
+    console.info(`${BrowserHandler.Stop} event received`)
 
     const { currentBrowserProcess } = k6StudioState
 
@@ -36,8 +38,8 @@ export function initialize() {
     }
   })
 
-  ipcMain.handle('browser:open:external:link', (_, url: string) => {
-    console.info('browser:open:external:link event received')
+  ipcMain.handle(BrowserHandler.OpenExternalLink, (_, url: string) => {
+    console.info(`${BrowserHandler.OpenExternalLink} event received`)
     return shell.openExternal(url)
   })
 }

--- a/src/handlers/browser/preload.ts
+++ b/src/handlers/browser/preload.ts
@@ -1,0 +1,25 @@
+import { ipcRenderer } from 'electron'
+
+import { createListener } from '../utils'
+
+import { BrowserHandler } from './types'
+
+export function launchBrowser(url?: string) {
+  return ipcRenderer.invoke(BrowserHandler.Start, url) as Promise<void>
+}
+
+export function stopBrowser() {
+  ipcRenderer.send(BrowserHandler.Stop)
+}
+
+export function onBrowserClosed(callback: () => void) {
+  return createListener(BrowserHandler.Closed, callback)
+}
+
+export function onBrowserLaunchFailed(callback: () => void) {
+  return createListener(BrowserHandler.Failed, callback)
+}
+
+export function openExternalLink(url: string) {
+  return ipcRenderer.invoke(BrowserHandler.OpenExternalLink, url)
+}

--- a/src/handlers/browser/types.ts
+++ b/src/handlers/browser/types.ts
@@ -1,5 +1,7 @@
 export enum BrowserHandler {
   Start = 'browser:start',
   Stop = 'browser:stop',
+  Closed = 'browser:closed',
+  Failed = 'browser:failed',
   OpenExternalLink = 'browser:open:external:link',
 }

--- a/src/handlers/browser/types.ts
+++ b/src/handlers/browser/types.ts
@@ -1,0 +1,5 @@
+export enum BrowserHandler {
+  Start = 'browser:start',
+  Stop = 'browser:stop',
+  OpenExternalLink = 'browser:open:external:link',
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,4 +1,5 @@
 import * as auth from './auth'
+import * as browser from './browser'
 import * as cloud from './cloud'
 import * as har from './har'
 
@@ -6,4 +7,5 @@ export function initialize() {
   auth.initialize()
   cloud.initialize()
   har.initialize()
+  browser.initialize()
 }

--- a/src/k6StudioState.ts
+++ b/src/k6StudioState.ts
@@ -1,0 +1,22 @@
+import { Process } from '@puppeteer/browsers'
+import { ChildProcessWithoutNullStreams } from 'child_process'
+import eventEmitter from 'events'
+
+import { ProxyStatus } from './types'
+
+export type k6StudioState = {
+  currentBrowserProcess: Process | ChildProcessWithoutNullStreams | null
+  proxyStatus: ProxyStatus
+  proxyEmitter: eventEmitter
+}
+
+export function initialize() {
+  globalThis.k6StudioState = {
+    currentBrowserProcess: null,
+    proxyStatus: 'offline',
+    proxyEmitter: new eventEmitter<{
+      'status:change': [ProxyStatus]
+      ready: [void]
+    }>(),
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,7 @@
 import { ipcRenderer, contextBridge } from 'electron'
 
 import * as auth from './handlers/auth/preload'
+import * as browser from './handlers/browser/preload'
 import * as cloud from './handlers/cloud/preload'
 import * as har from './handlers/har/preload'
 import { createListener } from './handlers/utils'
@@ -35,24 +36,6 @@ const proxy = {
   },
   onProxyStatusChange: (callback: (status: ProxyStatus) => void) => {
     return createListener('proxy:status:change', callback)
-  },
-} as const
-
-const browser = {
-  launchBrowser: (url?: string): Promise<void> => {
-    return ipcRenderer.invoke('browser:start', url)
-  },
-  stopBrowser: () => {
-    ipcRenderer.send('browser:stop')
-  },
-  onBrowserClosed: (callback: () => void) => {
-    return createListener('browser:closed', callback)
-  },
-  onBrowserLaunchFailed: (callback: () => void) => {
-    return createListener('browser:failed', callback)
-  },
-  openExternalLink: (url: string) => {
-    return ipcRenderer.invoke('browser:open:external:link', url)
   },
 } as const
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -147,3 +147,15 @@ export const getCertificateSPKI = async () => {
   // base64 encoded spki
   return forge.util.encode64(spki)
 }
+
+export const waitForProxy = async (): Promise<void> => {
+  if (k6StudioState.proxyStatus === 'online') {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve) => {
+    k6StudioState.proxyEmitter.once('ready', () => {
+      resolve()
+    })
+  })
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR continues the work of refactoring the main process by moving the `browser` handlers out of the `main.ts` file.
In addition to the IPC handlers, this PR introduces a global variable `k6StudioState` to help managing global variables that are being used across multiple handlers.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Check that the browser works as expected by starting and stopping a recording
- Check that the proxy status changes as expected

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
