### PR TITLE
fix: Validator run is available when proxy is offline

### DIFF
--- a/src/components/GhostButton.tsx
+++ b/src/components/GhostButton.tsx
@@ -1,20 +1,24 @@
 import { css } from '@emotion/react'
 import { Button, ButtonProps } from '@radix-ui/themes'
+import { forwardRef } from 'react'
 
 type GhostButtonProps = Omit<ButtonProps, 'variant'>
 
-export function GhostButton(props: GhostButtonProps) {
-  return (
-    <Button
-      css={css`
-        margin: 0;
-        height: var(--base-button-height);
+export const GhostButton = forwardRef<HTMLButtonElement, GhostButtonProps>(
+  function GhostButton(props, ref) {
+    return (
+      <Button
+        ref={ref}
+        css={css`
+          margin: 0;
+          height: var(--base-button-height);
 
-        --button-ghost-padding-x: var(--space-3);
-        --button-ghost-padding-y: 0;
-      `}
-      {...props}
-      variant="ghost"
-    />
-  )
-}
+          --button-ghost-padding-x: var(--space-3);
+          --button-ghost-padding-y: 0;
+        `}
+        {...props}
+        variant="ghost"
+      />
+    )
+  }
+)

--- a/src/views/Generator/GeneratorControls/GeneratorControls.tsx
+++ b/src/views/Generator/GeneratorControls/GeneratorControls.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { ButtonWithTooltip } from '@/components/ButtonWithTooltip'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
 import { useScriptPreview } from '@/hooks/useScriptPreview'
 import { getRoutePath } from '@/routeMap'
 import { getFileNameWithoutExtension } from '@/utils/file'
