### PR TITLE
[WIP] chore: migrate secrets to vault

### DIFF
--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -15,6 +15,7 @@ jobs:
   publish-studio:
     permissions:
       contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -22,6 +23,24 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
+        with:
+          repo_secrets: |
+            ENVVAR2=test-secret:key1
+            # apple
+            APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12
+            CERTIFICATE_PASSWORD=apple-certificates:APPLE_CERTIFICATE_P12_PASSWORD
+
+            # notarization
+            APPLE_API_KEY_ID=apple-certificates:APPLE_API_KEY_ID
+            APPLE_API_ISSUER=apple-certificates:APPLE_API_ISSUER
+            APPLE_API_KEY=apple-certificates:APPLE_API_KEY
+
+            # windows
+            WINDOWS_CERTIFICATE_PATH=windows-certificates:WINDOWS_CERTIFICATE_PATH
+            WINDOWS_CERTIFICATE_PASSWORD=windows-certificates:WINDOWS_CERTIFICATE_PASSWORD
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -56,10 +75,6 @@ jobs:
           security unlock-keychain -p "$CERTIFICATE_PASSWORD" build.keychain
           security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CERTIFICATE_PASSWORD" build.keychain
-        env:
-          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
 
       - name: setup windows certificate
         if: startsWith(matrix.platform, 'windows-')
@@ -74,10 +89,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # notarization
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ./apple_api_key.p8
           # sentry integration
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build
@@ -92,10 +103,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # notarization
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ./apple_api_key.p8
           # sentry integration
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   publish-studio:
     permissions:
       contents: write
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +17,25 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
+        with:
+          repo_secrets: |
+            ENVVAR2=test-secret:key1
+            # apple
+            APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12
+            CERTIFICATE_PASSWORD=apple-certificates:APPLE_CERTIFICATE_P12_PASSWORD
+
+            # notarization
+            APPLE_API_KEY_ID=apple-certificates:APPLE_API_KEY_ID
+            APPLE_API_ISSUER=apple-certificates:APPLE_API_ISSUER
+            APPLE_API_KEY=apple-certificates:APPLE_API_KEY
+
+            # windows
+            WINDOWS_CERTIFICATE_PATH=windows-certificates:WINDOWS_CERTIFICATE_PATH
+            WINDOWS_CERTIFICATE_PASSWORD=windows-certificates:WINDOWS_CERTIFICATE_PASSWORD
+
+
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
@@ -45,10 +65,6 @@ jobs:
           security unlock-keychain -p "$CERTIFICATE_PASSWORD" build.keychain
           security import certificate.p12 -k build.keychain -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$CERTIFICATE_PASSWORD" build.keychain
-        env:
-          APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_P12_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
 
       - name: setup windows certificate
         if: startsWith(matrix.platform, 'windows-')
@@ -63,10 +79,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # notarization
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ./apple_api_key.p8
           # sentry integration
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build
@@ -81,10 +93,6 @@ jobs:
         env:
           NODE_OPTIONS: '--max_old_space_size=8192'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # notarization
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ./apple_api_key.p8
           # sentry integration
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           # sentry vite plugin integration during build


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
Github secrets are getting migrated to `Vault` and this PR address the new way of accessing them.

List of secrets to migrate:
- [x] apple certificates
- [x] windows certificates
- [ ] release-please token
- [ ] sentry token

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
