### PR TITLE
internal(browser): Add beaker icon to Browser Events tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "jsonrepair": "^3.8.0",
         "keyboardjs": "^2.7.0",
         "lodash-es": "^4.17.21",
+        "lucide-react": "^0.503.0",
         "monaco-editor": "^0.50.0",
         "node-forge": "^1.3.1",
         "openid-client": "^6.1.7",
@@ -15445,6 +15446,15 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.503.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.503.0.tgz",
+      "integrity": "sha512-HGGkdlPWQ0vTF8jJ5TdIqhQXZi6uh3LnNgfZ8MHiuxFfX3RZeA79r2MW2tHAZKlAVfoNE8esm3p+O6VkIvpj6w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "jsonrepair": "^3.8.0",
     "keyboardjs": "^2.7.0",
     "lodash-es": "^4.17.21",
+    "lucide-react": "^0.503.0",
     "monaco-editor": "^0.50.0",
     "node-forge": "^1.3.1",
     "openid-client": "^6.1.7",

--- a/src/views/Recorder/RecordingInspector.tsx
+++ b/src/views/Recorder/RecordingInspector.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import { Tabs } from '@radix-ui/themes'
+import { FlaskConical } from 'lucide-react'
 
 import { BrowserEvent } from '@/schemas/recording'
 import { Group, ProxyData } from '@/types'
@@ -50,6 +51,14 @@ export function RecordingInspector({
           Requests ({requests.length})
         </Tabs.Trigger>
         <Tabs.Trigger value="browser-events">
+          <FlaskConical
+            css={css`
+              width: 1em;
+              height: 1em;
+              margin-right: 0.25em;
+            `}
+            strokeWidth={1.5}
+          />{' '}
           Browser events ({browserEvents.length})
         </Tabs.Trigger>
       </Tabs.List>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a beaker icon to the Browser Events tab in the recording views so that it's more obvious that the feature is in public preview.

## How to Test

1. Start a recording.
2. Check that the Browser Events tab has a beaker icon
3. Stop the recording
4. Check that the Browser Events tab still has a beaker icon.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/db720256-b004-4402-97d4-5b6258805d11)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
