### PR TITLE
refactor(split main): Move script handlers out of main.ts

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,10 +2,12 @@ import * as auth from './auth'
 import * as browser from './browser'
 import * as cloud from './cloud'
 import * as har from './har'
+import * as script from './script'
 
 export function initialize() {
   auth.initialize()
   cloud.initialize()
   har.initialize()
   browser.initialize()
+  script.initialize()
 }

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -1,0 +1,109 @@
+import { ipcMain } from 'electron'
+import log from 'electron-log/main'
+import { readFile, writeFile, unlink } from 'fs/promises'
+import path from 'path'
+
+import { SCRIPTS_PATH, TEMP_GENERATOR_SCRIPT_PATH } from '@/constants/workspace'
+import { appSettings } from '@/main'
+import { waitForProxy } from '@/proxy'
+import { showScriptSelectDialog, runScript, type K6Process } from '@/script'
+import { browserWindowFromEvent, sendToast } from '@/utils/electron'
+
+export function initialize() {
+  let currentk6Process: K6Process | null
+
+  ipcMain.handle('script:select', async (event) => {
+    console.info('script:select event received')
+    const browserWindow = browserWindowFromEvent(event)
+    const scriptPath = await showScriptSelectDialog(browserWindow)
+
+    return scriptPath
+  })
+
+  ipcMain.handle(
+    'script:open',
+    async (_, scriptPath: string, absolute: boolean = false) => {
+      console.log('script:open event received')
+      const resolvedScriptPath = absolute
+        ? scriptPath
+        : path.join(SCRIPTS_PATH, scriptPath)
+
+      const script = await readFile(resolvedScriptPath, {
+        encoding: 'utf-8',
+        flag: 'r',
+      })
+
+      return script
+    }
+  )
+
+  ipcMain.handle(
+    'script:run',
+    async (event, scriptPath: string, absolute: boolean = false) => {
+      console.info('script:run event received')
+      await waitForProxy()
+
+      const browserWindow = browserWindowFromEvent(event)
+
+      const resolvedScriptPath = absolute
+        ? scriptPath
+        : path.join(SCRIPTS_PATH, scriptPath)
+
+      currentk6Process = await runScript({
+        browserWindow,
+        scriptPath: resolvedScriptPath,
+        proxyPort: appSettings.proxy.port,
+        usageReport: appSettings.telemetry.usageReport,
+      })
+    }
+  )
+
+  ipcMain.on('script:stop', (event) => {
+    console.info('script:stop event received')
+    if (currentk6Process) {
+      currentk6Process.kill()
+      currentk6Process = null
+    }
+
+    const browserWindow = browserWindowFromEvent(event)
+    browserWindow.webContents.send('script:stopped')
+  })
+
+  ipcMain.handle('script:run-from-generator', async (event, script: string) => {
+    console.log('script:run-from-generator event received')
+    await writeFile(TEMP_GENERATOR_SCRIPT_PATH, script)
+
+    const browserWindow = browserWindowFromEvent(event)
+
+    currentk6Process = await runScript({
+      browserWindow,
+      scriptPath: TEMP_GENERATOR_SCRIPT_PATH,
+      proxyPort: appSettings.proxy.port,
+      usageReport: appSettings.telemetry.usageReport,
+    })
+
+    await unlink(TEMP_GENERATOR_SCRIPT_PATH)
+  })
+
+  ipcMain.handle(
+    'script:save',
+    async (event, script: string, fileName: string = 'script.js') => {
+      console.log('script:save event received')
+      const browserWindow = browserWindowFromEvent(event)
+      try {
+        const filePath = path.join(SCRIPTS_PATH, fileName)
+        await writeFile(filePath, script)
+        sendToast(browserWindow.webContents, {
+          title: 'Script exported successfully',
+          status: 'success',
+        })
+      } catch (error) {
+        sendToast(browserWindow.webContents, {
+          title: 'Failed to export the script',
+          status: 'error',
+        })
+        log.error(error)
+      }
+    }
+  )
+}

--- a/src/handlers/script/preload.ts
+++ b/src/handlers/script/preload.ts
@@ -1,0 +1,56 @@
+import { ipcRenderer } from 'electron'
+
+import { K6Log, K6Check } from '@/types'
+
+import { createListener } from '../utils'
+
+export function showScriptSelectDialog() {
+  return ipcRenderer.invoke('script:select') as Promise<string | void>
+}
+
+export function openScript(scriptPath: string, absolute: boolean = false) {
+  return ipcRenderer.invoke(
+    'script:open',
+    scriptPath,
+    absolute
+  ) as Promise<string>
+}
+
+export function runScriptFromGenerator(script: string) {
+  return ipcRenderer.invoke(
+    'script:run-from-generator',
+    script
+  ) as Promise<void>
+}
+
+export function saveScript(script: string, fileName: string) {
+  return ipcRenderer.invoke('script:save', script, fileName) as Promise<void>
+}
+
+export function runScript(scriptPath: string, absolute: boolean = false) {
+  return ipcRenderer.invoke('script:run', scriptPath, absolute) as Promise<void>
+}
+
+export function stopScript() {
+  ipcRenderer.send('script:stop')
+}
+
+export function onScriptLog(callback: (data: K6Log) => void) {
+  return createListener('script:log', callback)
+}
+
+export function onScriptStopped(callback: () => void) {
+  return createListener('script:stopped', callback)
+}
+
+export function onScriptFinished(callback: () => void) {
+  return createListener('script:finished', callback)
+}
+
+export function onScriptFailed(callback: () => void) {
+  return createListener('script:failed', callback)
+}
+
+export function onScriptCheck(callback: (data: K6Check[]) => void) {
+  return createListener('script:check', callback)
+}

