### PR TITLE
internal: main window cannot be restored on macOS

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,5 +1,3 @@
-import { BrowserWindow } from 'electron'
-
 import { BrowserServer } from '@/services/browser/server'
 
 import * as auth from './auth'
@@ -12,7 +10,6 @@ import * as settings from './settings'
 
 interface Services {
   browserServer: BrowserServer
-  browserWindow: BrowserWindow
 }
 
 export function initialize({ browserServer }: Services) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,7 +102,9 @@ if (require('electron-squirrel-startup')) {
 }
 
 initializeLogger()
-
+handlers.initialize({
+  browserServer,
+})
 mainState.initialize()
 
 // Used to convert `.json` files into the appropriate file extension for the Generator
@@ -195,11 +197,6 @@ const createWindow = async () => {
       preload: path.join(__dirname, 'preload.js'),
       devTools: process.env.NODE_ENV === 'development',
     },
-  })
-
-  handlers.initialize({
-    browserWindow: mainWindow,
-    browserServer,
   })
 
   configureApplicationMenu()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We introduce a change that tries to re-register IPC handlers when the main window is re-created. This PR reverts that change.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Launch the app on macOS
- Close the main window
- Restore it from the dock
- Check that the window was properly recreated

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
