### PR TITLE
refactor(Split main): Move proxy handlers out of main.ts 

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -7,6 +7,7 @@ import * as browser from './browser'
 import * as browserRemote from './browserRemote'
 import * as cloud from './cloud'
 import * as har from './har'
+import * as proxy from './proxy'
 import * as script from './script'
 import * as settings from './settings'
 
@@ -23,4 +24,5 @@ export function initialize({ browserServer }: Services) {
   browser.initialize(browserServer)
   script.initialize()
   settings.initialize()
+  proxy.initialize()
 }

--- a/src/handlers/proxy/index.ts
+++ b/src/handlers/proxy/index.ts
@@ -1,0 +1,25 @@
+import { ipcMain } from 'electron'
+
+import { launchProxyAndAttachEmitter, stopProxyProcess } from '@/proxy'
+import { browserWindowFromEvent } from '@/utils/electron'
+
+export function initialize() {
+  ipcMain.handle('proxy:start', async (event) => {
+    console.info('proxy:start event received')
+
+    const browserWindow = browserWindowFromEvent(event)
+    k6StudioState.currentProxyProcess =
+      await launchProxyAndAttachEmitter(browserWindow)
+  })
+
+  ipcMain.on('proxy:stop', () => {
+    console.info('proxy:stop event received')
+    k6StudioState.wasProxyStoppedByClient = true
+    return stopProxyProcess()
+  })
+
+  ipcMain.handle('proxy:status:get', () => {
+    console.info('proxy:status:get event received')
+    return k6StudioState.proxyStatus
+  })
+}

--- a/src/handlers/proxy/index.ts
+++ b/src/handlers/proxy/index.ts
@@ -3,23 +3,25 @@ import { ipcMain } from 'electron'
 import { launchProxyAndAttachEmitter, stopProxyProcess } from '@/proxy'
 import { browserWindowFromEvent } from '@/utils/electron'
 
