### PR TITLE
internal(browser): Styles are not applied to in-browser UI in production

### DIFF
--- a/extension/src/frontend/view/index.tsx
+++ b/extension/src/frontend/view/index.tsx
@@ -89,6 +89,7 @@ function initialize() {
   const shadowCache = createCache({
     key: 'ksix-studio',
     container: root,
+    speedy: false,
   })
 
   createRoot(root).render(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where styles would not be applied to the in-browser UI in production builds.

## How to Test

1. Open `vite.extension.config.mts`
2. Hardcode the `mode` option to be `production`
3. Start the extension (this will start the extension without k6 Studio):
    ```sh
    NODE_ENV=production npm run start:extension
    ```

The in-browser UI should look correct.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