@@ -30,6 +31,7 @@ export function GeneratorControls({
     useState(false)
   const { fileName } = useGeneratorParams()
   const { preview, hasError } = useScriptPreview()
+  const proxyStatus = useProxyStatus()
   const isScriptExportable = !hasError && !!preview
   const navigate = useNavigate()
 
@@ -63,7 +65,7 @@ export function GeneratorControls({
           <DropdownMenu.Content>
             <DropdownMenu.Item
               onSelect={() => setIsValidatorDialogOpen(true)}
-              disabled={!isScriptExportable}
+              disabled={!isScriptExportable || proxyStatus !== 'online'}
             >
               Validate script
             </DropdownMenu.Item>

--- a/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
+++ b/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
@@ -1,11 +1,12 @@
 import { CheckCircledIcon, DownloadIcon } from '@radix-ui/react-icons'
-import { Flex } from '@radix-ui/themes'
+import { Flex, Tooltip } from '@radix-ui/themes'
 import { useState } from 'react'
 
 import { GhostButton } from '@/components/GhostButton'
 import { CodeEditor } from '@/components/Monaco/CodeEditor'
 import { RunInCloudButton } from '@/components/RunInCloudDialog/RunInCloudButton'
 import { RunInCloudDialog } from '@/components/RunInCloudDialog/RunInCloudDialog'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
 import { useScriptPreview } from '@/hooks/useScriptPreview'
 
 import { ExportScriptDialog } from '../ExportScriptDialog'
@@ -24,20 +25,26 @@ export function ScriptPreview({ fileName }: ScriptPreviewProps) {
   const [isExportScriptDialogOpen, setIsExportScriptDialogOpen] =
     useState(false)
   const { preview, error } = useScriptPreview()
+  const proxyStatus = useProxyStatus()
   const isScriptExportable = !error && !!preview
 
   return (
     <Flex direction="column" height="100%" position="relative">
       <Flex py="1" px="2" gap="2" align="center" justify="end">
-        <GhostButton
-          disabled={!isScriptExportable}
-          onClick={() => {
-            setIsValidatorDialogOpen(true)
-          }}
+        <Tooltip
+          content={`Proxy is ${proxyStatus}`}
+          hidden={proxyStatus === 'online'}
         >
-          <CheckCircledIcon />
-          Validate
-        </GhostButton>
+          <GhostButton
+            disabled={!isScriptExportable || proxyStatus !== 'online'}
+            onClick={() => {
+              setIsValidatorDialogOpen(true)
+            }}
+          >
+            <CheckCircledIcon />
+            Validate
+          </GhostButton>
+        </Tooltip>
         <GhostButton
           disabled={!isScriptExportable}
           onClick={() => {

--- a/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
+++ b/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
@@ -35,17 +35,15 @@ export function ScriptPreview({ fileName }: ScriptPreviewProps) {
           content={`Proxy is ${proxyStatus}`}
           hidden={proxyStatus === 'online'}
         >
-          <span>
-            <GhostButton
-              disabled={!isScriptExportable || proxyStatus !== 'online'}
-              onClick={() => {
-                setIsValidatorDialogOpen(true)
-              }}
-            >
-              <CheckCircledIcon />
-              Validate
-            </GhostButton>
-          </span>
+          <GhostButton
+            disabled={!isScriptExportable || proxyStatus !== 'online'}
+            onClick={() => {
+              setIsValidatorDialogOpen(true)
+            }}
+          >
+            <CheckCircledIcon />
+            Validate
+          </GhostButton>
         </Tooltip>
         <GhostButton
           disabled={!isScriptExportable}

--- a/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
+++ b/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
@@ -35,15 +35,17 @@ export function ScriptPreview({ fileName }: ScriptPreviewProps) {
           content={`Proxy is ${proxyStatus}`}
           hidden={proxyStatus === 'online'}
         >
-          <GhostButton
-            disabled={!isScriptExportable || proxyStatus !== 'online'}
-            onClick={() => {
-              setIsValidatorDialogOpen(true)
-            }}
-          >
-            <CheckCircledIcon />
-            Validate
-          </GhostButton>
+          <span>
+            <GhostButton
+              disabled={!isScriptExportable || proxyStatus !== 'online'}
+              onClick={() => {
+                setIsValidatorDialogOpen(true)
+              }}
+            >
+              <CheckCircledIcon />
+              Validate
+            </GhostButton>
+          </span>
         </Tooltip>
         <GhostButton
           disabled={!isScriptExportable}

--- a/src/views/Validator/ValidatorControls.tsx
+++ b/src/views/Validator/ValidatorControls.tsx
@@ -43,7 +43,10 @@ export function ValidatorControls({
           <Button variant="outline" onClick={onRunInCloud}>
             <GrafanaIcon /> Run in Grafana Cloud
           </Button>
-          <Tooltip content="Proxy is offline" hidden={proxyStatus === 'online'}>
+          <Tooltip
+            content={`Proxy is ${proxyStatus}`}
+            hidden={proxyStatus === 'online'}
+          >
             <Button
               disabled={!isScriptSelected || proxyStatus !== 'online'}
               onClick={onRunScript}

--- a/src/views/Validator/ValidatorControls.tsx
+++ b/src/views/Validator/ValidatorControls.tsx
@@ -3,6 +3,7 @@ import { Button, DropdownMenu, IconButton, Tooltip } from '@radix-ui/themes'
 
 import TextSpinner from '@/components/TextSpinner/TextSpinner'
 import { GrafanaIcon } from '@/components/icons/GrafanaIcon'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
 
 interface ValidatorControlsProps {
   isRunning: boolean
@@ -25,6 +26,8 @@ export function ValidatorControls({
   onSelectScript,
   onStopScript,
 }: ValidatorControlsProps) {
+  const proxyStatus = useProxyStatus()
+
   return (
     <>
       {isRunning && (
@@ -40,9 +43,14 @@ export function ValidatorControls({
           <Button variant="outline" onClick={onRunInCloud}>
             <GrafanaIcon /> Run in Grafana Cloud
           </Button>
-          <Button disabled={!isScriptSelected} onClick={onRunScript}>
-            Validate script
-          </Button>
+          <Tooltip content="Proxy is offline" hidden={proxyStatus === 'online'}>
+            <Button
+              disabled={!isScriptSelected || proxyStatus !== 'online'}
+              onClick={onRunScript}
+            >
+              Validate script
+            </Button>
+          </Tooltip>
         </>
       )}
       <DropdownMenu.Root>

--- a/src/views/Validator/ValidatorEmptyState.tsx
+++ b/src/views/Validator/ValidatorEmptyState.tsx
@@ -1,6 +1,10 @@
 import { CheckCircledIcon } from '@radix-ui/react-icons'
 import { Button, Spinner, Text } from '@radix-ui/themes'
 
+import { TextButton } from '@/components/TextButton'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
+import { useStudioUIStore } from '@/store/ui'
+
 interface ValidatorEmptyStateProps {
   isRunning: boolean
   isScriptSelected: boolean
@@ -14,6 +18,14 @@ export function ValidatorEmptyState({
   onRunScript,
   onSelectScript,
 }: ValidatorEmptyStateProps) {
+  const proxyStatus = useProxyStatus()
+  const openSettingsDialog = useStudioUIStore(
+    (state) => state.openSettingsDialog
+  )
+  const handleProxyStart = () => {
+    return window.studio.proxy.launchProxy()
+  }
+
   if (!isScriptSelected) {
     return (
       <>
@@ -21,6 +33,25 @@ export function ValidatorEmptyState({
           Validate a k6 script created outside of Grafana k6 Studio
         </Text>
         <Button onClick={onSelectScript}>Open external script</Button>
+      </>
+    )
+  }
+
+  if (proxyStatus !== 'online') {
+    return (
+      <>
+        <Text size="1" color="gray" align="center">
+          Proxy is offline
+          <br />
+          Start proxy or check proxy configuration in{' '}
+          <TextButton onClick={() => openSettingsDialog('proxy')}>
+            Settings
+          </TextButton>
+          .
+        </Text>
+        <Button onClick={handleProxyStart} loading={proxyStatus === 'starting'}>
+          Start proxy
+        </Button>
       </>
     )
   }


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/609

## Description

<img width="830" alt="image" src="https://github.com/user-attachments/assets/41b177b8-ed40-4849-aaa3-634c3d32bfc3" />


## How to Test
- Stop proxy
- Verify that you cannot start a validation run (both in Validator and in Generator)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
