### PR TITLE
feat: Prompt to save recording when closing app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -168,6 +168,13 @@ const createWindow = async () => {
     ) {
       event.preventDefault()
     }
+
+    if (
+      k6StudioState.currentClientRoute.startsWith('/recorder') &&
+      k6StudioState.currentBrowserProcess !== null
+    ) {
+      event.preventDefault()
+    }
   })
 
   return mainWindow


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses an issue where the user can close the main window (or quit the app) while a recording is in progress. This causes the recording to be lost as the validate and save logic isn't triggered upon exiting.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Start a recording
- While the recording is in progress, close the main window
- Check that a prompt to stop the recording was triggered
- Check that the recording is saved after the app is closed

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/667

<!-- Thanks for your contribution! 🙏🏼 -->
