### PR TITLE
feat: Initial navigation event is sometimes not captured when starting a recording

### DIFF
--- a/extension/src/background/navigation.ts
+++ b/extension/src/background/navigation.ts
@@ -1,4 +1,4 @@
-import { WebNavigation, webNavigation } from 'webextension-polyfill'
+import { tabs, WebNavigation, webNavigation } from 'webextension-polyfill'
 
 import { BrowserEvent } from '@/schemas/recording'
 
@@ -90,4 +90,30 @@ export function captureNavigationEvents(
       return
     }
   })
+
+  tabs
+    .query({ active: true, currentWindow: true })
+    .then((tabs) => {
+      for (const tab of tabs) {
+        if (
+          tab.id === undefined ||
+          tab.url === undefined ||
+          tab.url.startsWith('chrome://')
+        ) {
+          continue
+        }
+
+        onCaptured({
+          type: 'navigate-to-page',
+          eventId: crypto.randomUUID(),
+          timestamp: Date.now(),
+          tab: tab.id.toString(),
+          url: tab.url,
+          source: 'address-bar',
+        })
+      }
+    })
+    .catch((error) => {
+      console.error('Error getting active tab:', error)
+    })
 }

--- a/extension/src/messaging/transports/webSocketServer.ts
+++ b/extension/src/messaging/transports/webSocketServer.ts
@@ -3,12 +3,27 @@ import { WebSocketServer } from 'ws'
 import { Transport } from './transport'
 
 export class WebSocketServerTransport extends Transport {
+  static async create(
+    host: string,
+    port: number
+  ): Promise<WebSocketServerTransport> {
+    return new Promise<WebSocketServerTransport>((resolve, reject) => {
+      const server = new WebSocketServer({ host, port })
+
+      server.on('listening', () => {
+        resolve(new WebSocketServerTransport(server))
+      })
+
+      server.on('error', reject)
+    })
+  }
+
   #server: WebSocketServer
 
-  constructor(host: string, port: number) {
+  constructor(server: WebSocketServer) {
     super()
 
-    this.#server = new WebSocketServer({ host, port })
+    this.#server = server
 
     this.#server.on('connection', (socket) => {
       socket.on('message', (data) => {

--- a/src/services/browser/server.ts
+++ b/src/services/browser/server.ts
@@ -16,11 +16,10 @@ type BrowserExtensionServerEvents = {
 export class BrowserServer extends EventEmitter<BrowserExtensionServerEvents> {
   #client: BrowserExtensionClient | null = null
 
-  start(browserWindow: BrowserWindow) {
-    this.#client = new BrowserExtensionClient(
-      'studio-server',
-      new WebSocketServerTransport('localhost', 7554)
-    )
+  async start(browserWindow: BrowserWindow) {
+    const transport = await WebSocketServerTransport.create('localhost', 7554)
+
+    this.#client = new BrowserExtensionClient('studio-server', transport)
 
     this.#client.on('events-recorded', (event) => {
       browserWindow.webContents.send('browser:event', event.data.events)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR attempts to fix an issue where the browser recorder wouldn't capture the initial navigation when starting a recording, resulting in a script that is unusable.

I have been able to reproduce the issue once, but not reliably. The likely culprit is that there is a race condition between the browser loading the page and us injecting the extension over CDP (which is why this issue hasn't appeared before since we previously used the `--load-extension` flag).

## How to Test

I'm not sure. It's (potentially) a race condition so it all comes down to luck.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
