### PR TITLE
fix: Modals close when trying to interact with the toolbar

### DIFF
--- a/extension/src/frontend/view/utils.ts
+++ b/extension/src/frontend/view/utils.ts
@@ -1,7 +1,7 @@
 import { useInBrowserUIStore } from './store'
 import { Bounds } from './types'
 
-export function shouldBypassEvent(event: Event): boolean {
+export function isUsingTool(): boolean {
   return (
     event instanceof FocusEvent && useInBrowserUIStore.getState().tool !== null
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes (or at least improves on) an issue where modals and dialogs would be closed whenever the user tried to pick a tool from the toolbar. This meant that it was impossible to inspect and add assertions to content inside modals.

## How to Test

I've tested it in three UI frameworks using their examples in their documentation: Radix UI, Material UI and React Aria.

1. Open a modal
2. Pick a tool from the toolbar
3. Interact with the dialog, e.g. pick an element
4. Try to add an assertion

NOTE: I've noticed an issue with Button-elements in React Aria where picking a Button opens our menu but then immediately closes it. It seems like they are doing something funky because it works fine in Radix UI and Material UI.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`npm run lint`) and all checks pass.
- [X] I have run tests locally (`npm test`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

Resolves #780 

<!-- Thanks for your contribution! 🙏🏼 -->