--- a/src/handlers/script/preload.ts
+++ b/src/handlers/script/preload.ts
@@ -4,13 +4,15 @@ import { K6Log, K6Check } from '@/types'
 
 import { createListener } from '../utils'
 
+import { ScriptHandler } from './types'
+
 export function showScriptSelectDialog() {
   return ipcRenderer.invoke('script:select') as Promise<string | void>
 }
 
 export function openScript(scriptPath: string, absolute: boolean = false) {
   return ipcRenderer.invoke(
-    'script:open',
+    ScriptHandler.Open,
     scriptPath,
     absolute
   ) as Promise<string>
@@ -18,39 +20,47 @@ export function openScript(scriptPath: string, absolute: boolean = false) {
 
 export function runScriptFromGenerator(script: string) {
   return ipcRenderer.invoke(
-    'script:run-from-generator',
+    ScriptHandler.RunFromGenerator,
     script
   ) as Promise<void>
 }
 
 export function saveScript(script: string, fileName: string) {
-  return ipcRenderer.invoke('script:save', script, fileName) as Promise<void>
+  return ipcRenderer.invoke(
+    ScriptHandler.Save,
+    script,
+    fileName
+  ) as Promise<void>
 }
 
 export function runScript(scriptPath: string, absolute: boolean = false) {
-  return ipcRenderer.invoke('script:run', scriptPath, absolute) as Promise<void>
+  return ipcRenderer.invoke(
+    ScriptHandler.Run,
+    scriptPath,
+    absolute
+  ) as Promise<void>
 }
 
 export function stopScript() {
-  ipcRenderer.send('script:stop')
+  ipcRenderer.send(ScriptHandler.Stop)
 }
 
 export function onScriptLog(callback: (data: K6Log) => void) {
-  return createListener('script:log', callback)
+  return createListener(ScriptHandler.Log, callback)
 }
 
 export function onScriptStopped(callback: () => void) {
-  return createListener('script:stopped', callback)
+  return createListener(ScriptHandler.Stopped, callback)
 }
 
 export function onScriptFinished(callback: () => void) {
-  return createListener('script:finished', callback)
+  return createListener(ScriptHandler.Finished, callback)
 }
 
 export function onScriptFailed(callback: () => void) {
-  return createListener('script:failed', callback)
+  return createListener(ScriptHandler.Failed, callback)
 }
 
 export function onScriptCheck(callback: (data: K6Check[]) => void) {
-  return createListener('script:check', callback)
+  return createListener(ScriptHandler.Check, callback)
 }

--- a/src/handlers/script/types.ts
+++ b/src/handlers/script/types.ts
@@ -1,0 +1,13 @@
+export enum ScriptHandler {
+  Select = 'script:select',
+  Open = 'script:open',
+  Run = 'script:run',
+  Stop = 'script:stop',
+  Save = 'script:save',
+  Log = 'script:log',
+  Stopped = 'script:stopped',
+  Finished = 'script:finished',
+  Failed = 'script:failed',
+  Check = 'script:check',
+  RunFromGenerator = 'script:run-from-generator',
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,9 +6,10 @@ import * as auth from './handlers/auth/preload'
 import * as browser from './handlers/browser/preload'
 import * as cloud from './handlers/cloud/preload'
 import * as har from './handlers/har/preload'
+import * as script from './handlers/script/preload'
 import { createListener } from './handlers/utils'
 import * as Sentry from './sentry'
-import { ProxyData, K6Log, K6Check, ProxyStatus, StudioFile } from './types'
+import { ProxyData, ProxyStatus, StudioFile } from './types'
 import { GeneratorFileData } from './types/generator'
 import { AppSettings } from './types/settings'
 import { DataFilePreview } from './types/testData'
@@ -36,45 +37,6 @@ const proxy = {
   },
   onProxyStatusChange: (callback: (status: ProxyStatus) => void) => {
     return createListener('proxy:status:change', callback)
-  },
-} as const
-
-const script = {
-  showScriptSelectDialog: (): Promise<string | void> => {
-    return ipcRenderer.invoke('script:select')
-  },
-  openScript: (
-    scriptPath: string,
-    absolute: boolean = false
-  ): Promise<string> => {
-    return ipcRenderer.invoke('script:open', scriptPath, absolute)
-  },
-  runScriptFromGenerator: (script: string): Promise<void> => {
-    return ipcRenderer.invoke('script:run-from-generator', script)
-  },
-  saveScript: (script: string, fileName: string): Promise<void> => {
-    return ipcRenderer.invoke('script:save', script, fileName)
-  },
-  runScript: (scriptPath: string, absolute: boolean = false): Promise<void> => {
-    return ipcRenderer.invoke('script:run', scriptPath, absolute)
-  },
-  stopScript: () => {
-    ipcRenderer.send('script:stop')
-  },
-  onScriptLog: (callback: (data: K6Log) => void) => {
-    return createListener('script:log', callback)
-  },
-  onScriptStopped: (callback: () => void) => {
-    return createListener('script:stopped', callback)
-  },
-  onScriptFinished: (callback: () => void) => {
-    return createListener('script:finished', callback)
-  },
-  onScriptFailed: (callback: () => void) => {
-    return createListener('script:failed', callback)
-  },
-  onScriptCheck: (callback: (data: K6Check[]) => void) => {
-    return createListener('script:check', callback)
   },
 } as const
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR continues the work of moving the IPC handlers out of the `main.ts` file.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

Test areas where `script` handlers are used:

Validator:
- Open an existing script from the sidebar
- Validate the script
- Stop the script execution
- Open an external script

Generator:
- Export a script
- Validate the script
- Stop the script execution

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
