### PR TITLE
internal(browser): Add toggle for browser events to start recording page

### DIFF
--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -98,8 +98,8 @@ export const RecorderSettings = () => {
         errors={errors}
         hint={
           <>
-            Enables the <em>experimental</em> browser recording feature. With
-            this feature enabled user interactions in the browser are recorded
+            Enables the browser recording <em>preview</em> feature. With this
+            feature enabled user interactions in the browser are recorded
             alongside network requests. The recorded interactions can be
             exported as a k6 browser script.
           </>
@@ -117,7 +117,7 @@ export const RecorderSettings = () => {
                   checked={field.value}
                   onCheckedChange={field.onChange}
                 />{' '}
-                Enable browser recording (experimental)
+                Enable browser recording (preview)
               </Text>
             )}
           />

--- a/src/handlers/browser/index.ts
+++ b/src/handlers/browser/index.ts
@@ -1,26 +1,29 @@
 import { ipcMain, shell } from 'electron'
 
-import { launchBrowser } from '@/browser'
+import { launchBrowser } from '@/handlers/browser/launch'
 import { waitForProxy } from '@/proxy'
 import { BrowserServer } from '@/services/browser/server'
 import { browserWindowFromEvent } from '@/utils/electron'
 
-import { BrowserHandler } from './types'
+import { BrowserHandler, LaunchBrowserOptions } from './types'
 
 export function initialize(browserServer: BrowserServer) {
-  ipcMain.handle(BrowserHandler.Start, async (event, url?: string) => {
-    console.info(`${BrowserHandler.Start} event received`)
+  ipcMain.handle(
+    BrowserHandler.Start,
+    async (event, options: LaunchBrowserOptions) => {
+      console.info(`${BrowserHandler.Start} event received`)
 
-    await waitForProxy()
+      await waitForProxy()
 
-    const browserWindow = browserWindowFromEvent(event)
-    k6StudioState.currentBrowserProcess = await launchBrowser(
-      browserWindow,
-      browserServer,
-      url
-    )
-    console.info('browser started')
-  })
+      const browserWindow = browserWindowFromEvent(event)
+      k6StudioState.currentBrowserProcess = await launchBrowser(
+        browserWindow,
+        browserServer,
+        options
+      )
+      console.info('browser started')
+    }
+  )
 
   ipcMain.on(BrowserHandler.Stop, async () => {
     console.info(`${BrowserHandler.Stop} event received`)

--- a/src/handlers/browser/launch.ts
+++ b/src/handlers/browser/launch.ts
@@ -12,10 +12,11 @@ import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
 
-import { BrowserHandler } from './handlers/browser/types'
-import { getCertificateSPKI } from './proxy'
-import { BrowserServer } from './services/browser/server'
-import { getPlatform } from './utils/electron'
+import { getCertificateSPKI } from '../../proxy'
+import { BrowserServer } from '../../services/browser/server'
+import { getPlatform } from '../../utils/electron'
+
+import { BrowserHandler, LaunchBrowserOptions } from './types'
 
 const createUserDataDir = async () => {
   return mkdtemp(path.join(os.tmpdir(), 'k6-studio-'))
@@ -53,7 +54,7 @@ function getExtensionPath() {
 export const launchBrowser = async (
   browserWindow: BrowserWindow,
   browserServer: BrowserServer,
-  url?: string
+  { url, capture }: LaunchBrowserOptions
 ) => {
   const path = await getBrowserPath()
   console.info(`browser path: ${path}`)
@@ -73,7 +74,7 @@ export const launchBrowser = async (
   const extensionPath = getExtensionPath()
   console.info(`extension path: ${extensionPath}`)
 
-  if (k6StudioState.appSettings.recorder.enableBrowserRecorder) {
+  if (capture.browser) {
     browserServer.start(browserWindow)
   }
 
@@ -93,8 +94,7 @@ export const launchBrowser = async (
     browserWindow.webContents.send(BrowserHandler.Failed)
   }
 
-  const browserRecordingArgs = k6StudioState.appSettings.recorder
-    .enableBrowserRecorder
+  const browserRecordingArgs = capture.browser
     ? [`--load-extension=${extensionPath}`]
     : []
 

--- a/src/handlers/browser/preload.ts
+++ b/src/handlers/browser/preload.ts
@@ -1,13 +1,12 @@
 import { ipcRenderer } from 'electron'
 
+import { LaunchBrowserOptions, BrowserHandler } from '@/handlers/browser/types'
 import { BrowserEvent } from '@/schemas/recording'
 
 import { createListener } from '../utils'
 
-import { BrowserHandler } from './types'
-
-export function launchBrowser(url?: string) {
-  return ipcRenderer.invoke(BrowserHandler.Start, url) as Promise<void>
+export function launchBrowser(options: LaunchBrowserOptions) {
+  return ipcRenderer.invoke(BrowserHandler.Start, options) as Promise<void>
 }
 
 export function stopBrowser() {

--- a/src/handlers/browser/types.ts
+++ b/src/handlers/browser/types.ts
@@ -6,3 +6,10 @@ export enum BrowserHandler {
   OpenExternalLink = 'browser:open:external:link',
   BrowserEvent = 'browser:event',
 }
+
+export interface LaunchBrowserOptions {
+  url?: string
+  capture: {
+    browser: boolean
+  }
+}

--- a/src/handlers/ui/index.ts
+++ b/src/handlers/ui/index.ts
@@ -4,7 +4,6 @@ import { unlink, readdir, access, rename } from 'fs/promises'
 import path from 'path'
 import invariant from 'tiny-invariant'
 
-import { getBrowserPath } from '@/browser'
 import { INVALID_FILENAME_CHARS } from '@/constants/files'
 import {
   RECORDINGS_PATH,
@@ -13,6 +12,7 @@ import {
   TEMP_SCRIPT_SUFFIX,
   DATA_FILES_PATH,
 } from '@/constants/workspace'
+import { getBrowserPath } from '@/handlers/browser/launch'
 import { getFilePath, getStudioFileFromPath } from '@/main/file'
 import { StudioFile } from '@/types'
 import { reportNewIssue } from '@/utils/bugReport'

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -1,6 +1,10 @@
 import { css } from '@emotion/react'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { DiscIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons'
+import {
+  DiscIcon,
+  ExclamationTriangleIcon,
+  InfoCircledIcon,
+} from '@radix-ui/react-icons'
 import {
   Button,
   Callout,
@@ -10,6 +14,7 @@ import {
   Spinner,
   Text,
   TextField,
+  Tooltip,
 } from '@radix-ui/themes'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -104,57 +109,93 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
           margin-top: var(--space-6);
         `}
       >
-        <FieldGroup
-          name="url"
-          label="Starting URL"
-          hint="Enter the URL of the website or service you want to test"
-          hintType="text"
-          errors={errors}
-          width="100%"
-        >
-          <Flex>
-            <TextField.Root
-              {...register('url')}
-              placeholder="e.g. quickpizza.grafana.com"
-              autoFocus
-              css={css`
-                flex-grow: 1;
-                border-right: 0;
-                border-bottom-right-radius: 0;
-                border-top-right-radius: 0;
-              `}
-            />
-            <Button
-              disabled={isLoading || !canRecord}
-              type="submit"
-              css={css`
-                margin-left: -1px;
-                border-bottom-left-radius: 0;
-                border-top-left-radius: 0;
-              `}
+        <Flex direction="column" gap="4">
+          <div>
+            <FieldGroup
+              name="url"
+              label="Starting URL"
+              hint="Enter the URL of the website or service you want to test"
+              hintType="text"
+              errors={errors}
+              width="100%"
             >
-              {isLoading ? <Spinner /> : <DiscIcon />} Start recording
-            </Button>
-          </Flex>
-        </FieldGroup>
-        {canCaptureBrowser && (
-          <Text as="label" size="2">
-            <Flex gap="2">
-              <Checkbox
-                disabled={!canRecord}
-                checked={captureBrowser}
-                onCheckedChange={handleCaptureBrowserChange}
-              />
-              <span>Capture browser events (Preview)</span>
-            </Flex>
-          </Text>
-        )}
+              <Flex>
+                <TextField.Root
+                  {...register('url')}
+                  placeholder="e.g. quickpizza.grafana.com"
+                  autoFocus
+                  css={css`
+                    flex-grow: 1;
+                    border-right: 0;
+                    border-bottom-right-radius: 0;
+                    border-top-right-radius: 0;
+                  `}
+                />
+                <Button
+                  disabled={isLoading || !canRecord}
+                  type="submit"
+                  css={css`
+                    margin-left: -1px;
+                    border-bottom-left-radius: 0;
+                    border-top-left-radius: 0;
+                  `}
+                >
+                  {isLoading ? <Spinner /> : <DiscIcon />} Start recording
+                </Button>
+              </Flex>
+            </FieldGroup>
 
-        <WarningMessage
-          proxyStatus={proxyStatus}
-          isBrowserInstalled={isBrowserInstalled}
-        />
+            <WarningMessage
+              proxyStatus={proxyStatus}
+              isBrowserInstalled={isBrowserInstalled}
+            />
+          </div>
+
+          {canCaptureBrowser && (
+            <FieldGroup
+              name="captureBrowser"
+              label={<CaptureBrowserLabel />}
+              hint="Record user interactions in the browser alongside network requests."
+              hintType="text"
+            >
+              <Text size="2">
+                <Flex gap="2" align="center">
+                  <Checkbox
+                    disabled={!canRecord}
+                    checked={captureBrowser}
+                    onCheckedChange={handleCaptureBrowserChange}
+                  />
+                  <span>Capture browser events</span>
+                </Flex>
+              </Text>
+            </FieldGroup>
+          )}
+        </Flex>
       </form>
+    </Flex>
+  )
+}
+
+function CaptureBrowserLabel() {
+  return (
+    <Flex align="center" gap="1">
+      <span>
+        Browser Events{' '}
+        <Text size="1" weight="light">
+          (Preview)
+        </Text>{' '}
+      </span>
+      <Tooltip
+        content={
+          <>
+            This will enable capture of user interactions such as clicks and
+            navigation. Recordings with these events can later be used to export
+            a k6 browser script.
+          </>
+        }
+      >
+        <InfoCircledIcon />
+      </Tooltip>
     </Flex>
   )
 }

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -7,6 +7,7 @@ import { useBlocker, useNavigate } from 'react-router-dom'
 import { View } from '@/components/Layout/View'
 import TextSpinner from '@/components/TextSpinner/TextSpinner'
 import { DEFAULT_GROUP_NAME } from '@/constants'
+import { LaunchBrowserOptions } from '@/handlers/browser/types'
 import { useListenBrowserEvent } from '@/hooks/useListenBrowserEvent'
 import { useListenProxyData } from '@/hooks/useListenProxyData'
 import { useSettings } from '@/hooks/useSettings'
@@ -65,12 +66,13 @@ export function Recorder() {
   const isLoading = recorderState === 'starting' || recorderState === 'saving'
 
   const handleStartRecording = useCallback(
-    async (url?: string) => {
-      setStartUrl(url)
+    async (options: LaunchBrowserOptions) => {
+      setStartUrl(options.url)
+
       try {
         resetProxyData()
         setRecorderState('starting')
-        await startRecording(url)
+        await startRecording(options)
       } catch (error) {
         setRecorderState('idle')
         showToast({
@@ -95,7 +97,7 @@ export function Recorder() {
     try {
       setRecorderState('saving')
 
-      if (proxyData.length === 0) {
+      if (proxyData.length === 0 && browserEvents.length === 0) {
         return null
       }
 

--- a/src/views/Recorder/Recorder.utils.ts
+++ b/src/views/Recorder/Recorder.utils.ts
@@ -1,6 +1,7 @@
 import { debounce } from 'lodash-es'
 import { useState, useMemo, useEffect } from 'react'
 
+import { LaunchBrowserOptions } from '@/handlers/browser/types'
 import { ProxyData, Request } from '@/types'
 import { getContentTypeWithCharsetHeader, upsertHeader } from '@/utils/headers'
 
@@ -87,11 +88,11 @@ export function getHostNameFromURL(url?: string) {
 }
 
 // TODO: add error and timeout handling
-export async function startRecording(url?: string) {
+export async function startRecording(options: LaunchBrowserOptions) {
   // Kill previous browser window
   window.studio.browser.stopBrowser()
 
-  return window.studio.browser.launchBrowser(url)
+  return window.studio.browser.launchBrowser(options)
 }
 
 export function stopRecording() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a button to toggle the browser recording feature when starting a recording. 

## How to Test

1. Start a recording with "Capture browser events" enabled
    * The in-browser UI should show and browser events should be recorded.
2. Start a recording with "Capture browser events" disabled
    * The in-browser UI should not be available and no events should be recorded.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
