### PR TITLE
fix: Text assertions break when using back button

### DIFF
--- a/extension/src/frontend/view/EventDrawer.tsx
+++ b/extension/src/frontend/view/EventDrawer.tsx
@@ -32,6 +32,24 @@ function useRecordedEvents() {
     })
   }, [])
 
+  useEffect(() => {
+    // We reload the list of events whenever the page is shown from the
+    // back/forward cache to make sure we have the latest state.
+    function handlePageShow(event: PageTransitionEvent) {
+      if (event.persisted) {
+        client.send({
+          type: 'load-events',
+        })
+      }
+    }
+
+    window.addEventListener('pageshow', handlePageShow)
+
+    return () => {
+      window.removeEventListener('pageshow', handlePageShow)
+    }
+  }, [])
+
   return events
 }
 

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -94,6 +94,10 @@ export const launchBrowser = async (
     browserWindow.webContents.send(BrowserHandler.Failed)
   }
 
+  const browserRecordingArgs = appSettings.recorder.enableBrowserRecorder
+    ? [`--load-extension=${extensionPath}`, `--disable-back-forward-cache`]
+    : []
+
   const args = [
     '--new',
     '--args',
@@ -107,9 +111,7 @@ export const launchBrowser = async (
     '--disable-search-engine-choice-screen',
     `--proxy-server=http://localhost:${appSettings.proxy.port}`,
     `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
-    appSettings.recorder.enableBrowserRecorder
-      ? `--load-extension=${extensionPath}`
-      : '',
+    ...browserRecordingArgs,
     disableChromeOptimizations,
     url?.trim() || 'about:blank',
   ]

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -95,7 +95,7 @@ export const launchBrowser = async (
   }
 
   const browserRecordingArgs = appSettings.recorder.enableBrowserRecorder
-    ? [`--load-extension=${extensionPath}`, `--disable-back-forward-cache`]
+    ? [`--load-extension=${extensionPath}`]
     : []
 
   const args = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Text assertions break when using the back button.

## How to Test

1. Go to a page
2. Click a link that navigates you to another page
3. Click back
4. Add a text assertion
5. Check that the text assertion is added to the event list

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
