### PR TITLE
fix: Can't delete file after restoring window on macOS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {
   stopProxyProcess,
 } from './main/proxy'
 import { getSettings, initSettings } from './main/settings'
-import { configureWatcher } from './main/watcher'
+import { closeWatcher, configureWatcher } from './main/watcher'
 import { showWindow, trackWindowState } from './main/window'
 import { BrowserServer } from './services/browser/server'
 import { ProxyStatus } from './types'
@@ -193,10 +193,13 @@ app.whenReady().then(
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
-app.on('window-all-closed', () => {
+app.on('window-all-closed', async () => {
   if (process.platform !== 'darwin') {
     app.quit()
+    return
   }
+
+  await closeWatcher()
 })
 
 app.on('activate', async () => {
@@ -209,10 +212,7 @@ app.on('activate', async () => {
 })
 
 app.on('before-quit', async () => {
-  // stop watching files to avoid crash on exit
   k6StudioState.appShuttingDown = true
-  if (k6StudioState.watcher) {
-    await k6StudioState.watcher.close()
-  }
+  await closeWatcher()
   return stopProxyProcess()
 })

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -40,3 +40,10 @@ export function configureWatcher(browserWindow: BrowserWindow) {
     browserWindow.webContents.send(UIHandler.REMOVE_FILE, file)
   })
 }
+
+export async function closeWatcher() {
+  // stop watching files to avoid crash on exit
+  if (k6StudioState.watcher) {
+    await k6StudioState.watcher.close()
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where an error shows up after restoring the main window from the dock and deleting a file from the sidebar.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- On `main` branch, close the main window on macOS using the X button
- Restore the main window from the dock
- Attempt to delete a file from the sidebar
- A runtime error shows up
- Check that the same behaviour is no longer reproducible in this branch

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):


https://github.com/user-attachments/assets/20db9944-42f5-48b0-b61c-907dd33e4398



## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
