### PR TITLE
feat: Add support to start proxy with --ssl-insecure flag

### DIFF
--- a/src/components/Settings/ProxySettings.tsx
+++ b/src/components/Settings/ProxySettings.tsx
@@ -98,8 +98,8 @@ export const ProxySettings = () => {
           />
         </Flex>
         <Text size="1" color="gray">
-          Enabling this option introduces vulnerability to TLS interception. Use
-          carefully.
+          Enabling this option leaves connections open to man-in-the-middle
+          (MITM) attacks. Use it carefully.
         </Text>
       </Flex>
     </SettingsSection>

--- a/src/components/Settings/ProxySettings.tsx
+++ b/src/components/Settings/ProxySettings.tsx
@@ -79,6 +79,29 @@ export const ProxySettings = () => {
       </FieldGroup>
 
       {proxy && proxy.mode === 'upstream' && <UpstreamProxySettings />}
+
+      <Flex direction="column" mb="4">
+        <Flex mt="2" mb="1">
+          <Controller
+            control={control}
+            name="proxy.sslInsecure"
+            render={({ field }) => (
+              <Text size="2" as="label">
+                <Checkbox
+                  {...register('proxy.sslInsecure')}
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />{' '}
+                Skip SSL/TLS certificate validation
+              </Text>
+            )}
+          />
+        </Flex>
+        <Text size="1" color="gray">
+          Enabling this option introduces vulnerability to TLS interception. Use
+          carefully.
+        </Text>
+      </Flex>
     </SettingsSection>
   )
 }

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -66,6 +66,10 @@ export const launchProxy = (
     getProxyMode(proxySettings),
   ]
 
+  if (proxySettings.sslInsecure) {
+    proxyArgs.push('--ssl-insecure')
+  }
+
   if (proxySettings.mode === 'upstream' && proxySettings.requiresAuth) {
     const { username, password } = proxySettings
     proxyArgs.push('--upstream-auth', `${username}:${password}`)

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -18,6 +18,7 @@ export const defaultSettings: AppSettings = {
     mode: 'regular',
     port: 6000,
     automaticallyFindPort: true,
+    sslInsecure: false,
   },
   recorder: {
     detectBrowserPath: true,

--- a/src/schemas/settings/index.test.ts
+++ b/src/schemas/settings/index.test.ts
@@ -13,6 +13,7 @@ describe('Settings migration', () => {
         mode: 'regular',
         port: 6000,
         automaticallyFindPort: true,
+        sslInsecure: false,
       },
       recorder: {
         detectBrowserPath: true,
@@ -46,6 +47,7 @@ describe('Settings migration', () => {
         mode: 'regular',
         port: 6000,
         automaticallyFindPort: true,
+        sslInsecure: false,
       },
       recorder: {
         detectBrowserPath: true,

--- a/src/schemas/settings/v1/index.ts
+++ b/src/schemas/settings/v1/index.ts
@@ -10,6 +10,7 @@ export const RegularProxySettingsSchema = z.object({
     .min(1)
     .max(65535, { message: 'Port number must be between 1 and 65535' }),
   automaticallyFindPort: z.boolean(),
+  sslInsecure: z.boolean().default(false),
 })
 
 export const UpstreamProxySettingsSchema = RegularProxySettingsSchema.extend({

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -153,6 +153,7 @@ export function EmptyState({ isLoading, onStart }: EmptyStateProps) {
             <WarningMessage
               proxyStatus={proxyStatus}
               isBrowserInstalled={isBrowserInstalled}
+              isSSLInsecureEnabled={settings?.proxy.sslInsecure}
             />
           </div>
 
@@ -215,11 +216,13 @@ function BrowserEventsSection({ children }: BrowserEventsSectionProps) {
 interface WarningMessageProps {
   proxyStatus: ProxyStatus
   isBrowserInstalled?: boolean
+  isSSLInsecureEnabled?: boolean
 }
 
 function WarningMessage({
   proxyStatus,
   isBrowserInstalled,
+  isSSLInsecureEnabled,
 }: WarningMessageProps) {
   const openSettingsDialog = useStudioUIStore(
     (state) => state.openSettingsDialog
@@ -242,6 +245,26 @@ function WarningMessage({
           the recording functionality to work. If the browser is installed,
           specify the path in{' '}
           <TextButton onClick={() => openSettingsDialog('recorder')}>
+            Settings
+          </TextButton>
+          .
+        </Callout.Text>
+      </Callout.Root>
+    )
+  }
+
+  if (proxyStatus === 'online' && isSSLInsecureEnabled) {
+    return (
+      <Callout.Root>
+        <Callout.Icon>
+          <ExclamationTriangleIcon />
+        </Callout.Icon>
+        <Callout.Text>
+          <strong>SSL/TLS certificate validation will be skipped</strong>
+          <br />
+          Recording with this option enabled introduces vulnerability to TLS
+          interception. Use carefully or disable it in{' '}
+          <TextButton onClick={() => openSettingsDialog('proxy')}>
             Settings
           </TextButton>
           .

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -262,8 +262,8 @@ function WarningMessage({
         <Callout.Text>
           <strong>SSL/TLS certificate validation will be skipped</strong>
           <br />
-          Recording with this option enabled introduces vulnerability to TLS
-          interception. Use carefully or disable it in{' '}
+          Recording with this option enabled introduces vulnerability to
+          man-in-the-middle (MITM) attacks. Use carefully or disable it in{' '}
           <TextButton onClick={() => openSettingsDialog('proxy')}>
             Settings
           </TextButton>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

This PR introduces a new option in the proxy settings that allows users to [bypass SSL verification](https://docs.mitmproxy.org/stable/concepts-options/#ssl_insecure) to test certain environments when required.

A section in the Troubleshoot doc was also added in https://github.com/grafana/k6-docs/pull/1940

## How to Test

- Launch a new instance of mitmproxy:

```sh
mitmdump --mode regular@7005
```

### Sad path:

- Change k6 Studio proxy mode to "upstream" and Server URL to "http://localhost:7005"
- Keep the "Skip SSL/TLS certificate validation" __unchecked__
- Start a new recording
- Check that the browser returns a 502 Certificate verify failed error

### Happy path

- Change k6 Studio proxy mode to "upstream" and Server URL to "http://localhost:7005"
- Check the "Skip SSL/TLS certificate validation" option
- Start a new recording
- Check that the recording works as expected


<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/0c64b212-e44f-4eee-9e3a-5d63d1743c30)

![image](https://github.com/user-attachments/assets/a70df4cb-d87a-49fa-b4a0-1ff35f9c7b30)


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/636

<!-- Thanks for your contribution! 🙏🏼 -->
