### PR TITLE
refactor(Split main): Move data file handlers out of main.ts

### DIFF
--- a/src/handlers/dataFiles/index.ts
+++ b/src/handlers/dataFiles/index.ts
@@ -1,0 +1,67 @@
+import { COPYFILE_EXCL } from 'constants'
+import { ipcMain, dialog } from 'electron'
+import { stat, copyFile, readFile } from 'fs/promises'
+import path from 'path'
+import invariant from 'tiny-invariant'
+
+import { MAX_DATA_FILE_SIZE } from '@/constants/files'
+import { DATA_FILES_PATH } from '@/constants/workspace'
+import { DataFilePreview } from '@/types/testData'
+import { parseDataFile } from '@/utils/dataFile'
+import { browserWindowFromEvent } from '@/utils/electron'
+
+export function initialize() {
+  ipcMain.handle('data-file:import', async (event) => {
+    const browserWindow = browserWindowFromEvent(event)
+
+    const dialogResult = await dialog.showOpenDialog(browserWindow, {
+      message: 'Import data file',
+      properties: ['openFile'],
+      filters: [{ name: 'Supported data files', extensions: ['csv', 'json'] }],
+    })
+
+    const filePath = dialogResult.filePaths[0]
+
+    if (dialogResult.canceled || !filePath) {
+      return
+    }
+
+    const { size } = await stat(filePath)
+    invariant(size <= MAX_DATA_FILE_SIZE, 'File is too large')
+
+    await copyFile(
+      filePath,
+      path.join(DATA_FILES_PATH, path.basename(filePath)),
+      COPYFILE_EXCL
+    )
+
+    return path.basename(filePath)
+  })
+
+  ipcMain.handle(
+    'data-file:load-preview',
+    async (_, fileName: string): Promise<DataFilePreview> => {
+      const fileType = fileName.split('.').pop()
+      const filePath = path.join(DATA_FILES_PATH, fileName)
+
+      invariant(
+        fileType === 'csv' || fileType === 'json',
+        'Unsupported file type'
+      )
+
+      const data = await readFile(filePath, {
+        flag: 'r',
+        encoding: 'utf-8',
+      })
+
+      const parsedData = parseDataFile(data, fileType)
+
+      return {
+        type: fileType,
+        data: parsedData.slice(0, 20),
+        props: parsedData[0] ? Object.keys(parsedData[0]) : [],
+        total: parsedData.length,
+      }
+    }
+  )
+}

--- a/src/handlers/dataFiles/index.ts
+++ b/src/handlers/dataFiles/index.ts
@@ -10,8 +10,10 @@ import { DataFilePreview } from '@/types/testData'
 import { parseDataFile } from '@/utils/dataFile'
 import { browserWindowFromEvent } from '@/utils/electron'
 
