### PR TITLE
deps: Replace `papaparse` with `k6/experimental/csv`

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -167,7 +167,8 @@ describe('Code generation', () => {
         import http from 'k6/http'
         import execution from "k6/execution";
         import { SharedArray } from 'k6/data'
-        import Papa from 'https://jslib.k6.io/papaparse/5.1.1/index.js'
+        import csv from "k6/experimental/csv";
+        import fs from "k6/experimental/fs";
         `)
 
       expect(
@@ -210,9 +211,7 @@ describe('Code generation', () => {
 
       const expectedResult = await prettify(`
         const FILES = {
-          users: new SharedArray("users", () => {
-            return Papa.parse(open("../Data/users.csv"), { header: true }).data;
-          }),
+          users: await csv.parse(await fs.open("../Data/users.csv"), { asObjects: true }),
 
           products: new SharedArray("products", () => {
             const data = JSON.parse(open("../Data/products.json"));

--- a/src/constants/imports.ts
+++ b/src/constants/imports.ts
@@ -6,6 +6,8 @@ type K6ExportName =
   | 'k6/encoding'
   | 'k6/data'
   | 'k6/execution'
+  | 'k6/experimental/csv'
+  | 'k6/experimental/fs'
   | 'k6/html'
   | 'k6/http'
   | 'k6/net/grpc'
@@ -43,6 +45,14 @@ export const K6_EXPORTS: Record<K6ExportName, ImportModule> = {
   'k6/execution': {
     path: 'k6/execution',
     default: { name: 'execution' },
+  },
+  'k6/experimental/csv': {
+    path: 'k6/experimental/csv',
+    default: { name: 'csv' },
+  },
+  'k6/experimental/fs': {
+    path: 'k6/experimental/fs',
+    default: { name: 'fs' },
   },
   'k6/html': {
     path: 'k6/html',


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/757

## Description
> [!Note]
> Add this to the release notes as it changes the output of generators that use CSV files.
> Let me know if this should have a different commit prefix

## How to Test
* Remove the local k6 binary in `/resources/../k6` - this is needed, because `install-k6.js` skips the installation step if a k6 binary is already present
* Run `npm i`
* Start the app
* Check that CSV data files work as expected

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
