### PR TITLE
fix: Threshold metric for http_req_failed

### DIFF
--- a/src/codegen/options.test.ts
+++ b/src/codegen/options.test.ts
@@ -89,7 +89,7 @@ describe('Code generation - thresholds', () => {
       http_req_failed: [
         {
           abortOnFail: true,
-          threshold: 'rate===100',
+          threshold: 'rate===1',
         },
       ],
     }

--- a/src/codegen/options.ts
+++ b/src/codegen/options.ts
@@ -35,7 +35,7 @@ export function generateThresholds(thresholds: Threshold[]) {
       result[key] = []
     }
 
-    const thresholdValue = `${threshold.statistic}${threshold.condition}${threshold.value}`
+    const thresholdValue = getThresholdValue(threshold)
 
     if (threshold.stopTest) {
       result[key].push({ threshold: thresholdValue, abortOnFail: true })
@@ -65,4 +65,13 @@ export function generateLoadZones(loadZones: LoadZoneData['zones']) {
   })
 
   return result
+}
+
+function getThresholdValue(threshold: Threshold) {
+  let thresholdValue = threshold.value
+  if (threshold.metric === 'http_req_failed') {
+    thresholdValue = threshold.value / 100
+  }
+
+  return `${threshold.statistic}${threshold.condition}${thresholdValue}`
 }

--- a/src/schemas/generator/v2/thresholds.ts
+++ b/src/schemas/generator/v2/thresholds.ts
@@ -36,16 +36,26 @@ export const ThresholdStatisticSchema = z.enum([
   'min',
 ])
 
-export const ThresholdSchema = z.object({
-  id: z.string(),
-  metric: ThresholdMetricSchema,
-  statistic: ThresholdStatisticSchema,
-  condition: ThresholdConditionSchema,
-  value: z
-    .number({ message: 'Invalid value' })
-    .min(0, { message: 'Invalid value' }),
-  stopTest: z.boolean().default(false),
-})
+export const ThresholdSchema = z
+  .object({
+    id: z.string(),
+    metric: ThresholdMetricSchema,
+    statistic: ThresholdStatisticSchema,
+    condition: ThresholdConditionSchema,
+    value: z
+      .number({ message: 'Invalid value' })
+      .min(0, { message: 'Invalid value' }),
+    stopTest: z.boolean().default(false),
+  })
+  .superRefine((data, ctx) => {
+    if (data.metric === 'http_req_failed' && data.value > 100) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Invalid percentage',
+        path: ['value'],
+      })
+    }
+  })
 
 export const ThresholdDataSchema = z.object({
   thresholds: z.array(ThresholdSchema),

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.utils.ts
@@ -22,7 +22,7 @@ const metricsMap: Record<ThresholdMetric, ThresholdMetricMap> = {
   },
   http_req_failed: {
     label: 'Failed requests',
-    unit: '',
+    unit: '%',
     type: 'rate',
   },
   http_req_connecting: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue in codegen that doesn't follow the specification from k6 docs when generating thresholds for `http_req_failed`.

Right now, the percentage value is being treated as inputted, when it should be a [floating point](https://grafana.com/docs/k6/latest/using-k6/thresholds/#thresholds-example-for-http-errors-and-response-duration).

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

- Open the generator
- Set a threshold as `http_req_failed`
- Check that the maximum input value is 100
- Check that the generated value is divided by 100. Example `90%` should generate `0.9`.

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
