### PR TITLE
feat: Display Rule preview in Rule editor

### DIFF
--- a/src/views/Generator/RuleEditor/RuleEditor.tsx
+++ b/src/views/Generator/RuleEditor/RuleEditor.tsx
@@ -1,13 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import {
-  Box,
-  Button,
-  Callout,
-  Flex,
-  Heading,
-  ScrollArea,
-} from '@radix-ui/themes'
-import { capitalize, startCase } from 'lodash-es'
+import { Box, Button, Callout, Flex, ScrollArea } from '@radix-ui/themes'
 import { ChevronLeftIcon, InfoIcon } from 'lucide-react'
 import { useCallback, useEffect } from 'react'
 import { FormProvider, useForm, useFormContext } from 'react-hook-form'
@@ -18,6 +10,8 @@ import { TestRule } from '@/types/rules'
 import { exhaustive } from '@/utils/typescript'
 
 import { StickyPanelHeader } from '../TestRuleContainer/StickyPanelHeader'
+import { TestRuleInlineContent } from '../TestRuleContainer/TestRule/TestRuleInlineContent'
+import { TestRuleTypeBadge } from '../TestRuleContainer/TestRule/TestRuleTypeBadge'
 
 import { CorrelationEditor } from './CorrelationEditor'
 import { CustomCodeEditor } from './CustomCodeEditor'
@@ -100,10 +94,7 @@ export function RuleEditor({ rule }: RuleEditorProps) {
     <ScrollArea scrollbars="vertical">
       <FormProvider {...formMethods}>
         <StickyPanelHeader>
-          <Flex align="center" gap="3">
-            <Heading size="2" weight="medium">
-              {capitalize(startCase(rule.type))}
-            </Heading>
+          <Flex align="center" gap="3" maxWidth="100%">
             <Button
               onClick={handleClose}
               variant="ghost"
@@ -113,6 +104,10 @@ export function RuleEditor({ rule }: RuleEditorProps) {
               <ChevronLeftIcon />
               Back
             </Button>
+            <Flex align="center" gap="2" flexGrow="1" minWidth="0">
+              <TestRuleTypeBadge rule={rule} />
+              <TestRuleInlineContent rule={rule} />
+            </Flex>
           </Flex>
         </StickyPanelHeader>
         <form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/606

## Description
Add rule preview to the Rule Editor header to provide the same visual summary of a test rule as shown in the rule list

## How to Test
- Verify that there's no overflow when filters/selectors get too long

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):
#### Before
<img width="829" alt="image" src="https://github.com/user-attachments/assets/be8dfaac-563d-478e-8c9b-182dbe958ff1" />


#### After
<img width="830" alt="image" src="https://github.com/user-attachments/assets/6a4388e7-13da-42c2-b800-fd77b56dffbf" />

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
