### PR TITLE
internal(browser): Element highlights get out of sync with content when resizing/scrolling page

### DIFF
--- a/extension/src/frontend/view/ElementInspector.hooks.ts
+++ b/extension/src/frontend/view/ElementInspector.hooks.ts
@@ -8,11 +8,20 @@ import { useGlobalClass } from './GlobalStyles'
 import { useHighlightDebounce } from './hooks/useHighlightDebounce'
 import { usePreventClick } from './hooks/usePreventClick'
 import { Bounds } from './types'
+import { getElementBounds } from './utils'
 
 interface TrackedElement {
   selector: ElementSelector
   target: Element
   bounds: Bounds
+}
+
+function toTrackedElement(element: Element): TrackedElement {
+  return {
+    selector: generateSelector(element),
+    target: element,
+    bounds: getElementBounds(element),
+  }
 }
 
 export function useInspectedElement() {
@@ -40,18 +49,7 @@ export function useInspectedElement() {
         return
       }
 
-      const { top, left, width, height } = target.getBoundingClientRect()
-
-      setInspectedElement({
-        selector: generateSelector(target),
-        target: target,
-        bounds: {
-          top,
-          left,
-          width,
-          height,
-        },
-      })
+      setInspectedElement(toTrackedElement(target))
     }
 
     window.addEventListener('mouseover', handleMouseOver)
@@ -60,22 +58,6 @@ export function useInspectedElement() {
       window.removeEventListener('mouseover', handleMouseOver)
     }
   }, [])
-
-  useEffect(() => {
-    if (element === null) {
-      return
-    }
-
-    const handleScroll = () => {
-      setInspectedElement(null)
-    }
-
-    window.addEventListener('scroll', handleScroll)
-
-    return () => {
-      window.removeEventListener('scroll', handleScroll)
-    }
-  }, [element])
 
   usePreventClick(element !== null)
   useGlobalClass('inspecting')

--- a/extension/src/frontend/view/Overlay.tsx
+++ b/extension/src/frontend/view/Overlay.tsx
@@ -13,7 +13,7 @@ export const Overlay = forwardRef<HTMLDivElement, OverlayProps>(
       <div
         ref={ref}
         css={css`
-          position: fixed;
+          position: absolute;
           pointer-events: none;
         `}
         style={{

--- a/extension/src/frontend/view/RemoteHighlights.hooks.ts
+++ b/extension/src/frontend/view/RemoteHighlights.hooks.ts
@@ -1,46 +1,78 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { HighlightSelector } from 'extension/src/messaging/types'
+
 import { client } from '../routing'
 
 import { useHighlightDebounce } from './hooks/useHighlightDebounce'
 import { Bounds } from './types'
+import { getElementBounds } from './utils'
 
 interface Highlight {
   id: number
+  element: Element
   bounds: Bounds
 }
 
 export function useHighlightedElements() {
   const idCounter = useRef(0)
-  const [bounds, setBounds] = useState<Highlight[] | null>(null)
+
+  const [selector, setSelector] = useState<HighlightSelector | null>(null)
+  const [highlights, setHighlights] = useState<Highlight[] | null>(null)
 
   useEffect(() => {
     return client.on('highlight-elements', ({ data }) => {
-      if (data.selector === null) {
-        setBounds(null)
-
-        return
-      }
-
-      const elements = document.querySelectorAll(data.selector.selector)
-
-      const bounds = Array.from(elements).map((el) => {
-        const { top, left, width, height } = el.getBoundingClientRect()
-
-        return {
-          id: idCounter.current++,
-          bounds: {
-            top,
-            left,
-            width,
-            height,
-          },
-        }
-      })
-
-      setBounds(bounds)
+      setSelector(data.selector)
     })
   }, [])
 
-  return useHighlightDebounce(bounds)
+  useEffect(() => {
+    if (selector === null) {
+      setHighlights(null)
+
+      return
+    }
+
+    const elements = document.querySelectorAll(selector.selector)
+    const highlights = Array.from(elements).map((element) => {
+      const bounds = getElementBounds(element)
+
+      return {
+        id: idCounter.current++,
+        element,
+        bounds,
+      }
+    })
+
+    setHighlights(highlights)
+  }, [selector])
+
+  useEffect(() => {
+    if (selector === null) {
+      return
+    }
+
+    const observer = new ResizeObserver(() => {
+      setHighlights((highlights) => {
+        if (highlights === null) {
+          return null
+        }
+
+        return highlights.map((highlight) => {
+          return {
+            ...highlight,
+            bounds: getElementBounds(highlight.element),
+          }
+        })
+      })
+    })
+
+    observer.observe(document.body)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [selector])
+
+  return useHighlightDebounce(highlights)
 }

--- a/extension/src/frontend/view/TextAssertionEditor.hooks.ts
+++ b/extension/src/frontend/view/TextAssertionEditor.hooks.ts
@@ -4,6 +4,14 @@ import { useContainerElement } from '@/components/primitives/ContainerProvider'
 import { generateSelector } from 'extension/src/selectors'
 
 import { TextSelection } from './TextAssertionEditor.types'
+import { getElementBounds, toBounds } from './utils'
+
+function measureRange(range: Range) {
+  return {
+    highlights: Array.from(range.getClientRects()).map(toBounds),
+    bounds: getElementBounds(range),
+  }
+}
 
 export function useTextSelection() {
   const isSelecting = useRef(false)
@@ -69,27 +77,11 @@ export function useTextSelection() {
         return
       }
 
-      const bounds = range.getBoundingClientRect()
-      const highlights = Array.from(range.getClientRects()).map((rect) => {
-        return {
-          top: rect.top,
-          left: rect.left,
-          width: rect.width,
-          height: rect.height,
-        }
-      })
-
       setSelection({
         text: range.toString(),
         selector: generateSelector(commonAncestor),
         range,
-        highlights: highlights,
-        bounds: {
-          top: bounds.top,
-          left: bounds.left,
-          width: bounds.width,
-          height: bounds.height,
-        },
+        ...measureRange(range),
       })
     }
 
@@ -107,27 +99,9 @@ export function useTextSelection() {
           return null
         }
 
-        const bounds = selection.range.getBoundingClientRect()
-        const textRects = Array.from(selection.range.getClientRects()).map(
-          (rect) => {
-            return {
-              top: rect.top,
-              left: rect.left,
-              width: rect.width,
-              height: rect.height,
-            }
-          }
-        )
-
         return {
           ...selection,
-          highlights: textRects,
-          bounds: {
-            top: bounds.top,
-            left: bounds.left,
-            width: bounds.width,
-            height: bounds.height,
-          },
+          ...measureRange(selection.range),
         }
       })
     })

