### PR TITLE
feat: Allow in-browser toolbar to be re-positioned

### DIFF
--- a/extension/src/frontend/view/ToolBox.tsx
+++ b/extension/src/frontend/view/ToolBox.tsx
@@ -1,5 +1,19 @@
+import {
+  DndContext,
+  DragEndEvent,
+  Modifier,
+  MouseSensor,
+  useDraggable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  restrictToHorizontalAxis,
+  restrictToWindowEdges,
+} from '@dnd-kit/modifiers'
 import { css } from '@emotion/react'
 import {
+  GripVerticalIcon,
   PanelRight,
   SquareDashedMousePointerIcon,
   SquareIcon,
@@ -9,7 +23,99 @@ import {
 import { Toolbar } from '@/components/primitives/Toolbar'
 import { Tooltip } from '@/components/primitives/Tooltip'
 
+import { InBrowserSettings, useToolboxSettings } from './settings'
 import { Tool } from './types'
+
+interface ToolBoxRootProps {
+  settings: InBrowserSettings['toolbox']
+  children?: React.ReactNode
+}
+
+function ToolBoxRoot({ settings, children }: ToolBoxRootProps) {
+  const {
+    isDragging,
+    attributes,
+    listeners,
+    transform,
+    setNodeRef,
+    setActivatorNodeRef,
+  } = useDraggable({
+    id: 'toolbox',
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      css={css`
+        position: fixed;
+        top: var(--studio-spacing-2);
+        transform: translateX(-50%);
+        z-index: var(--studio-layer-2);
+
+        display: flex;
+        align-items: stretch;
+
+        color: var(--studio-foreground);
+        background-color: var(--studio-background);
+        box-shadow: var(--studio-shadow-1);
+        border: 1px solid var(--gray-6);
+      `}
+      style={{
+        transform:
+          transform !== null
+            ? `translateX(calc(${transform.x}px - 50%))`
+            : undefined,
+        left: `${settings.position.left}vw`,
+      }}
+    >
+      <div
+        ref={setActivatorNodeRef}
+        css={css`
+          display: flex;
+          align-items: center;
+          color: var(--gray-7);
+          border-right: 1px solid var(--gray-3);
+        `}
+        style={{
+          cursor: isDragging ? 'grabbing' : 'grab',
+        }}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon size={'1.2em'} />
+      </div>
+      <Toolbar.Root
+        css={css`
+          padding: var(--studio-spacing-1);
+        `}
+      >
+        {children}
+      </Toolbar.Root>
+    </div>
+  )
+}
+
+const restrictToolBoxToWindowEdges: Modifier = ({
+  draggingNodeRect,
+  ...rest
+}) => {
+  if (draggingNodeRect === null) {
+    return restrictToWindowEdges({ draggingNodeRect, ...rest })
+  }
+
+  // Since we're using `transform: translateX(-50%)` to center the toolbox,
+  // we need to adjust the left and right edges of the dragging node rect.
+  const halfWidth = draggingNodeRect.width / 2
+
+  return restrictToWindowEdges({
+    ...rest,
+    draggingNodeRect: {
+      ...draggingNodeRect,
+      left: draggingNodeRect.left - halfWidth,
+      right: draggingNodeRect.right - halfWidth,
+    },
+  })
+}
 
 interface ToolBoxProps {
   tool: Tool | null
@@ -26,6 +132,11 @@ export function ToolBox({
   onStopRecording,
   onToggleDrawer,
 }: ToolBoxProps) {
+  const [settings, setSettings] = useToolboxSettings()
+
+  const mouse = useSensor(MouseSensor)
+  const sensors = useSensors(mouse)
+
   const handleToolChange = (value: string) => {
     switch (value) {
       case 'assert-text':
@@ -43,69 +154,75 @@ export function ToolBox({
     onToggleDrawer(values === 'events')
   }
 
+  function handleDragEnd(event: DragEndEvent) {
+    const newLeft =
+      settings.position.left + (event.delta.x / window.innerWidth) * 100 // Convert to vw units
+
+    setSettings({
+      ...settings,
+      position: {
+        ...settings.position,
+        left: newLeft,
+      },
+    })
+  }
+
   return (
-    <Toolbar.Root
-      css={css`
-        position: fixed;
-        top: var(--studio-spacing-2);
-        left: calc(50% - var(--removed-body-scroll-bar-size, 0px) / 2);
-        transform: translateX(-50%);
-        z-index: var(--studio-layer-2);
-        color: var(--studio-foreground);
-        background-color: var(--studio-background);
-        box-shadow: var(--studio-shadow-1);
-        border: 1px solid var(--gray-6);
-        padding: var(--studio-spacing-1);
-      `}
+    <DndContext
+      sensors={sensors}
+      modifiers={[restrictToHorizontalAxis, restrictToolBoxToWindowEdges]}
+      onDragEnd={handleDragEnd}
     >
-      <Tooltip delayDuration={0} asChild content="Stop recording">
-        <Toolbar.Button onClick={onStopRecording}>
-          <SquareIcon />
-        </Toolbar.Button>
-      </Tooltip>
-      <Toolbar.Separator />
-      <Toolbar.ToggleGroup
-        type="single"
-        value={tool ?? ''}
-        onValueChange={handleToolChange}
-      >
-        <Tooltip
-          delayDuration={0}
-          asChild
-          content="Pick an element to add assertions to it"
+      <ToolBoxRoot settings={settings}>
+        <Tooltip delayDuration={0} asChild content="Stop recording">
+          <Toolbar.Button onClick={onStopRecording}>
+            <SquareIcon />
+          </Toolbar.Button>
+        </Tooltip>
+        <Toolbar.Separator />
+        <Toolbar.ToggleGroup
+          type="single"
+          value={tool ?? ''}
+          onValueChange={handleToolChange}
         >
-          <div>
-            <Toolbar.ToggleItem value="inspect">
-              <SquareDashedMousePointerIcon />
-            </Toolbar.ToggleItem>
-          </div>
-        </Tooltip>
-        <Tooltip
-          delayDuration={0}
-          asChild
-          content="Add assertions on text content by selecting it"
+          <Tooltip
+            delayDuration={0}
+            asChild
+            content="Pick an element to add assertions to it"
+          >
+            <div>
+              <Toolbar.ToggleItem value="inspect">
+                <SquareDashedMousePointerIcon />
+              </Toolbar.ToggleItem>
+            </div>
+          </Tooltip>
+          <Tooltip
+            delayDuration={0}
+            asChild
+            content="Add assertions on text content by selecting it"
+          >
+            <div>
+              <Toolbar.ToggleItem value="assert-text">
+                <TextCursorIcon />
+              </Toolbar.ToggleItem>
+            </div>
+          </Tooltip>
+        </Toolbar.ToggleGroup>
+        <Toolbar.Separator />
+        <Toolbar.ToggleGroup
+          type="single"
+          value={isDrawerOpen ? 'events' : ''}
+          onValueChange={handleDrawerToggle}
         >
-          <div>
-            <Toolbar.ToggleItem value="assert-text">
-              <TextCursorIcon />
-            </Toolbar.ToggleItem>
-          </div>
-        </Tooltip>
-      </Toolbar.ToggleGroup>
-      <Toolbar.Separator />
-      <Toolbar.ToggleGroup
-        type="single"
-        value={isDrawerOpen ? 'events' : ''}
-        onValueChange={handleDrawerToggle}
-      >
-        <Tooltip delayDuration={0} asChild content="Toggle event list">
-          <div>
-            <Toolbar.ToggleItem value="events">
-              <PanelRight />
-            </Toolbar.ToggleItem>
-          </div>
-        </Tooltip>
-      </Toolbar.ToggleGroup>
-    </Toolbar.Root>
+          <Tooltip delayDuration={0} asChild content="Toggle event list">
+            <div>
+              <Toolbar.ToggleItem value="events">
+                <PanelRight />
+              </Toolbar.ToggleItem>
+            </div>
+          </Tooltip>
+        </Toolbar.ToggleGroup>
+      </ToolBoxRoot>
+    </DndContext>
   )
 }

--- a/extension/src/frontend/view/ToolBox/ToolBoxRoot.tsx
+++ b/extension/src/frontend/view/ToolBox/ToolBoxRoot.tsx
@@ -1,0 +1,76 @@
+import { useDraggable } from '@dnd-kit/core'
+import { css } from '@emotion/react'
+import { GripVerticalIcon } from 'lucide-react'
+
+import { Toolbar } from '@/components/primitives/Toolbar'
+
+import { InBrowserSettings } from '../settings'
+
+interface ToolBoxRootProps {
+  settings: InBrowserSettings['toolbox']
+  children?: React.ReactNode
+}
+
+export function ToolBoxRoot({ settings, children }: ToolBoxRootProps) {
+  const {
+    isDragging,
+    attributes,
+    listeners,
+    transform,
+    setNodeRef,
+    setActivatorNodeRef,
+  } = useDraggable({
+    id: 'toolbox',
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      css={css`
+        position: fixed;
+        top: var(--studio-spacing-2);
+        transform: translateX(-50%);
+        z-index: var(--studio-layer-2);
+
+        display: flex;
+        align-items: stretch;
+
+        color: var(--studio-foreground);
+        background-color: var(--studio-background);
+        box-shadow: var(--studio-shadow-1);
+        border: 1px solid var(--gray-6);
+      `}
+      style={{
+        transform:
+          transform !== null
+            ? `translateX(calc(${transform.x}px - 50%))`
+            : undefined,
+        left: `${settings.position.left}vw`,
+      }}
+    >
+      <div
+        ref={setActivatorNodeRef}
+        css={css`
+          display: flex;
+          align-items: center;
+          color: var(--gray-7);
+          border-right: 1px solid var(--gray-3);
+        `}
+        style={{
+          cursor: isDragging ? 'grabbing' : 'grab',
+        }}
+        {...attributes}
+        {...listeners}
+      >
+        <GripVerticalIcon size={'1.2em'} />
+      </div>
+      <Toolbar.Root
+        css={css`
+          padding: var(--studio-spacing-1);
+        `}
+      >
+        {children}
+      </Toolbar.Root>
+    </div>
+  )
+}

--- a/extension/src/frontend/view/ToolBox/ToolBoxRoot.tsx
+++ b/extension/src/frontend/view/ToolBox/ToolBoxRoot.tsx
@@ -1,10 +1,11 @@
-import { useDraggable } from '@dnd-kit/core'
+import { useDndMonitor, useDraggable } from '@dnd-kit/core'
 import { css } from '@emotion/react'
 import { GripVerticalIcon } from 'lucide-react'
 
 import { Toolbar } from '@/components/primitives/Toolbar'
 
 import { InBrowserSettings } from '../settings'
+import { useInBrowserUIStore } from '../store'
 
 interface ToolBoxRootProps {
   settings: InBrowserSettings['toolbox']
@@ -21,6 +22,33 @@ export function ToolBoxRoot({ settings, children }: ToolBoxRootProps) {
     setActivatorNodeRef,
   } = useDraggable({
     id: 'toolbox',
+  })
+
+  const blockEventCapture = useInBrowserUIStore(
+    (state) => state.blockEventCapture
+  )
+
+  const unblockEventCapture = useInBrowserUIStore(
+    (state) => state.unblockEventCapture
+  )
+
+  const resetDragging = () => {
+    // Dragging is ended on 'mouseup', so we need to wait a tick to allow
+    // any 'click' events to be processed before unblocking.
+    setTimeout(() => {
+      unblockEventCapture()
+    }, 0)
+  }
+
+  useDndMonitor({
+    onDragStart() {
+      // We need to block event capture while dragging the toolbox, otherwise
+      // click events could be recorded if the user releases the button outside
+      // of the toolbox.
+      blockEventCapture()
+    },
+    onDragCancel: resetDragging,
+    onDragEnd: resetDragging,
   })
 
   return (

--- a/extension/src/frontend/view/ToolBox/ToolBoxTooltip.tsx
+++ b/extension/src/frontend/view/ToolBox/ToolBoxTooltip.tsx
@@ -1,0 +1,25 @@
+import { useDndContext } from '@dnd-kit/core'
+
+import { Tooltip, TooltipProps } from '@/components/primitives/Tooltip'
+
+export function ToolBoxTooltip({
+  children,
+  ...props
+}: Omit<TooltipProps, 'delayDuration' | 'asChild'>) {
+  const context = useDndContext()
+
+  return (
+    <Tooltip {...props} delayDuration={0} asChild>
+      <div
+        style={{
+          // If you drag the toolbox too fast, the mouse cursor might hover a
+          // button. This prevents tooltip and hover effects from being shown
+          // while the toolbox is being dragged.
+          pointerEvents: context.active !== null ? 'none' : undefined,
+        }}
+      >
+        {children}
+      </div>
+    </Tooltip>
+  )
+}

--- a/extension/src/frontend/view/ToolBox/index.tsx
+++ b/extension/src/frontend/view/ToolBox/index.tsx
@@ -3,7 +3,6 @@ import {
   DragEndEvent,
   Modifier,
   MouseSensor,
-  useDraggable,
   useSensor,
   useSensors,
 } from '@dnd-kit/core'
@@ -11,9 +10,7 @@ import {
   restrictToHorizontalAxis,
   restrictToWindowEdges,
 } from '@dnd-kit/modifiers'
-import { css } from '@emotion/react'
 import {
-  GripVerticalIcon,
   PanelRight,
   SquareDashedMousePointerIcon,
   SquareIcon,
@@ -21,79 +18,12 @@ import {
 } from 'lucide-react'
 
 import { Toolbar } from '@/components/primitives/Toolbar'
-import { Tooltip } from '@/components/primitives/Tooltip'
 
-import { InBrowserSettings, useToolboxSettings } from './settings'
-import { Tool } from './types'
+import { useToolboxSettings } from '../settings'
+import { Tool } from '../types'
 
-interface ToolBoxRootProps {
-  settings: InBrowserSettings['toolbox']
-  children?: React.ReactNode
-}
-
-function ToolBoxRoot({ settings, children }: ToolBoxRootProps) {
-  const {
-    isDragging,
-    attributes,
-    listeners,
-    transform,
-    setNodeRef,
-    setActivatorNodeRef,
-  } = useDraggable({
-    id: 'toolbox',
-  })
-
-  return (
-    <div
-      ref={setNodeRef}
-      css={css`
-        position: fixed;
-        top: var(--studio-spacing-2);
-        transform: translateX(-50%);
-        z-index: var(--studio-layer-2);
-
-        display: flex;
-        align-items: stretch;
-
-        color: var(--studio-foreground);
-        background-color: var(--studio-background);
-        box-shadow: var(--studio-shadow-1);
-        border: 1px solid var(--gray-6);
-      `}
-      style={{
-        transform:
-          transform !== null
-            ? `translateX(calc(${transform.x}px - 50%))`
-            : undefined,
-        left: `${settings.position.left}vw`,
-      }}
-    >
-      <div
-        ref={setActivatorNodeRef}
-        css={css`
-          display: flex;
-          align-items: center;
-          color: var(--gray-7);
-          border-right: 1px solid var(--gray-3);
-        `}
-        style={{
-          cursor: isDragging ? 'grabbing' : 'grab',
-        }}
-        {...attributes}
-        {...listeners}
-      >
-        <GripVerticalIcon size={'1.2em'} />
-      </div>
-      <Toolbar.Root
-        css={css`
-          padding: var(--studio-spacing-1);
-        `}
-      >
-        {children}
-      </Toolbar.Root>
-    </div>
-  )
-}
+import { ToolBoxRoot } from './ToolBoxRoot'
+import { ToolBoxTooltip } from './ToolBoxTooltip'
 
 const restrictToolBoxToWindowEdges: Modifier = ({
   draggingNodeRect,
@@ -174,39 +104,27 @@ export function ToolBox({
       onDragEnd={handleDragEnd}
     >
       <ToolBoxRoot settings={settings}>
-        <Tooltip delayDuration={0} asChild content="Stop recording">
+        <ToolBoxTooltip content="Stop recording">
           <Toolbar.Button onClick={onStopRecording}>
             <SquareIcon />
           </Toolbar.Button>
-        </Tooltip>
+        </ToolBoxTooltip>
         <Toolbar.Separator />
         <Toolbar.ToggleGroup
           type="single"
           value={tool ?? ''}
           onValueChange={handleToolChange}
         >
-          <Tooltip
-            delayDuration={0}
-            asChild
-            content="Pick an element to add assertions to it"
-          >
-            <div>
-              <Toolbar.ToggleItem value="inspect">
-                <SquareDashedMousePointerIcon />
-              </Toolbar.ToggleItem>
-            </div>
-          </Tooltip>
-          <Tooltip
-            delayDuration={0}
-            asChild
-            content="Add assertions on text content by selecting it"
-          >
-            <div>
-              <Toolbar.ToggleItem value="assert-text">
-                <TextCursorIcon />
-              </Toolbar.ToggleItem>
-            </div>
-          </Tooltip>
+          <ToolBoxTooltip content="Pick an element to add assertions to it">
+            <Toolbar.ToggleItem value="inspect">
+              <SquareDashedMousePointerIcon />
+            </Toolbar.ToggleItem>
+          </ToolBoxTooltip>
+          <ToolBoxTooltip content="Add assertions on text content by selecting it">
+            <Toolbar.ToggleItem value="assert-text">
+              <TextCursorIcon />
+            </Toolbar.ToggleItem>
+          </ToolBoxTooltip>
         </Toolbar.ToggleGroup>
         <Toolbar.Separator />
         <Toolbar.ToggleGroup
@@ -214,13 +132,11 @@ export function ToolBox({
           value={isDrawerOpen ? 'events' : ''}
           onValueChange={handleDrawerToggle}
         >
-          <Tooltip delayDuration={0} asChild content="Toggle event list">
-            <div>
-              <Toolbar.ToggleItem value="events">
-                <PanelRight />
-              </Toolbar.ToggleItem>
-            </div>
-          </Tooltip>
+          <ToolBoxTooltip content="Toggle event list">
+            <Toolbar.ToggleItem value="events">
+              <PanelRight />
+            </Toolbar.ToggleItem>
+          </ToolBoxTooltip>
         </Toolbar.ToggleGroup>
       </ToolBoxRoot>
     </DndContext>

--- a/extension/src/frontend/view/settings.tsx
+++ b/extension/src/frontend/view/settings.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react'
+import { storage } from 'webextension-polyfill'
+import { z } from 'zod'
+
+const InBrowserSettingsSchema = z.object({
+  toolbox: z.object({
+    position: z.object({
+      left: z.number(),
+    }),
+  }),
+})
+
+export type InBrowserSettings = z.infer<typeof InBrowserSettingsSchema>
+
+const DEFAULT_SETTINGS: InBrowserSettings = {
+  toolbox: {
+    position: {
+      // Position in vw units
+      left: 50,
+    },
+  },
+}
+
+// Load the settings as soon as possible, preferably before the UI mounts
+let storedSettings: InBrowserSettings = DEFAULT_SETTINGS
+
+const loaded = storage.local.get(DEFAULT_SETTINGS).then((result) => {
+  storedSettings =
+    InBrowserSettingsSchema.safeParse(result).data ?? DEFAULT_SETTINGS
+
+  return storedSettings
+})
+
+export function useInBrowserSettings() {
+  const [settings, setSettings] = useState<InBrowserSettings>(storedSettings)
+
+  useEffect(() => {
+    // We sync the settings here just in case the weren't loaded before the UI mounted.
+    loaded.then(setSettings).catch((err) => {
+      console.error('Failed to load in-browser settings', err)
+    })
+  }, [])
+
+  function setSettingsWithSync(
+    newSettings: Partial<InBrowserSettings>,
+    commit = true
+  ) {
+    if (commit) {
+      storage.local.set(newSettings).catch((err) => {
+        console.error('Failed to commit in-browser settings', err)
+      })
+    }
+
+    setSettings((prevSettings) => ({
+      ...prevSettings,
+      ...newSettings,
+    }))
+  }
+
+  return [settings, setSettingsWithSync] as const
+}
+
+export function useToolboxSettings() {
+  const [settings, setSettings] = useInBrowserSettings()
+
+  function setToolboxSettings(
+    settings: InBrowserSettings['toolbox'],
+    commit = true
+  ) {
+    setSettings({ toolbox: settings }, commit)
+  }
+
+  return [settings.toolbox, setToolboxSettings] as const
+}

--- a/extension/src/frontend/view/store.ts
+++ b/extension/src/frontend/view/store.ts
@@ -3,13 +3,19 @@ import { create } from 'zustand'
 import { Tool } from './types'
 
 interface InBrowserUIStore {
+  isCaptureBlocked: boolean
   tool: Tool | null
   selectTool: (tool: Tool | null) => void
+  blockEventCapture: () => void
+  unblockEventCapture: () => void
 }
 
 export const useInBrowserUIStore = create<InBrowserUIStore>((set) => {
   return {
+    isCaptureBlocked: false,
     tool: null,
     selectTool: (tool: Tool | null) => set({ tool }),
+    blockEventCapture: () => set({ isCaptureBlocked: true }),
+    unblockEventCapture: () => set({ isCaptureBlocked: false }),
   }
 })

--- a/extension/src/frontend/view/utils.ts
+++ b/extension/src/frontend/view/utils.ts
@@ -4,7 +4,7 @@ import { Bounds } from './types'
 export function shouldSkipEvent(event: Event): boolean {
   const store = useInBrowserUIStore.getState()
 
-  if (store.tool !== null) {
+  if (store.tool !== null || store.isCaptureBlocked) {
     return true
   }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preinstall": "node install-k6.js",
     "start": "electron-forge start",
     "start:extension": "STANDALONE_EXTENSION=true vite --config vite.extension.config.mts",
+    "watch:extension": "vite --config vite.extension.config.mts",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/src/components/primitives/Toolbar.tsx
+++ b/src/components/primitives/Toolbar.tsx
@@ -1,14 +1,19 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as RadixToolbar from '@radix-ui/react-toolbar'
+import { forwardRef } from 'react'
 
 type RootProps = RadixToolbar.ToolbarProps & {
   size?: '1' | '2'
 }
 
-function Root({ size, ...props }: RootProps) {
+const Root = forwardRef<HTMLDivElement, RootProps>(function Root(
+  { size, ...props },
+  ref
+) {
   return (
     <RadixToolbar.Root
+      ref={ref}
       css={css`
         display: flex;
         gap: var(--studio-spacing-1);
@@ -28,7 +33,7 @@ function Root({ size, ...props }: RootProps) {
       data-size={size}
     />
   )
-}
+})
 
 const Button = styled(RadixToolbar.Button)`
   display: flex;

--- a/src/components/primitives/Tooltip.tsx
+++ b/src/components/primitives/Tooltip.tsx
@@ -40,7 +40,7 @@ const Arrow = styled(RadixTooltip.Arrow)`
   fill: var(--studio-foreground);
 `
 
-interface TooltipProps extends RadixTooltip.TooltipProps {
+export interface TooltipProps extends RadixTooltip.TooltipProps {
   asChild?: boolean
   content: string
   children: ReactNode

--- a/vite.extension.config.mts
+++ b/vite.extension.config.mts
@@ -66,7 +66,7 @@ export default defineConfig((env) => {
                 js: ['extension/src/frontend/index.ts'],
               },
             ],
-            permissions: ['webNavigation'],
+            permissions: ['webNavigation', 'storage'],
           }
         },
       }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Closes https://github.com/grafana/k6-studio/issues/632

## Description

This PR adds the ability to re-position the in-browser toolbar. Users can drag the sidebar sideways to prevent it from covering up parts of the recorded page.

## How to Test

1. Start a recording
2. Re-position the toolbar by using the drag handle
3. Navigate between different pages and sites to make sure that the toolbar stays in position.

https://github.com/user-attachments/assets/344c6c1a-e2e8-4e8f-bdb4-817b52fb76d1

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
