### PR TITLE
fix(browser): Extension doesn't load when starting a recording in Chrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "clsx": "^2.1.1",
         "constrained-editor-plugin": "^1.3.0",
         "country-flag-icons": "^1.5.18",
+        "devtools-protocol": "^0.0.1468520",
         "diff": "^7.0.0",
         "electron-log": "^5.2.0",
         "electron-squirrel-startup": "^1.0.1",
@@ -11032,6 +11033,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1468520",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1468520.tgz",
+      "integrity": "sha512-b3LExy6ZymSz0DFKtjncelQfh9sNrnew84q+MvNdRMr9VWHKrqQihrmVTzHotX06A0v94W60iUv909Yg5MCRsw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "clsx": "^2.1.1",
     "constrained-editor-plugin": "^1.3.0",
     "country-flag-icons": "^1.5.18",
+    "devtools-protocol": "^0.0.1468520",
     "diff": "^7.0.0",
     "electron-log": "^5.2.0",
     "electron-squirrel-startup": "^1.0.1",

--- a/src/handlers/browser/index.ts
+++ b/src/handlers/browser/index.ts
@@ -25,22 +25,11 @@ export function initialize(browserServer: BrowserServer) {
     }
   )
 
-  ipcMain.on(BrowserHandler.Stop, async () => {
+  ipcMain.on(BrowserHandler.Stop, () => {
     console.info(`${BrowserHandler.Stop} event received`)
 
-    const { currentBrowserProcess } = k6StudioState
-
-    if (currentBrowserProcess) {
-      // macOS & windows
-      if ('close' in currentBrowserProcess) {
-        await currentBrowserProcess.close()
-        // linux
-      } else {
-        currentBrowserProcess.kill()
-      }
-
-      k6StudioState.currentBrowserProcess = null
-    }
+    k6StudioState.currentBrowserProcess?.kill()
+    k6StudioState.currentBrowserProcess = null
   })
 
   ipcMain.handle(BrowserHandler.OpenExternalLink, (_, url: string) => {

--- a/src/main/k6StudioState.ts
+++ b/src/main/k6StudioState.ts
@@ -1,5 +1,4 @@
-import { Process } from '@puppeteer/browsers'
-import { ChildProcessWithoutNullStreams } from 'child_process'
+import { ChildProcess } from 'child_process'
 import { FSWatcher } from 'chokidar'
 import { BrowserWindow } from 'electron'
 import eventEmitter from 'events'
@@ -11,7 +10,7 @@ import { type ProxyProcess } from './proxy'
 import { defaultSettings } from './settings'
 
 export type k6StudioState = {
-  currentBrowserProcess: Process | ChildProcessWithoutNullStreams | null
+  currentBrowserProcess: ChildProcess | null
   proxyStatus: ProxyStatus
   proxyEmitter: eventEmitter
   appSettings: AppSettings

--- a/src/utils/cdp/client.ts
+++ b/src/utils/cdp/client.ts
@@ -1,0 +1,104 @@
+import { ChildProcess } from 'child_process'
+import { Readable, Writable } from 'stream'
+
+import {
+  ChromeRequest,
+  ChromeRequestMap,
+  ChromeResponse,
+  ChromeResponseSchema,
+} from './types'
+
+export class ChromeDevtoolsClient {
+  static fromChildProcess(process: ChildProcess): ChromeDevtoolsClient {
+    const send = process.stdio[3]
+    const receive = process.stdio[4]
+
+    if (send instanceof Writable === false) {
+      throw new Error(
+        'File descriptor 3 must be writable to send commands over CDP to the browser.'
+      )
+    }
+
+    if (receive instanceof Readable === false) {
+      throw new Error(
+        'File descriptor 4 must be readable to receive responses from CDP in the browser.'
+      )
+    }
+
+    return new ChromeDevtoolsClient(send, receive)
+  }
+
+  #id: number = 0
+
+  #buffer: string = ''
+
+  #send: Writable
+  #receive: Readable
+
+  #pending = new Map<number, PromiseWithResolvers<unknown>>()
+
+  constructor(send: Writable, receive: Readable) {
+    this.#send = send
+    this.#receive = receive
+
+    this.#receive.on('data', (data) => {
+      const string = String(data)
+
+      const [first = '', rest] = string.split('\u0000')
+
+      this.#buffer += first
+
+      if (rest === undefined) {
+        return
+      }
+
+      const response = JSON.parse(this.#buffer) as unknown
+      const parsed = ChromeResponseSchema.safeParse(response)
+
+      this.#buffer = rest
+
+      if (!parsed.success) {
+        console.error(
+          'Failed to parse response from browser:',
+          response,
+          parsed.error
+        )
+
+        return
+      }
+
+      const resolver = this.#pending.get(parsed.data.id)
+
+      if (resolver === undefined) {
+        return
+      }
+
+      if ('error' in parsed.data) {
+        resolver.reject(parsed.data.error)
+
+        return
+      }
+
+      resolver.resolve(parsed.data.result)
+    })
+  }
+
+  call<K extends keyof ChromeRequestMap>(
+    command: ChromeRequest<K>
+  ): Promise<ChromeResponse<K>> {
+    const resolvers = Promise.withResolvers<ChromeResponse<K>>()
+
+    const id = ++this.#id
+
+    this.#pending.set(id, resolvers as PromiseWithResolvers<unknown>)
+
+    const data = JSON.stringify({
+      ...command,
+      id,
+    })
+
+    this.#send.write(data + '\u0000')
+
+    return resolvers.promise
+  }
+}

--- a/src/utils/cdp/types.ts
+++ b/src/utils/cdp/types.ts
@@ -1,0 +1,32 @@
+import { Protocol as CDP } from 'devtools-protocol'
+import { z } from 'zod'
+
+const ChromeResultSchema = z.object({
+  id: z.number(),
+  result: z.record(z.unknown()),
+})
+
+const ChromeErrorSchema = z.object({
+  id: z.number(),
+  error: z.record(z.unknown()),
+})
+
+export const ChromeResponseSchema = z.union([
+  ChromeResultSchema,
+  ChromeErrorSchema,
+])
+
+export interface ChromeRequestMap {
+  'Extensions.loadUnpacked': {
+    request: CDP.Extensions.LoadUnpackedRequest
+    response: CDP.Extensions.LoadUnpackedResponse
+  }
+}
+
+export type ChromeRequest<K extends keyof ChromeRequestMap> = {
+  method: K
+  params: ChromeRequestMap[K]['request']
+}
+
+export type ChromeResponse<K extends keyof ChromeRequestMap> =
+  ChromeRequestMap[K]['response']


### PR DESCRIPTION
## Description

This PR fixes an issue where the browser recorder extension wouldn't load if the user was using Chrome 137+. The reason is that the `--load-extension` used to load the extension has been removed for security reasons.

## How to Test

In both Chrome and Chromium:

1. Start a recording with browser capture enabled.
2. Make sure the in-browser UI is visible.
3. Try to generate some browser events.
4. Check that they appear in k6 Studio
5. Start another recording with browser capture disabled.
6. The in-browser UI should not be shown and no events captured.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
