### PR TITLE
chore: Preload fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="Content-Security-Policy" content="script-src 'self'" />
+    <link
+      rel="preload"
+      href="/src/assets/fonts/Inter/InterVariable.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin
+    />
     <title>Grafana k6 Studio</title>
   </head>
   <body>


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/643

## How to Test
* Start k6 studio locally and pay close attention to the in-app text
* Verify that the font doesn't switch from a fallback font to Inter

