### PR TITLE
internal(browser): Elements are not highlighted when hovering selector in k6 Studio

### DIFF
--- a/extension/src/frontend/routing.ts
+++ b/extension/src/frontend/routing.ts
@@ -14,5 +14,6 @@ frontend.forward('load-events', [background])
 
 background.forward('events-recorded', [frontend])
 background.forward('events-loaded', [frontend])
+background.forward('highlight-elements', [frontend])
 
 export { frontend as client }


### PR DESCRIPTION
## Description

This PR fixes element highlights when hovering selectors in k6 Studio.

## How to Test

1. Start a recording.
2. Interact with the page.
3. Hover a selector in the browser list.
4. The corresponding element(s) should be highlighted in the browser.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
