### PR TITLE
fix: Preview payload when correlating numeric properties

### DIFF
--- a/src/components/WebLogView/RequestDetails/utils.ts
+++ b/src/components/WebLogView/RequestDetails/utils.ts
@@ -35,7 +35,11 @@ export function parseParams(data: ProxyData) {
     return stringify(
       // TODO: https://github.com/grafana/k6-studio/issues/277
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      JSON.parse(jsonrepair(parsePythonByteString(contentDecoded)))
+      JSON.parse(
+        jsonrepair(
+          parsePythonByteString(wrapTemplateExpressionsInQuotes(contentDecoded))
+        )
+      )
     )
   } catch (e) {
     console.error('Failed to parse query parameters', e)
@@ -63,4 +67,13 @@ export function isJsonString(str: string) {
 
 export function getRawContent(content: string) {
   return content.replace(/\s+/g, '')
+}
+
+// When replacing number values in the payload, we need to wrap variable expressions
+// in quotes, otherwise JSON parse will fail
+function wrapTemplateExpressionsInQuotes(str: string) {
+  return str.replace(
+    /(:\s*)(\$\{[^}]+\})(?=[,}])/g,
+    (_, prefix, expr) => `${prefix}"${expr}"`
+  )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Payload preview doesn't work when a numeric value is replaced by a correlation variable, for example:
```json
{ "id": ${correlation_vars['correlation_0'] }
```
In Payload preview, we parse the string as JSON, but the injected variable makes in invalid. 

To solve this I've added a function to wrap variable expressions in quotes, that's not ideal because it makes it look like the value injected would be a string, but at least it doesn't break the preview. We might want to revisit this in the future and remove JSON parse altogether, but we'd need a new way to prettify it. 

## How to Test

Use attached recording and generator.

Steps to reproduce:
1. In the generator, inspect `POST /api/ratings` request 
2. Click on payload.

**Expected result**: payload preview with injected correlation value is displayed
**Actual result**: payload preview is not available

**Verify payload preview works as expected in recording, generator and validator**

[correlate-pizza-id.zip](https://github.com/user-attachments/files/19792449/correlate-pizza-id.zip)


## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![screencapture 2025-04-17 at 12 59 12](https://github.com/user-attachments/assets/a76fec09-f7a1-4a4b-8e7b-7ed461aa1c2d)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
