### PR TITLE
chore: Pin get-vault-secrets action to a hash

### DIFF
--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
         with:
           repo_secrets: |
             APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
         with:
           repo_secrets: |
             APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
We are seeing the following error in CI when a PR from a fork is raised:

```
error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release-test-version.yml:27:9
   |
27 |         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/release.yml:21:9
   |
21 |         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.2.0
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

2 findings: 0 unknown, 0 informational, 0 low, 0 medium, 2 high
zizmor-exit-code=14
```

This PR replaces the `get-vault-secrets-v1.2.0` tag with the equivalent hash of that version. This should satisfy zizmor's policy and allow CI checks to pass.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