+import { ProxyHandler } from './types'
+
 export function initialize() {
-  ipcMain.handle('proxy:start', async (event) => {
-    console.info('proxy:start event received')
+  ipcMain.handle(ProxyHandler.Start, async (event) => {
+    console.info(`${ProxyHandler.Start} event received`)
 
     const browserWindow = browserWindowFromEvent(event)
     k6StudioState.currentProxyProcess =
       await launchProxyAndAttachEmitter(browserWindow)
   })
 
-  ipcMain.on('proxy:stop', () => {
-    console.info('proxy:stop event received')
+  ipcMain.on(ProxyHandler.Stop, () => {
+    console.info(`${ProxyHandler.Stop} event received`)
     k6StudioState.wasProxyStoppedByClient = true
     return stopProxyProcess()
   })
 
-  ipcMain.handle('proxy:status:get', () => {
-    console.info('proxy:status:get event received')
+  ipcMain.handle(ProxyHandler.GetStatus, () => {
+    console.info(`${ProxyHandler.GetStatus} event received`)
     return k6StudioState.proxyStatus
   })
 }

--- a/src/handlers/proxy/preload.ts
+++ b/src/handlers/proxy/preload.ts
@@ -4,22 +4,24 @@ import { ProxyData, ProxyStatus } from '@/types'
 
 import { createListener } from '../utils'
 
+import { ProxyHandler } from './types'
+
 export function launchProxy() {
-  return ipcRenderer.invoke('proxy:start') as Promise<void>
+  return ipcRenderer.invoke(ProxyHandler.Start) as Promise<void>
 }
 
 export function stopProxy() {
-  ipcRenderer.send('proxy:stop')
+  ipcRenderer.send(ProxyHandler.Stop)
 }
 
 export function onProxyData(callback: (data: ProxyData) => void) {
-  return createListener('proxy:data', callback)
+  return createListener(ProxyHandler.Data, callback)
 }
 
 export function getProxyStatus() {
-  return ipcRenderer.invoke('proxy:status:get') as Promise<ProxyStatus>
+  return ipcRenderer.invoke(ProxyHandler.GetStatus) as Promise<ProxyStatus>
 }
 
 export function onProxyStatusChange(callback: (status: ProxyStatus) => void) {
-  return createListener('proxy:status:change', callback)
+  return createListener(ProxyHandler.ChangeStatus, callback)
 }

--- a/src/handlers/proxy/preload.ts
+++ b/src/handlers/proxy/preload.ts
@@ -1,0 +1,25 @@
+import { ipcRenderer } from 'electron'
+
+import { ProxyData, ProxyStatus } from '@/types'
+
+import { createListener } from '../utils'
+
+export function launchProxy() {
+  return ipcRenderer.invoke('proxy:start') as Promise<void>
+}
+
+export function stopProxy() {
+  ipcRenderer.send('proxy:stop')
+}
+
+export function onProxyData(callback: (data: ProxyData) => void) {
+  return createListener('proxy:data', callback)
+}
+
+export function getProxyStatus() {
+  return ipcRenderer.invoke('proxy:status:get') as Promise<ProxyStatus>
+}
+
+export function onProxyStatusChange(callback: (status: ProxyStatus) => void) {
+  return createListener('proxy:status:change', callback)
+}

--- a/src/handlers/proxy/types.ts
+++ b/src/handlers/proxy/types.ts
@@ -1,0 +1,8 @@
+export enum ProxyHandler {
+  Start = 'proxy:start',
+  Stop = 'proxy:stop',
+  Close = 'proxy:close',
+  GetStatus = 'proxy:status:get',
+  ChangeStatus = 'proxy:status:change',
+  Data = 'proxy:data',
+}

--- a/src/handlers/settings/index.ts
+++ b/src/handlers/settings/index.ts
@@ -1,8 +1,8 @@
 import { ipcMain } from 'electron'
 import log from 'electron-log/main'
 
-import { applySettings } from '@/main'
 import {
+  applySettings,
   getSettings,
   saveSettings,
   selectBrowserExecutable,

--- a/src/k6StudioState.ts
+++ b/src/k6StudioState.ts
@@ -30,6 +30,8 @@ export function initialize() {
     currentProxyProcess: null,
     wasProxyStoppedByClient: false,
     proxyRetryCount: 0,
+
+    // Used mainly to avoid starting a new proxy when closing the active one on shutdown
     appShuttingDown: false,
   }
 }

--- a/src/k6StudioState.ts
+++ b/src/k6StudioState.ts
@@ -2,6 +2,7 @@ import { Process } from '@puppeteer/browsers'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import eventEmitter from 'events'
 
+import { type ProxyProcess } from './proxy'
 import { defaultSettings } from './settings'
 import { ProxyStatus } from './types'
 import { AppSettings } from './types/settings'
@@ -11,6 +12,10 @@ export type k6StudioState = {
   proxyStatus: ProxyStatus
   proxyEmitter: eventEmitter
   appSettings: AppSettings
+  currentProxyProcess: ProxyProcess | null
+  wasProxyStoppedByClient: boolean
+  proxyRetryCount: number
+  appShuttingDown: boolean
 }
 
 export function initialize() {
@@ -22,5 +27,9 @@ export function initialize() {
       ready: [void]
     }>(),
     appSettings: defaultSettings,
+    currentProxyProcess: null,
+    wasProxyStoppedByClient: false,
+    proxyRetryCount: 0,
+    appShuttingDown: false,
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import {
   TEMP_SCRIPT_SUFFIX,
 } from './constants/workspace'
 import * as handlers from './handlers'
+import { ProxyHandler } from './handlers/proxy/types'
 import * as mainState from './k6StudioState'
 import { getLogContent, initializeLogger, openLogFolder } from './logger'
 import { configureApplicationMenu } from './menu'
@@ -204,7 +205,7 @@ const createWindow = async () => {
 
   k6StudioState.proxyEmitter.on('status:change', (status: ProxyStatus) => {
     k6StudioState.proxyStatus = status
-    mainWindow.webContents.send('proxy:status:change', status)
+    mainWindow.webContents.send(ProxyHandler.ChangeStatus, status)
   })
 
   // Start proxy

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,8 +83,6 @@ if (process.env.NODE_ENV !== 'development') {
   })
 }
 
-// Used mainly to avoid starting a new proxy when closing the active one on shutdown
-let appShuttingDown: boolean = false
 let currentClientRoute = '/'
 let wasAppClosedByClient = false
 
@@ -279,7 +277,7 @@ app.on('activate', async () => {
 
 app.on('before-quit', async () => {
   // stop watching files to avoid crash on exit
-  appShuttingDown = true
+  k6StudioState.appShuttingDown = true
   await watcher.close()
   return stopProxyProcess()
 })
@@ -292,7 +290,7 @@ ipcMain.on('app:close', (event) => {
   console.log('app:close event received')
 
   wasAppClosedByClient = true
-  if (appShuttingDown) {
+  if (k6StudioState.appShuttingDown) {
     app.quit()
     return
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import {
   shell,
 } from 'electron'
 import log from 'electron-log/main'
-import find from 'find-process'
 import { existsSync } from 'fs'
 import {
   access,
@@ -24,7 +23,6 @@ import {
 } from 'fs/promises'
 import path from 'path'
 import invariant from 'tiny-invariant'
-import kill from 'tree-kill'
 import { updateElectronApp } from 'update-electron-app'
 
 import { getBrowserPath } from './browser'
@@ -40,20 +38,22 @@ import * as handlers from './handlers'
 import * as mainState from './k6StudioState'
 import { getLogContent, initializeLogger, openLogFolder } from './logger'
 import { configureApplicationMenu } from './menu'
-import { launchProxy, type ProxyProcess } from './proxy'
+import {
+  cleanUpProxies,
+  launchProxyAndAttachEmitter,
+  stopProxyProcess,
+} from './proxy'
 import { GeneratorFileDataSchema } from './schemas/generator'
 import { BrowserServer } from './services/browser/server'
 import { getSettings, initSettings, saveSettings } from './settings'
 import { ProxyStatus, StudioFile } from './types'
 import { GeneratorFileData } from './types/generator'
-import { AppSettings } from './types/settings'
 import { DataFilePreview } from './types/testData'
 import { sendReport } from './usageReport'
 import { reportNewIssue } from './utils/bugReport'
 import { parseDataFile } from './utils/dataFile'
 import {
   sendToast,
-  findOpenPort,
   getAppIcon,
   getPlatform,
   browserWindowFromEvent,
@@ -84,12 +84,8 @@ if (process.env.NODE_ENV !== 'development') {
 
 // Used mainly to avoid starting a new proxy when closing the active one on shutdown
 let appShuttingDown: boolean = false
-let currentProxyProcess: ProxyProcess | null
-const PROXY_RETRY_LIMIT = 5
-let proxyRetryCount = 0
 let currentClientRoute = '/'
 let wasAppClosedByClient = false
-let wasProxyStoppedByClient = false
 
 let watcher: FSWatcher
 let splashscreenWindow: BrowserWindow
@@ -212,7 +208,8 @@ const createWindow = async () => {
   })
 
   // Start proxy
-  currentProxyProcess = await launchProxyAndAttachEmitter(mainWindow)
+  k6StudioState.currentProxyProcess =
+    await launchProxyAndAttachEmitter(mainWindow)
 
   // and load the index.html of the app.
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
@@ -300,20 +297,6 @@ ipcMain.on('app:close', (event) => {
   }
   const browserWindow = browserWindowFromEvent(event)
   browserWindow.close()
-})
-
-// Proxy
-ipcMain.handle('proxy:start', async (event) => {
-  console.info('proxy:start event received')
-
-  const browserWindow = browserWindowFromEvent(event)
-  currentProxyProcess = await launchProxyAndAttachEmitter(browserWindow)
-})
-
-ipcMain.on('proxy:stop', () => {
-  console.info('proxy:stop event received')
-  wasProxyStoppedByClient = true
-  return stopProxyProcess()
 })
 
 // Generator
@@ -543,94 +526,6 @@ ipcMain.handle('log:read', () => {
   return getLogContent()
 })
 
-ipcMain.handle('proxy:status:get', () => {
-  console.info('proxy:status:get event received')
-  return k6StudioState.proxyStatus
-})
-
-// TODO: Move this function to settings.ts once proxy handlers are refactored
-// https://github.com/grafana/k6-studio/issues/378
-export async function applySettings(
-  modifiedSettings: Partial<AppSettings>,
-  browserWindow: BrowserWindow
-) {
-  if (modifiedSettings.proxy) {
-    await stopProxyProcess()
-    k6StudioState.appSettings.proxy = modifiedSettings.proxy
-    currentProxyProcess = await launchProxyAndAttachEmitter(browserWindow)
-  }
-  if (modifiedSettings.recorder) {
-    k6StudioState.appSettings.recorder = modifiedSettings.recorder
-  }
-  if (modifiedSettings.telemetry) {
-    k6StudioState.appSettings.telemetry = modifiedSettings.telemetry
-  }
-  if (modifiedSettings.appearance) {
-    k6StudioState.appSettings.appearance = modifiedSettings.appearance
-    nativeTheme.themeSource = k6StudioState.appSettings.appearance.theme
-  }
-}
-
-const launchProxyAndAttachEmitter = async (browserWindow: BrowserWindow) => {
-  const { port, automaticallyFindPort } = k6StudioState.appSettings.proxy
-
-  const proxyPort = automaticallyFindPort ? await findOpenPort(port) : port
-  k6StudioState.appSettings.proxy.port = proxyPort
-
-  console.log(
-    `launching proxy ${JSON.stringify(k6StudioState.appSettings.proxy)}`
-  )
-
-  k6StudioState.proxyEmitter.emit('status:change', 'starting')
-
-  return launchProxy(browserWindow, k6StudioState.appSettings.proxy, {
-    onReady: () => {
-      wasProxyStoppedByClient = false
-      k6StudioState.proxyEmitter.emit('status:change', 'online')
-      k6StudioState.proxyEmitter.emit('ready')
-    },
-    onFailure: async () => {
-      if (wasProxyStoppedByClient) {
-        k6StudioState.proxyEmitter.emit('status:change', 'offline')
-      }
-
-      if (
-        appShuttingDown ||
-        wasProxyStoppedByClient ||
-        k6StudioState.proxyStatus === 'starting'
-      ) {
-        // don't restart the proxy if the app is shutting down, manually stopped by client or already restarting
-        return
-      }
-
-      if (proxyRetryCount === PROXY_RETRY_LIMIT && !automaticallyFindPort) {
-        proxyRetryCount = 0
-        k6StudioState.proxyEmitter.emit('status:change', 'offline')
-
-        sendToast(browserWindow.webContents, {
-          title: `Port ${proxyPort} is already in use`,
-          description:
-            'Please select a different port or enable automatic port selection',
-          status: 'error',
-        })
-
-        return
-      }
-
-      proxyRetryCount++
-      k6StudioState.proxyEmitter.emit('status:change', 'starting')
-      currentProxyProcess = await launchProxyAndAttachEmitter(browserWindow)
-
-      const errorMessage = `Proxy failed to start on port ${proxyPort}, restarting...`
-      log.error(errorMessage)
-      sendToast(browserWindow.webContents, {
-        title: errorMessage,
-        status: 'error',
-      })
-    },
-  })
-}
-
 function showWindow(browserWindow: BrowserWindow) {
   const { isMaximized } = k6StudioState.appSettings.windowState
   if (isMaximized) {
@@ -746,23 +641,4 @@ function getFilePath(
     default:
       return exhaustive(file.type)
   }
-}
-
-const stopProxyProcess = async () => {
-  if (currentProxyProcess) {
-    currentProxyProcess.kill()
-    currentProxyProcess = null
-
-    // kill remaining proxies if any, this might happen on windows
-    if (getPlatform() === 'win') {
-      await cleanUpProxies()
-    }
-  }
-}
-
-const cleanUpProxies = async () => {
-  const processList = await find('name', 'k6-studio-proxy', false)
-  processList.forEach((proc) => {
-    kill(proc.pid)
-  })
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,11 +7,12 @@ import * as browser from './handlers/browser/preload'
 import * as browserRemote from './handlers/browserRemote/preload'
 import * as cloud from './handlers/cloud/preload'
 import * as har from './handlers/har/preload'
+import * as proxy from './handlers/proxy/preload'
 import * as script from './handlers/script/preload'
 import * as settings from './handlers/settings/preload'
 import { createListener } from './handlers/utils'
 import * as Sentry from './sentry'
-import { ProxyData, ProxyStatus, StudioFile } from './types'
+import { StudioFile } from './types'
 import { GeneratorFileData } from './types/generator'
 import { DataFilePreview } from './types/testData'
 import { AddToastPayload } from './types/toast'
@@ -22,24 +23,6 @@ interface GetFilesResponse {
   scripts: StudioFile[]
   dataFiles: StudioFile[]
 }
-
-const proxy = {
-  launchProxy: (): Promise<void> => {
-    return ipcRenderer.invoke('proxy:start')
-  },
-  stopProxy: () => {
-    ipcRenderer.send('proxy:stop')
-  },
-  onProxyData: (callback: (data: ProxyData) => void) => {
-    return createListener('proxy:data', callback)
-  },
-  getProxyStatus: (): Promise<ProxyStatus> => {
-    return ipcRenderer.invoke('proxy:status:get')
-  },
-  onProxyStatusChange: (callback: (status: ProxyStatus) => void) => {
-    return createListener('proxy:status:change', callback)
-  },
-} as const
 
 const data = {
   importFile: (): Promise<string | undefined> => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,7 @@ import path from 'path'
 import readline from 'readline/promises'
 import kill from 'tree-kill'
 
+import { ProxyHandler } from './handlers/proxy/types'
 import { ProxyData } from './types'
 import { ProxySettings } from './types/settings'
 import { getPlatform, getArch, findOpenPort, sendToast } from './utils/electron'
@@ -88,7 +89,7 @@ export const launchProxy = (
 
     const proxyData = safeJsonParse<ProxyData>(data)
     if (proxyData) {
-      browserWindow.webContents.send('proxy:data', proxyData)
+      browserWindow.webContents.send(ProxyHandler.Data, proxyData)
     } else {
       // the proxy outputs some errors to stdout
       // example: [Errno 48] HTTP(S) proxy failed to listen on *:6001
@@ -109,7 +110,7 @@ export const launchProxy = (
       return
     }
 
-    browserWindow.webContents.send('proxy:close', code)
+    browserWindow.webContents.send(ProxyHandler.Close, code)
     onFailure?.()
   })
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,14 +1,16 @@
 import { app, BrowserWindow } from 'electron'
 import log from 'electron-log/main'
+import find from 'find-process'
 import { readFile } from 'fs/promises'
 import forge from 'node-forge'
 import { spawn, ChildProcessWithoutNullStreams } from 'node:child_process'
 import path from 'path'
 import readline from 'readline/promises'
+import kill from 'tree-kill'
 
 import { ProxyData } from './types'
 import { ProxySettings } from './types/settings'
-import { getPlatform, getArch } from './utils/electron'
+import { getPlatform, getArch, findOpenPort, sendToast } from './utils/electron'
 import { safeJsonParse } from './utils/json'
 
 export type ProxyProcess = ChildProcessWithoutNullStreams
@@ -157,5 +159,91 @@ export const waitForProxy = async (): Promise<void> => {
     k6StudioState.proxyEmitter.once('ready', () => {
       resolve()
     })
+  })
+}
+
+export const launchProxyAndAttachEmitter = async (
+  browserWindow: BrowserWindow
+) => {
+  const PROXY_RETRY_LIMIT = 5
+  const { port, automaticallyFindPort } = k6StudioState.appSettings.proxy
+
+  const proxyPort = automaticallyFindPort ? await findOpenPort(port) : port
+  k6StudioState.appSettings.proxy.port = proxyPort
+
+  console.log(
+    `launching proxy ${JSON.stringify(k6StudioState.appSettings.proxy)}`
+  )
+
+  k6StudioState.proxyEmitter.emit('status:change', 'starting')
+
+  return launchProxy(browserWindow, k6StudioState.appSettings.proxy, {
+    onReady: () => {
+      k6StudioState.wasProxyStoppedByClient = false
+      k6StudioState.proxyEmitter.emit('status:change', 'online')
+      k6StudioState.proxyEmitter.emit('ready')
+    },
+    onFailure: async () => {
+      if (k6StudioState.wasProxyStoppedByClient) {
+        k6StudioState.proxyEmitter.emit('status:change', 'offline')
+      }
+
+      if (
+        k6StudioState.appShuttingDown ||
+        k6StudioState.wasProxyStoppedByClient ||
+        k6StudioState.proxyStatus === 'starting'
+      ) {
+        // don't restart the proxy if the app is shutting down, manually stopped by client or already restarting
+        return
+      }
+
+      if (
+        k6StudioState.proxyRetryCount === PROXY_RETRY_LIMIT &&
+        !automaticallyFindPort
+      ) {
+        k6StudioState.proxyRetryCount = 0
+        k6StudioState.proxyEmitter.emit('status:change', 'offline')
+
+        sendToast(browserWindow.webContents, {
+          title: `Port ${proxyPort} is already in use`,
+          description:
+            'Please select a different port or enable automatic port selection',
+          status: 'error',
+        })
+
+        return
+      }
+
+      k6StudioState.proxyRetryCount++
+      k6StudioState.proxyEmitter.emit('status:change', 'starting')
+      k6StudioState.currentProxyProcess =
+        await launchProxyAndAttachEmitter(browserWindow)
+
+      const errorMessage = `Proxy failed to start on port ${proxyPort}, restarting...`
+      log.error(errorMessage)
+      sendToast(browserWindow.webContents, {
+        title: errorMessage,
+        status: 'error',
+      })
+    },
+  })
+}
+
+export const stopProxyProcess = async () => {
+  if (k6StudioState.currentProxyProcess) {
+    k6StudioState.currentProxyProcess.kill()
+    k6StudioState.currentProxyProcess = null
+
+    // kill remaining proxies if any, this might happen on windows
+    if (getPlatform() === 'win') {
+      await cleanUpProxies()
+    }
+  }
+}
+
+export const cleanUpProxies = async () => {
+  const processList = await find('name', 'k6-studio-proxy', false)
+  processList.forEach((proc) => {
+    kill(proc.pid)
   })
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR moves the proxy handlers, preload and related helper functions out of `main.ts`. No functional changes were made.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Proxy starts and stops as expected
- Proxy status is properly reported to the UI
- Script validator works as expected
- Proxy settings are properly saved

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