+import { DataFileHandler } from './types'
+
 export function initialize() {
-  ipcMain.handle('data-file:import', async (event) => {
+  ipcMain.handle(DataFileHandler.Import, async (event) => {
     const browserWindow = browserWindowFromEvent(event)
 
     const dialogResult = await dialog.showOpenDialog(browserWindow, {
@@ -39,7 +41,7 @@ export function initialize() {
   })
 
   ipcMain.handle(
-    'data-file:load-preview',
+    DataFileHandler.LoadPreview,
     async (_, fileName: string): Promise<DataFilePreview> => {
       const fileType = fileName.split('.').pop()
       const filePath = path.join(DATA_FILES_PATH, fileName)

--- a/src/handlers/dataFiles/preload.ts
+++ b/src/handlers/dataFiles/preload.ts
@@ -2,13 +2,17 @@ import { ipcRenderer } from 'electron'
 
 import { DataFilePreview } from '@/types/testData'
 
+import { DataFileHandler } from './types'
+
 export function importFile() {
-  return ipcRenderer.invoke('data-file:import') as Promise<string | undefined>
+  return ipcRenderer.invoke(DataFileHandler.Import) as Promise<
+    string | undefined
+  >
 }
 
 export function loadPreview(filePath: string) {
   return ipcRenderer.invoke(
-    'data-file:load-preview',
+    DataFileHandler.LoadPreview,
     filePath
   ) as Promise<DataFilePreview>
 }

--- a/src/handlers/dataFiles/preload.ts
+++ b/src/handlers/dataFiles/preload.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron'
+
+import { DataFilePreview } from '@/types/testData'
+
+export function importFile() {
+  return ipcRenderer.invoke('data-file:import') as Promise<string | undefined>
+}
+
+export function loadPreview(filePath: string) {
+  return ipcRenderer.invoke(
+    'data-file:load-preview',
+    filePath
+  ) as Promise<DataFilePreview>
+}

--- a/src/handlers/dataFiles/types.ts
+++ b/src/handlers/dataFiles/types.ts
@@ -1,0 +1,4 @@
+export enum DataFileHandler {
+  Import = 'data-file:import',
+  LoadPreview = 'data-file:load-preview',
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -4,6 +4,7 @@ import * as auth from './auth'
 import * as browser from './browser'
 import * as browserRemote from './browserRemote'
 import * as cloud from './cloud'
+import * as dataFiles from './dataFiles'
 import * as generator from './generator'
 import * as har from './har'
 import * as proxy from './proxy'
@@ -26,4 +27,5 @@ export function initialize({ browserServer }: Services) {
   proxy.initialize()
   ui.initialize()
   generator.initialize()
+  dataFiles.initialize()
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,12 @@
 import * as Sentry from '@sentry/electron/main'
 import { watch, FSWatcher } from 'chokidar'
-import { COPYFILE_EXCL } from 'constants'
-import { app, BrowserWindow, dialog, ipcMain, nativeTheme } from 'electron'
+import { app, BrowserWindow, ipcMain, nativeTheme } from 'electron'
 import log from 'electron-log/main'
 import { existsSync } from 'fs'
-import { copyFile, readdir, rename, readFile, stat } from 'fs/promises'
+import { readdir, rename } from 'fs/promises'
 import path from 'path'
-import invariant from 'tiny-invariant'
 import { updateElectronApp } from 'update-electron-app'
 
-import { MAX_DATA_FILE_SIZE } from './constants/files'
 import {
   DATA_FILES_PATH,
   GENERATORS_PATH,
@@ -32,9 +29,7 @@ import {
 import { BrowserServer } from './services/browser/server'
 import { getSettings, initSettings, saveSettings } from './settings'
 import { ProxyStatus } from './types'
-import { DataFilePreview } from './types/testData'
 import { sendReport } from './usageReport'
-import { parseDataFile } from './utils/dataFile'
 import {
   getAppIcon,
   getPlatform,
@@ -272,60 +267,6 @@ ipcMain.on('app:close', (event) => {
   const browserWindow = browserWindowFromEvent(event)
   browserWindow.close()
 })
-
-ipcMain.handle('data-file:import', async (event) => {
-  const browserWindow = browserWindowFromEvent(event)
-
-  const dialogResult = await dialog.showOpenDialog(browserWindow, {
-    message: 'Import data file',
-    properties: ['openFile'],
-    filters: [{ name: 'Supported data files', extensions: ['csv', 'json'] }],
-  })
-
-  const filePath = dialogResult.filePaths[0]
-
-  if (dialogResult.canceled || !filePath) {
-    return
-  }
-
-  const { size } = await stat(filePath)
-  invariant(size <= MAX_DATA_FILE_SIZE, 'File is too large')
-
-  await copyFile(
-    filePath,
-    path.join(DATA_FILES_PATH, path.basename(filePath)),
-    COPYFILE_EXCL
-  )
-
-  return path.basename(filePath)
-})
-
-ipcMain.handle(
-  'data-file:load-preview',
-  async (_, fileName: string): Promise<DataFilePreview> => {
-    const fileType = fileName.split('.').pop()
-    const filePath = path.join(DATA_FILES_PATH, fileName)
-
-    invariant(
-      fileType === 'csv' || fileType === 'json',
-      'Unsupported file type'
-    )
-
-    const data = await readFile(filePath, {
-      flag: 'r',
-      encoding: 'utf-8',
-    })
-
-    const parsedData = parseDataFile(data, fileType)
-
-    return {
-      type: fileType,
-      data: parsedData.slice(0, 20),
-      props: parsedData[0] ? Object.keys(parsedData[0]) : [],
-      total: parsedData.length,
-    }
-  }
-)
 
 ipcMain.on('splashscreen:close', (event) => {
   console.info('splashscreen:close event received')

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,7 @@ import * as auth from './handlers/auth/preload'
 import * as browser from './handlers/browser/preload'
 import * as browserRemote from './handlers/browserRemote/preload'
 import * as cloud from './handlers/cloud/preload'
+import * as data from './handlers/dataFiles/preload'
 import * as generator from './handlers/generator/preload'
 import * as har from './handlers/har/preload'
 import * as proxy from './handlers/proxy/preload'
@@ -14,16 +15,6 @@ import * as settings from './handlers/settings/preload'
 import * as ui from './handlers/ui/preload'
 import { createListener } from './handlers/utils'
 import * as Sentry from './sentry'
-import { DataFilePreview } from './types/testData'
-
-const data = {
-  importFile: (): Promise<string | undefined> => {
-    return ipcRenderer.invoke('data-file:import')
-  },
-  loadPreview: (filePath: string): Promise<DataFilePreview> => {
-    return ipcRenderer.invoke('data-file:load-preview', filePath)
-  },
-} as const
 
 const app = {
   platform: process.platform,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR moves the data file handlers and preload functions to its own namespace in `./src/handlers`. No functional changes were made.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

Check that the following works as expected:

- Import a data file
- Preview of a data file

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
