### PR TITLE
internal: Improved tools for developing the browser extension

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -1,4 +1,4 @@
-import { tabs } from 'webextension-polyfill'
+import { runtime, tabs } from 'webextension-polyfill'
 
 import { BrowserEvent } from '@/schemas/recording'
 
@@ -47,6 +47,12 @@ client.on('load-events', () => {
     type: 'events-loaded',
     events: eventLog,
   })
+})
+
+client.on('reload-extension', () => {
+  console.log('reloading extension...')
+
+  runtime.reload()
 })
 
 const logEvent = (event: BrowserExtensionEvent) => {

--- a/extension/src/background/routing.ts
+++ b/extension/src/background/routing.ts
@@ -21,6 +21,7 @@ background.forward('events-loaded', [frontend])
 studio.forward('navigate', [background])
 studio.forward('highlight-elements', [frontend])
 
+frontend.forward('reload-extension', [background])
 frontend.forward('record-events', [background])
 frontend.forward('navigate', [background])
 frontend.forward('load-events', [background])

--- a/extension/src/frontend/routing.ts
+++ b/extension/src/frontend/routing.ts
@@ -12,6 +12,7 @@ frontend.forward('record-events', [background])
 frontend.forward('navigate', [background])
 frontend.forward('load-events', [background])
 frontend.forward('stop-recording', [background])
+frontend.forward('reload-extension', [background])
 
 background.forward('events-recorded', [frontend])
 background.forward('events-loaded', [frontend])

--- a/extension/src/frontend/view/ToolBox/index.tsx
+++ b/extension/src/frontend/view/ToolBox/index.tsx
@@ -10,8 +10,10 @@ import {
   restrictToHorizontalAxis,
   restrictToWindowEdges,
 } from '@dnd-kit/modifiers'
+import { css } from '@emotion/react'
 import {
   PanelRight,
+  RotateCcwIcon,
   SquareDashedMousePointerIcon,
   SquareIcon,
   TextCursorIcon,
@@ -19,6 +21,7 @@ import {
 
 import { Toolbar } from '@/components/primitives/Toolbar'
 
+import { client } from '../../routing'
 import { useToolboxSettings } from '../settings'
 import { Tool } from '../types'
 
@@ -138,6 +141,34 @@ export function ToolBox({
             </Toolbar.ToggleItem>
           </ToolBoxTooltip>
         </Toolbar.ToggleGroup>
+        {
+          // @ts-expect-error we have commonjs set as module option
+          import.meta.env.DEV && (
+            <>
+              <Toolbar.Separator />
+              <ToolBoxTooltip content="Reload extension (dev only)">
+                <Toolbar.Button
+                  onClick={() => {
+                    client.send({
+                      type: 'reload-extension',
+                    })
+
+                    setTimeout(() => {
+                      window.location.reload()
+                    }, 500)
+                  }}
+                >
+                  <RotateCcwIcon
+                    css={css`
+                      stroke-width: 2px !important;
+                      color: var(--red-10);
+                    `}
+                  />
+                </Toolbar.Button>
+              </ToolBoxTooltip>
+            </>
+          )
+        }
       </ToolBoxRoot>
     </DndContext>
   )

--- a/extension/src/messaging/types.ts
+++ b/extension/src/messaging/types.ts
@@ -44,6 +44,10 @@ export const StopRecordingSchema = z.object({
   type: z.literal('stop-recording'),
 })
 
+export const ReloadExtensionSchema = z.object({
+  type: z.literal('reload-extension'),
+})
+
 export const BrowserExtensionMessageSchema = z.discriminatedUnion('type', [
   LoadEventsSchema,
 
@@ -53,6 +57,8 @@ export const BrowserExtensionMessageSchema = z.discriminatedUnion('type', [
   HighlightElementsSchema,
   NavigateSchema,
   StopRecordingSchema,
+
+  ReloadExtensionSchema,
 ])
 
 export type RecordEvents = z.infer<typeof RecordEventsSchema>

--- a/src/handlers/browser/launch.ts
+++ b/src/handlers/browser/launch.ts
@@ -6,7 +6,7 @@ import {
 import { exec, spawn } from 'child_process'
 import { app, BrowserWindow } from 'electron'
 import log from 'electron-log/main'
-import { mkdtemp } from 'fs/promises'
+import { mkdir, mkdtemp, writeFile } from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
@@ -19,8 +19,42 @@ import { getPlatform } from '../../utils/electron'
 
 import { BrowserHandler, LaunchBrowserOptions } from './types'
 
+const CHROME_DEV_PREFERENCES = JSON.stringify({
+  devtools: {
+    preferences: {
+      currentDockState: '"undocked"',
+      'navigator-view-selected-tab': '"navigator-content-scripts"',
+      'panel-selected-tab': '"sources"',
+    },
+    synced_preferences_sync_disabled: {
+      // This allows content scripts to be debugged via DevTools without
+      // having to whitelist them yourself.
+      'skip-content-scripts': 'false',
+    },
+  },
+})
+
 const createUserDataDir = async () => {
-  return mkdtemp(path.join(os.tmpdir(), 'k6-studio-'))
+  const userDataDir = await mkdtemp(path.join(os.tmpdir(), 'k6-studio-'))
+
+  // If we're in development mode, we create a default Chrome profile
+  // with some preferences that make developing the extension easier
+  // (e.g. whitelisting content scripts in the debugger).
+  //
+  // @ts-expect-error - Electron apps are built as CJS.
+  if (import.meta.env.DEV) {
+    try {
+      const defaultProfilePath = path.join(userDataDir, 'Default')
+      const preferencesPath = path.join(defaultProfilePath, 'Preferences')
+
+      await mkdir(defaultProfilePath, { recursive: true })
+      await writeFile(preferencesPath, CHROME_DEV_PREFERENCES, 'utf8')
+    } catch (error) {
+      console.error('Error creating Chrome profile:', error)
+    }
+  }
+
+  return userDataDir
 }
 
 export async function getBrowserPath() {

--- a/vite.extension.config.mts
+++ b/vite.extension.config.mts
@@ -56,6 +56,7 @@ export default defineConfig((env) => {
             name: 'k6 Studio',
             version: version.replace(/-.*/, ''),
             manifest_version: 3,
+
             background: {
               service_worker: 'extension/src/background/index.ts',
             },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds two features that enhances the developer experience while working on the extension:

1. A button to reload the extension has been added to the toolbox. This is required to see the changes in the code and you previously had to go in to the Manage Extensions page, click reload on the extension and then reload the page. The new button does all of that for you.
2. Default settings for Chrome to not ignore content scripts in the debugger.

https://github.com/user-attachments/assets/e64baf21-95ac-46dd-aeff-628b645c4a00

## How to Test

Since Chrome 137+ you need to run an additional command in parallel to `npm start`:

```
npm run watch:extension
```

_(the extension should technically be re-built by electron-forge, but that doesn't seem to be happening for some reason)._

1. Start a recording.
2. Open up DevTools
3. Go to Sources -> Content Scripts
4. You should see the files of the extension and not a message about the script being ignore listed.
5. Make some changes to the code that would visually alter the UI.
6. Click the reload button in the toolbox.
7. Check that the changes are visible.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
