### PR TITLE
internal(browser): Unified schema for assertion events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM node:slim
-
-RUN git clone https://github.com/cirosantilli/node-express-sequelize-nextjs-realworld-example-app.git
-RUN npm install
-
-CMD ["npm", "run", "dev"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:slim
+
+RUN git clone https://github.com/cirosantilli/node-express-sequelize-nextjs-realworld-example-app.git
+RUN npm install
+
+CMD ["npm", "run", "dev"]
+
+

--- a/extension/src/background/navigation.ts
+++ b/extension/src/background/navigation.ts
@@ -48,7 +48,7 @@ export function captureNavigationEvents(
 
     if (isReload(details)) {
       onCaptured({
-        type: 'reloaded-page',
+        type: 'reload-page',
         eventId: crypto.randomUUID(),
         timestamp: details.timeStamp,
         tab: details.tabId.toString(),
@@ -65,7 +65,7 @@ export function captureNavigationEvents(
     }
 
     onCaptured({
-      type: 'navigated-to-page',
+      type: 'navigate-to-page',
       eventId: crypto.randomUUID(),
       timestamp: details.timeStamp,
       tab: details.tabId.toString(),
@@ -79,7 +79,7 @@ export function captureNavigationEvents(
 
     if (isHistoryNavigation(details)) {
       onCaptured({
-        type: 'navigated-to-page',
+        type: 'navigate-to-page',
         eventId: crypto.randomUUID(),
         timestamp: details.timeStamp,
         tab: details.tabId.toString(),

--- a/extension/src/frontend/index.ts
+++ b/extension/src/frontend/index.ts
@@ -59,7 +59,7 @@ window.addEventListener(
     }
 
     recordEvents({
-      type: 'clicked',
+      type: 'click',
       eventId: crypto.randomUUID(),
       timestamp: Date.now(),
       selector: generateSelector(ev.target),
@@ -78,7 +78,7 @@ window.addEventListener(
 
 function handleSelectChange(target: HTMLSelectElement) {
   recordEvents({
-    type: 'select-changed',
+    type: 'select-change',
     eventId: crypto.randomUUID(),
     timestamp: Date.now(),
     selector: generateSelector(target),
@@ -90,7 +90,7 @@ function handleSelectChange(target: HTMLSelectElement) {
 
 function handleTextAreaChange(target: HTMLTextAreaElement) {
   recordEvents({
-    type: 'input-changed',
+    type: 'input-change',
     eventId: crypto.randomUUID(),
     timestamp: Date.now(),
     selector: generateSelector(target),
@@ -113,7 +113,7 @@ function handleInputChange(target: HTMLInputElement) {
 
   if (target.type === 'checkbox') {
     recordEvents({
-      type: 'check-changed',
+      type: 'check-change',
       eventId: crypto.randomUUID(),
       timestamp: Date.now(),
       selector: generateSelector(target),
@@ -130,7 +130,7 @@ function handleInputChange(target: HTMLInputElement) {
     }
 
     recordEvents({
-      type: 'radio-changed',
+      type: 'radio-change',
       eventId: crypto.randomUUID(),
       timestamp: Date.now(),
       selector: generateSelector(target),
@@ -143,7 +143,7 @@ function handleInputChange(target: HTMLInputElement) {
   }
 
   recordEvents({
-    type: 'input-changed',
+    type: 'input-change',
     eventId: crypto.randomUUID(),
     timestamp: Date.now(),
     selector: generateSelector(target),
@@ -198,7 +198,7 @@ window.addEventListener('submit', (ev) => {
   }
 
   recordEvents({
-    type: 'form-submitted',
+    type: 'submit-form',
     eventId: crypto.randomUUID(),
     timestamp: Date.now(),
     form: generateSelector(ev.target),

--- a/extension/src/frontend/view/TextAssertionEditor.tsx
+++ b/extension/src/frontend/view/TextAssertionEditor.tsx
@@ -177,7 +177,7 @@ export function TextAssertionEditor({ onClose }: TextAssertionEditorProps) {
         {
           eventId: crypto.randomUUID(),
           timestamp: Date.now(),
-          type: 'asserted',
+          type: 'assert',
           tab: '',
           selector: assertion.selector,
           assertion: {

--- a/extension/src/frontend/view/TextAssertionEditor.tsx
+++ b/extension/src/frontend/view/TextAssertionEditor.tsx
@@ -177,12 +177,15 @@ export function TextAssertionEditor({ onClose }: TextAssertionEditorProps) {
         {
           eventId: crypto.randomUUID(),
           timestamp: Date.now(),
-          type: 'asserted-text',
-          selector: assertion.selector,
+          type: 'asserted',
           tab: '',
-          operation: {
-            type: 'contains',
-            value: assertion.text,
+          selector: assertion.selector,
+          assertion: {
+            type: 'text',
+            operation: {
+              type: 'contains',
+              value: assertion.text,
+            },
           },
         },
       ],

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -164,13 +164,13 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'asserted-text':
+      case 'asserted':
         return {
           type: 'assert',
           nodeId: event.eventId,
           operation: {
             type: 'text-contains',
-            value: event.operation.value,
+            value: event.assertion.operation.value,
           },
           inputs: {
             previous,

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -68,7 +68,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
 
   function toNode(event: BrowserEvent): TestNode | null {
     switch (event.type) {
-      case 'navigated-to-page':
+      case 'navigate-to-page':
         return {
           type: 'goto',
           nodeId: event.eventId,
@@ -79,7 +79,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'reloaded-page':
+      case 'reload-page':
         return {
           type: 'reload',
           nodeId: event.eventId,
@@ -89,7 +89,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'clicked': {
+      case 'click': {
         return {
           type: 'click',
           nodeId: event.eventId,
@@ -102,7 +102,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
         }
       }
 
-      case 'input-changed':
+      case 'input-change':
         return {
           type: 'type-text',
           nodeId: event.eventId,
@@ -113,7 +113,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'check-changed':
+      case 'check-change':
         return {
           type: 'check',
           nodeId: event.eventId,
@@ -124,7 +124,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'radio-changed':
+      case 'radio-change':
         return {
           type: 'check',
           nodeId: event.eventId,
@@ -135,7 +135,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'select-changed':
+      case 'select-change':
         return {
           type: 'select-options',
           nodeId: event.eventId,
@@ -147,7 +147,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'form-submitted':
+      case 'submit-form':
         return {
           type: 'click',
           nodeId: event.eventId,

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -164,7 +164,7 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
           },
         }
 
-      case 'asserted':
+      case 'assert':
         return {
           type: 'assert',
           nodeId: event.eventId,

--- a/src/components/BrowserEventList/EventDescription/ClickDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/ClickDescription.tsx
@@ -1,11 +1,11 @@
 import { Kbd } from '@/components/primitives/Kbd'
-import { ClickedEvent } from '@/schemas/recording'
+import { ClickEvent } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 import { HighlightSelector } from 'extension/src/messaging/types'
 
 import { Selector } from './Selector'
 
-function getModifierKeys(modifiers: ClickedEvent['modifiers']) {
+function getModifierKeys(modifiers: ClickEvent['modifiers']) {
   const keys = []
 
   if (modifiers.ctrl) {
@@ -27,7 +27,7 @@ function getModifierKeys(modifiers: ClickedEvent['modifiers']) {
   return keys
 }
 
-function getButtonDescription(event: ClickedEvent) {
+function getButtonDescription(event: ClickEvent) {
   switch (event.button) {
     case 'left':
       return 'Clicked'
@@ -44,7 +44,7 @@ function getButtonDescription(event: ClickedEvent) {
 }
 
 interface ClickDescriptionProps {
-  event: ClickedEvent
+  event: ClickEvent
   onHighlight: (selector: HighlightSelector | null) => void
 }
 

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -6,7 +6,7 @@ import { exhaustive } from '@/utils/typescript'
 import { HighlightSelector } from 'extension/src/messaging/types'
 
 import { ClickDescription } from './ClickDescription'
-import { InputChangedDescription } from './InputChangedDescription'
+import { InputChangeDescription } from './InputChangeDescription'
 import { PageNavigationDescription } from './PageNavigationDescription'
 import { Selector } from './Selector'
 
@@ -47,19 +47,19 @@ export function EventDescription({
   onHighlight,
 }: EventDescriptionProps) {
   switch (event.type) {
-    case 'navigated-to-page':
+    case 'navigate-to-page':
       return <PageNavigationDescription event={event} onNavigate={onNavigate} />
 
-    case 'reloaded-page':
+    case 'reload-page':
       return <>Reloaded page</>
 
-    case 'clicked':
+    case 'click':
       return <ClickDescription event={event} onHighlight={onHighlight} />
 
-    case 'input-changed':
-      return <InputChangedDescription event={event} onHighlight={onHighlight} />
+    case 'input-change':
+      return <InputChangeDescription event={event} onHighlight={onHighlight} />
 
-    case 'check-changed':
+    case 'check-change':
       return (
         <>
           {event.checked ? 'Checked' : 'Unchecked'} checkbox{' '}
@@ -67,7 +67,7 @@ export function EventDescription({
         </>
       )
 
-    case 'radio-changed':
+    case 'radio-change':
       return (
         <>
           Switched value of <strong>{event.name}</strong> to{' '}
@@ -76,7 +76,7 @@ export function EventDescription({
         </>
       )
 
-    case 'select-changed':
+    case 'select-change':
       return (
         <>
           Selected {formatOptions(event.selected)} from{' '}
@@ -84,7 +84,7 @@ export function EventDescription({
         </>
       )
 
-    case 'form-submitted':
+    case 'submit-form':
       return (
         <>
           Submitted form{' '}

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -92,14 +92,14 @@ export function EventDescription({
         </>
       )
 
-    case 'asserted-text':
+    case 'asserted':
       return (
         <>
           Assert that{' '}
           <Selector selector={event.selector} onHighlight={onHighlight} />{' '}
           contains the text{' '}
-          <Tooltip asChild content={event.operation.value}>
-            <em>{`"${event.operation.value}"`}</em>
+          <Tooltip asChild content={event.assertion.operation.value}>
+            <em>{`"${event.assertion.operation.value}"`}</em>
           </Tooltip>
         </>
       )

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -92,7 +92,7 @@ export function EventDescription({
         </>
       )
 
-    case 'asserted':
+    case 'assert':
       return (
         <>
           Assert that{' '}

--- a/src/components/BrowserEventList/EventDescription/InputChangeDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/InputChangeDescription.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import { EyeNoneIcon, EyeOpenIcon } from '@radix-ui/react-icons'
 import { ReactNode, useState } from 'react'
 
-import { InputChangedEvent } from '@/schemas/recording'
+import { InputChangeEvent } from '@/schemas/recording'
 import { HighlightSelector } from 'extension/src/messaging/types'
 
 import { Selector } from './Selector'
@@ -73,15 +73,15 @@ function MaskedValue({ sensitive, value }: SensitiveValueProps) {
   )
 }
 
-interface InputChangedDescriptionProps {
-  event: InputChangedEvent
+interface InputChangeDescriptionProps {
+  event: InputChangeEvent
   onHighlight: (selector: HighlightSelector | null) => void
 }
 
-export function InputChangedDescription({
+export function InputChangeDescription({
   event,
   onHighlight,
-}: InputChangedDescriptionProps) {
+}: InputChangeDescriptionProps) {
   return (
     <>
       Changed input of{' '}

--- a/src/components/BrowserEventList/EventDescription/PageNavigationDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/PageNavigationDescription.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import { forwardRef, MouseEvent } from 'react'
 
 import { Tooltip } from '@/components/primitives/Tooltip'
-import { NavigatedToPageEvent } from '@/schemas/recording'
+import { NavigateToPageEvent } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 import { useIsRecording } from '@/views/Recorder/RecordingContext'
 
@@ -52,7 +52,7 @@ const RemoteLink = forwardRef<HTMLElement, RemoteLinkProps>(function RemoteLink(
 })
 
 interface PageNavigationDescriptionProps {
-  event: NavigatedToPageEvent
+  event: NavigateToPageEvent
   onNavigate: (url: string) => void
 }
 

--- a/src/components/BrowserEventList/EventIcon.tsx
+++ b/src/components/BrowserEventList/EventIcon.tsx
@@ -44,7 +44,7 @@ export function EventIcon({ event }: EventIconProps) {
     case 'form-submitted':
       return <ReaderIcon />
 
-    case 'asserted':
+    case 'assert':
       return <EyeOpenIcon />
 
     default:

--- a/src/components/BrowserEventList/EventIcon.tsx
+++ b/src/components/BrowserEventList/EventIcon.tsx
@@ -20,28 +20,28 @@ interface EventIconProps {
 
 export function EventIcon({ event }: EventIconProps) {
   switch (event.type) {
-    case 'navigated-to-page':
+    case 'navigate-to-page':
       return <GlobeIcon />
 
-    case 'reloaded-page':
+    case 'reload-page':
       return <UpdateIcon />
 
-    case 'clicked':
+    case 'click':
       return <TargetIcon />
 
-    case 'input-changed':
+    case 'input-change':
       return <InputIcon />
 
-    case 'check-changed':
+    case 'check-change':
       return event.checked ? <CheckCircledIcon /> : <CircleIcon />
 
-    case 'radio-changed':
+    case 'radio-change':
       return <RadiobuttonIcon />
 
-    case 'select-changed':
+    case 'select-change':
       return <DropdownMenuIcon />
 
-    case 'form-submitted':
+    case 'submit-form':
       return <ReaderIcon />
 
     case 'assert':

--- a/src/components/BrowserEventList/EventIcon.tsx
+++ b/src/components/BrowserEventList/EventIcon.tsx
@@ -44,7 +44,7 @@ export function EventIcon({ event }: EventIconProps) {
     case 'form-submitted':
       return <ReaderIcon />
 
-    case 'asserted-text':
+    case 'asserted':
       return <EyeOpenIcon />
 
     default:

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -9,21 +9,21 @@ const BrowserEventBaseSchema = z.object({
   timestamp: z.number(),
 })
 
-const NavigatedToPageEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('navigated-to-page'),
+const NavigateToPageEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('navigate-to-page'),
   tab: z.string(),
   url: z.string(),
   source: z.union([z.literal('address-bar'), z.literal('history')]),
 })
 
-const ReloadedPageEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('reloaded-page'),
+const ReloadPageEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('reload-page'),
   tab: z.string(),
   url: z.string(),
 })
 
-const ClickedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('clicked'),
+const ClickEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('click'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   button: z.union([z.literal('left'), z.literal('middle'), z.literal('right')]),
@@ -35,39 +35,39 @@ const ClickedEventSchema = BrowserEventBaseSchema.extend({
   }),
 })
 
-const InputChangedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('input-changed'),
+const InputChangeEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('input-change'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   value: z.string(),
   sensitive: z.boolean(),
 })
 
-const CheckChangedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('check-changed'),
+const CheckChangeEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('check-change'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   checked: z.boolean(),
 })
 
-const RadioChangedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('radio-changed'),
+const RadioChangeEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('radio-change'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   name: z.string(),
   value: z.string(),
 })
 
-const SelectChangedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('select-changed'),
+const SelectChangeEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('select-change'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   selected: z.array(z.string()),
   multiple: z.boolean(),
 })
 
-const FormSubmittedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('form-submitted'),
+const SubmitFormEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('submit-form'),
   tab: z.string(),
   form: ElementSelectorSchema,
   submitter: ElementSelectorSchema,
@@ -92,27 +92,27 @@ const AssertEventSchema = BrowserEventBaseSchema.extend({
 })
 
 export const BrowserEventSchema = z.discriminatedUnion('type', [
-  NavigatedToPageEventSchema,
-  ReloadedPageEventSchema,
-  ClickedEventSchema,
-  InputChangedEventSchema,
-  CheckChangedEventSchema,
-  RadioChangedEventSchema,
-  SelectChangedEventSchema,
-  FormSubmittedEventSchema,
+  NavigateToPageEventSchema,
+  ReloadPageEventSchema,
+  ClickEventSchema,
+  InputChangeEventSchema,
+  CheckChangeEventSchema,
+  RadioChangeEventSchema,
+  SelectChangeEventSchema,
+  SubmitFormEventSchema,
   AssertEventSchema,
 ])
 
 export type ElementSelector = z.infer<typeof ElementSelectorSchema>
 
-export type NavigatedToPageEvent = z.infer<typeof NavigatedToPageEventSchema>
-export type ReloadedPageEvent = z.infer<typeof ReloadedPageEventSchema>
-export type ClickedEvent = z.infer<typeof ClickedEventSchema>
-export type InputChangedEvent = z.infer<typeof InputChangedEventSchema>
-export type CheckChangedEvent = z.infer<typeof CheckChangedEventSchema>
-export type RadioChangedEvent = z.infer<typeof RadioChangedEventSchema>
-export type SelectChangedEvent = z.infer<typeof SelectChangedEventSchema>
-export type FormSubmittedEvent = z.infer<typeof FormSubmittedEventSchema>
+export type NavigateToPageEvent = z.infer<typeof NavigateToPageEventSchema>
+export type ReloadPageEvent = z.infer<typeof ReloadPageEventSchema>
+export type ClickEvent = z.infer<typeof ClickEventSchema>
+export type InputChangeEvent = z.infer<typeof InputChangeEventSchema>
+export type CheckChangeEvent = z.infer<typeof CheckChangeEventSchema>
+export type RadioChangeEvent = z.infer<typeof RadioChangeEventSchema>
+export type SelectChangeEvent = z.infer<typeof SelectChangeEventSchema>
+export type SubmitFormEvent = z.infer<typeof SubmitFormEventSchema>
 export type AssertEvent = z.infer<typeof AssertEventSchema>
 
 export type BrowserEvent = z.infer<typeof BrowserEventSchema>

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -84,7 +84,7 @@ const TextAssertionSchema = z.object({
 // Will eventually be a union of different assertion types
 const AssertionSchema = TextAssertionSchema
 
-const AssertedEventSchema = BrowserEventBaseSchema.extend({
+const AssertEventSchema = BrowserEventBaseSchema.extend({
   type: z.literal('assert'),
   tab: z.string(),
   selector: ElementSelectorSchema,
@@ -100,7 +100,7 @@ export const BrowserEventSchema = z.discriminatedUnion('type', [
   RadioChangedEventSchema,
   SelectChangedEventSchema,
   FormSubmittedEventSchema,
-  AssertedEventSchema,
+  AssertEventSchema,
 ])
 
 export type ElementSelector = z.infer<typeof ElementSelectorSchema>
@@ -113,6 +113,6 @@ export type CheckChangedEvent = z.infer<typeof CheckChangedEventSchema>
 export type RadioChangedEvent = z.infer<typeof RadioChangedEventSchema>
 export type SelectChangedEvent = z.infer<typeof SelectChangedEventSchema>
 export type FormSubmittedEvent = z.infer<typeof FormSubmittedEventSchema>
-export type AssertedEvent = z.infer<typeof AssertedEventSchema>
+export type AssertEvent = z.infer<typeof AssertEventSchema>
 
 export type BrowserEvent = z.infer<typeof BrowserEventSchema>

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -85,7 +85,7 @@ const TextAssertionSchema = z.object({
 const AssertionSchema = TextAssertionSchema
 
 const AssertedEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('asserted'),
+  type: z.literal('assert'),
   tab: z.string(),
   selector: ElementSelectorSchema,
   assertion: AssertionSchema,

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -73,14 +73,22 @@ const FormSubmittedEventSchema = BrowserEventBaseSchema.extend({
   submitter: ElementSelectorSchema,
 })
 
-const AssertedTextEventSchema = BrowserEventBaseSchema.extend({
-  type: z.literal('asserted-text'),
-  tab: z.string(),
-  selector: ElementSelectorSchema,
+const TextAssertionSchema = z.object({
+  type: z.literal('text'),
   operation: z.object({
     type: z.literal('contains'),
     value: z.string(),
   }),
+})
+
+// Will eventually be a union of different assertion types
+const AssertionSchema = TextAssertionSchema
+
+const AssertedEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('asserted'),
+  tab: z.string(),
+  selector: ElementSelectorSchema,
+  assertion: AssertionSchema,
 })
 
 export const BrowserEventSchema = z.discriminatedUnion('type', [
@@ -92,7 +100,7 @@ export const BrowserEventSchema = z.discriminatedUnion('type', [
   RadioChangedEventSchema,
   SelectChangedEventSchema,
   FormSubmittedEventSchema,
-  AssertedTextEventSchema,
+  AssertedEventSchema,
 ])
 
 export type ElementSelector = z.infer<typeof ElementSelectorSchema>
@@ -105,6 +113,6 @@ export type CheckChangedEvent = z.infer<typeof CheckChangedEventSchema>
 export type RadioChangedEvent = z.infer<typeof RadioChangedEventSchema>
 export type SelectChangedEvent = z.infer<typeof SelectChangedEventSchema>
 export type FormSubmittedEvent = z.infer<typeof FormSubmittedEventSchema>
-export type AssertedTextEventSchema = z.infer<typeof AssertedTextEventSchema>
+export type AssertedEvent = z.infer<typeof AssertedEventSchema>
 
 export type BrowserEvent = z.infer<typeof BrowserEventSchema>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

While working on adding additional types of assertions I came to the conclusion that it was better to have a single browser event for all assertions and let the event contain the specifics of the assertion.

I want to get this merged before releasing so that I won't have to add a migration for it.

## How to Test

1. Start a recording
2. Add a text assertion
3. Stop recording
4. Open browser events list
5. Export script
6. Verify that generated script calls `toContainText`

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