--- a/extension/src/frontend/view/TextAssertionEditor.tsx
+++ b/extension/src/frontend/view/TextAssertionEditor.tsx
@@ -91,7 +91,7 @@ function TextAssertionForm({
   }
 
   return (
-    <Popover.Root modal open={true} onOpenChange={onClose}>
+    <Popover.Root open={true} onOpenChange={onClose}>
       <Popover.Anchor asChild>
         <Overlay bounds={selection.bounds} />
       </Popover.Anchor>

--- a/extension/src/frontend/view/utils.ts
+++ b/extension/src/frontend/view/utils.ts
@@ -28,6 +28,10 @@ export function shouldSkipEvent(event: Event): boolean {
 }
 
 export function toBounds(rect: DOMRect): Bounds {
+  // `getBoundingClientRect` returns the coordinates relative to the viewport
+  // and not the document, so we add the scroll position so that the element
+  // is relative to the page instead. This means that content will stay in place
+  // when scrolling.
   return {
     top: rect.top + window.scrollY,
     left: rect.left + window.scrollX,

--- a/extension/src/frontend/view/utils.ts
+++ b/extension/src/frontend/view/utils.ts
@@ -1,4 +1,5 @@
 import { useInBrowserUIStore } from './store'
+import { Bounds } from './types'
 
 export function shouldSkipEvent(event: Event): boolean {
   const store = useInBrowserUIStore.getState()
@@ -24,4 +25,17 @@ export function shouldSkipEvent(event: Event): boolean {
     root.firstElementChild !== null &&
     root.firstElementChild.hasAttribute('data-ksix-studio')
   )
+}
+
+export function toBounds(rect: DOMRect): Bounds {
+  return {
+    top: rect.top + window.scrollY,
+    left: rect.left + window.scrollX,
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+export function getElementBounds(element: Element | Range): Bounds {
+  return toBounds(element.getBoundingClientRect())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes element highlights getting out of sync, i.e. no longer overlaying elements, when scrolling or resizing the window.

## How to Test

1. Start a recording.
2. Use the inspect element tool and scroll while hovering an element
    - The highlight should stick to the element (until it highlights another element)
3. Highlight text using the Add text assertion tool.
    - Highlight should stick when scrolling up/down
    - Highlight should stick when resizing window

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
