### PR TITLE
internal(browser): In-browser UI crashes when entering an invalid selector

### DIFF
--- a/extension/src/frontend/view/RemoteHighlights.hooks.ts
+++ b/extension/src/frontend/view/RemoteHighlights.hooks.ts
@@ -33,18 +33,22 @@ export function useHighlightedElements() {
       return
     }
 
-    const elements = document.querySelectorAll(selector.selector)
-    const highlights = Array.from(elements).map((element) => {
-      const bounds = getElementBounds(element)
+    try {
+      const elements = document.querySelectorAll(selector.selector)
+      const highlights = Array.from(elements).map((element) => {
+        const bounds = getElementBounds(element)
 
-      return {
-        id: idCounter.current++,
-        element,
-        bounds,
-      }
-    })
+        return {
+          id: idCounter.current++,
+          element,
+          bounds,
+        }
+      })
 
-    setHighlights(highlights)
+      setHighlights(highlights)
+    } catch {
+      setHighlights([])
+    }
   }, [selector])
 
   useEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Users can crash the in-browser UI by entering an invalid selector in the text assertions dialog.

## How to Test

1. Start a recording
2. Select the text assertion tool
3. Highlight some text
4. Change the selector to something invalid.

The UI should not crash.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
