### PR TITLE
refactor(Split main): Move app handlers out of main.ts

### DIFF
--- a/src/handlers/app/index.ts
+++ b/src/handlers/app/index.ts
@@ -1,0 +1,38 @@
+import { ipcMain, app } from 'electron'
+
+import { showWindow } from '@/main/window'
+import { browserWindowFromEvent } from '@/utils/electron'
+
+import { AppHandler } from './types'
+
+export function initialize() {
+  ipcMain.on(AppHandler.CHANGE_ROUTE, (_, route: string) => {
+    k6StudioState.currentClientRoute = route
+  })
+
+  ipcMain.on(AppHandler.CLOSE, (event) => {
+    console.log(`${AppHandler.CLOSE} event received`)
+
+    k6StudioState.wasAppClosedByClient = true
+    if (k6StudioState.appShuttingDown) {
+      app.quit()
+      return
+    }
+    const browserWindow = browserWindowFromEvent(event)
+    browserWindow.close()
+  })
+
+  ipcMain.on(AppHandler.SPLASHSCREEN_CLOSE, (event) => {
+    console.log(`${AppHandler.SPLASHSCREEN_CLOSE} event received`)
+
+    const browserWindow = browserWindowFromEvent(event)
+
+    if (
+      k6StudioState.splashscreenWindow &&
+      !k6StudioState.splashscreenWindow.isDestroyed()
+    ) {
+      k6StudioState.splashscreenWindow.close()
+      showWindow(browserWindow)
+    }
+  })
+}

--- a/src/handlers/app/preload.ts
+++ b/src/handlers/app/preload.ts
@@ -1,0 +1,23 @@
+import { ipcRenderer } from 'electron'
+
+import { createListener } from '../utils'
+
+import { AppHandler } from './types'
+
+export const platform = process.platform
+
+export function closeSplashscreen() {
+  ipcRenderer.send(AppHandler.SPLASHSCREEN_CLOSE)
+}
+
+export function onApplicationClose(callback: () => void) {
+  return createListener(AppHandler.CLOSE, callback)
+}
+
+export function closeApplication() {
+  ipcRenderer.send(AppHandler.CLOSE)
+}
+
+export function changeRoute(route: string) {
+  return ipcRenderer.send(AppHandler.CHANGE_ROUTE, route)
+}

--- a/src/handlers/app/types.ts
+++ b/src/handlers/app/types.ts
@@ -1,0 +1,5 @@
+export enum AppHandler {
+  CLOSE = 'app:close',
+  CHANGE_ROUTE = 'app:change-route',
+  SPLASHSCREEN_CLOSE = 'splashscreen:close',
+}

--- a/src/handlers/app/types.ts
+++ b/src/handlers/app/types.ts
@@ -1,5 +1,5 @@
 export enum AppHandler {
   CLOSE = 'app:close',
   CHANGE_ROUTE = 'app:change-route',
-  SPLASHSCREEN_CLOSE = 'splashscreen:close',
+  SPLASHSCREEN_CLOSE = 'app:splashscreen-close',
 }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,5 +1,6 @@
 import { BrowserServer } from '@/services/browser/server'
 
+import * as app from './app'
 import * as auth from './auth'
 import * as browser from './browser'
 import * as browserRemote from './browserRemote'
@@ -30,4 +31,5 @@ export function initialize({ browserServer }: Services) {
   generator.initialize()
   dataFiles.initialize()
   log.initialize()
+  app.initialize()
 }

--- a/src/k6StudioState.ts
+++ b/src/k6StudioState.ts
@@ -1,5 +1,6 @@
 import { Process } from '@puppeteer/browsers'
 import { ChildProcessWithoutNullStreams } from 'child_process'
+import { BrowserWindow } from 'electron'
 import eventEmitter from 'events'
 
 import { type ProxyProcess } from './proxy'
@@ -16,6 +17,9 @@ export type k6StudioState = {
   wasProxyStoppedByClient: boolean
   proxyRetryCount: number
   appShuttingDown: boolean
+  currentClientRoute: string
+  wasAppClosedByClient: boolean
+  splashscreenWindow: BrowserWindow | null
 }
 
 export function initialize() {
@@ -33,5 +37,10 @@ export function initialize() {
 
     // Used mainly to avoid starting a new proxy when closing the active one on shutdown
     appShuttingDown: false,
+    // Used to track the current route in the client side
+    currentClientRoute: '/',
+    wasAppClosedByClient: false,
+
+    splashscreenWindow: null,
   }
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,0 +1,31 @@
+import { BrowserWindow } from 'electron'
+import log from 'electron-log/main'
+
+import { saveSettings } from '@/settings'
+
+export function showWindow(browserWindow: BrowserWindow) {
+  const { isMaximized } = k6StudioState.appSettings.windowState
+  if (isMaximized) {
+    browserWindow.maximize()
+  } else {
+    browserWindow.show()
+  }
+  browserWindow.focus()
+}
+
+export async function trackWindowState(browserWindow: BrowserWindow) {
+  const { width, height, x, y } = browserWindow.getBounds()
+  const isMaximized = browserWindow.isMaximized()
+  k6StudioState.appSettings.windowState = {
+    width,
+    height,
+    x,
+    y,
+    isMaximized,
+  }
+  try {
+    await saveSettings(k6StudioState.appSettings)
+  } catch (error) {
+    log.error(error)
+  }
+}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,3 @@
-// TODO: https://github.com/grafana/k6-studio/issues/277
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 import { contextBridge } from 'electron'
 
 import * as app from './handlers/app/preload'

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,7 +1,8 @@
 // TODO: https://github.com/grafana/k6-studio/issues/277
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-import { ipcRenderer, contextBridge } from 'electron'
+import { contextBridge } from 'electron'
 
+import * as app from './handlers/app/preload'
 import * as auth from './handlers/auth/preload'
 import * as browser from './handlers/browser/preload'
 import * as browserRemote from './handlers/browserRemote/preload'
@@ -14,24 +15,7 @@ import * as proxy from './handlers/proxy/preload'
 import * as script from './handlers/script/preload'
 import * as settings from './handlers/settings/preload'
 import * as ui from './handlers/ui/preload'
-import { createListener } from './handlers/utils'
 import * as Sentry from './sentry'
-
-const app = {
-  platform: process.platform,
-  closeSplashscreen: () => {
-    ipcRenderer.send('splashscreen:close')
-  },
-  onApplicationClose: (callback: () => void) => {
-    return createListener('app:close', callback)
-  },
-  closeApplication: () => {
-    ipcRenderer.send('app:close')
-  },
-  changeRoute: (route: string) => {
-    return ipcRenderer.send('app:change-route', route)
-  },
-} as const
 
 const studio = {
   auth,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is the last one from the series "Move handlers out of main.ts" and addresses the `app` handlers and preload functions. With this final change, we no longer have a `main.ts` file with IPC handlers.

One more PR is coming up that moves some files from the root folder to the `./src/main` folder, making the organization a bit clearer.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Check that the splashscreen shows and closes as expected
- Modify a generator and close the app without saving. Check that the app prompts you to save before closing

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
