### PR TITLE
chore: release test version action

### DIFF
--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -1,0 +1,132 @@
+name: 'Manual Release Test Version'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Specify a version for the test release (ex. test-browser)"
+        required: true
+        type: string
+        default: "test-version"
+
+jobs:
+  publish-studio:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        # There is a bug on Ubuntu 22.04 (ubuntu-latest) regarding stripping a binary for a different
+        # architecture. Since we include both x86_64 and arm64 in linux a solution is to use ubuntu 20.04
+        # https://github.com/electron/forge/issues/3102
+        # https://github.com/electron/forge/issues/3701
+        platform: [macos-latest, windows-latest, ubuntu-20.04]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set version for test release
+        with:
+          version: ${{ inputs.version }}
+        run: python update_version.py
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # try earlier python version for appdmg
+      # https://github.com/electron/forge/issues/3371#issuecomment-2105195302
+      - name: Install Python 3.11.4
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11.4'
+
+      - name: install dependencies
+        run: npm ci
+
+      - name: setup macos keychain
+        if: startsWith(matrix.platform, 'macos-')
+        run: |
+          echo "$APPLE_API_KEY" > ./apple_api_key.p8
+          echo $APPLE_CERTIFICATE_P12 | base64 --decode > certificate.p12
+          security create-keychain -p "$CERTIFICATE_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$CERTIFICATE_PASSWORD" build.keychain
+          security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CERTIFICATE_PASSWORD" build.keychain
+        env:
+          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+
+      - name: setup windows certificate
+        if: startsWith(matrix.platform, 'windows-')
+        run: |
+          $bytes = [Convert]::FromBase64String("${{ secrets.WINDOWS_CERTIFICATE }}")
+          [IO.File]::WriteAllBytes("certificate.pfx", $bytes)
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+
+      - name: publish macOS
+        if: startsWith(matrix.platform, 'macos-')
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # notarization
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ./apple_api_key.p8
+          # sentry integration
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # sentry vite plugin integration during build
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: |
+          # on macos we also build the x64 app separately
+          npm run publish -- --arch=x64
+          npm run publish
+
+      - name: publish Windows
+        if: startsWith(matrix.platform, 'windows-')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # windows cert
+          WINDOWS_CERTIFICATE_PATH: ./certificate.pfx
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          # sentry integration
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # sentry vite plugin integration during build
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: npm run publish
+
+      - name: publish Linux
+        if: startsWith(matrix.platform, 'ubuntu-')
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # sentry integration
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          # sentry vite plugin integration during build
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+        run: |
+          sudo apt install -y rpm
+          npm run publish
+          npm run publish -- --arch=arm64
+
+      - name: cleanup macos certificates
+        if: startsWith(matrix.platform, 'macos-')
+        run: |
+          rm apple_api_key.p8
+          rm certificate.p12
+
+      - name: cleanup windows certificates
+        if: startsWith(matrix.platform, 'windows-')
+        run: |
+          del certificate.pfx

--- a/update_version.py
+++ b/update_version.py
@@ -1,0 +1,16 @@
+import os
+import json
+
+
+version = os.environ['INPUT_VERSION']
+
+
+with open('package.json', 'r') as f:
+    data = json.loads(f.read())
+
+
+with open('package.json', 'w') as f:
+    data['version'] = version
+    f.write(json.dumps(data, indent=2))
+
+print(f'Updated package.json version to {version}')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
Adds a github action to build a test version of k6 studio without having to jump through hoops.
The action will require the user to specify a `version` to be used for that specific test release.

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
