### PR TITLE
fix: Add support for Chromium path from Flatpak

### DIFF
--- a/src/components/Settings/RecorderSettings.tsx
+++ b/src/components/Settings/RecorderSettings.tsx
@@ -45,6 +45,7 @@ export const RecorderSettings = () => {
       'chromium.exe',
       '/chrome',
       '/chromium',
+      'org.chromium.chromium',
     ]
     return validPaths.some((validPath) => path.includes(validPath))
   }
@@ -80,7 +81,7 @@ export const RecorderSettings = () => {
       {!recorder.detectBrowserPath &&
         recorder.browserPath !== '' &&
         !isValidPath(recorder.browserPath?.toLocaleLowerCase()) && (
-          <Callout.Root color="amber">
+          <Callout.Root color="amber" mb="4">
             <Callout.Icon>
               <AlertTriangleIcon />
             </Callout.Icon>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

When users install Chromium via [Flatpak](https://flatpak.org/) on Linux distros, the installation path is `/var/lib/flatpak/exports/bin/org.chromium.Chromium`, which is detected by k6 Studio as invalid.

This PR whitelists that path, so the error message is no longer displayed.

![image](https://github.com/user-attachments/assets/59952691-3108-42ac-9f74-257cb7ac5450)

## How to Test

- Input `/var/lib/flatpak/exports/bin/org.chromium.Chromium` in the browser recorder path and check that error is no longer displayed
- (optionally) Install Chromium via Flatpak on a Linux distro and check that the browser launches as expected

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves https://github.com/grafana/k6-studio/issues/749

<!-- Thanks for your contribution! 🙏🏼 -->
