### PR TITLE
fix: Use `.fill()` instead of `.type()` when a text input has changed

### DIFF
--- a/src/codegen/browser/__snapshots__/browser/type-text-on-element.ts
+++ b/src/codegen/browser/__snapshots__/browser/type-text-on-element.ts
@@ -14,5 +14,5 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.locator("input").type("Hello, World!");
+  await page.locator("input").fill("Hello, World!");
 }

--- a/src/codegen/browser/code/options.ts
+++ b/src/codegen/browser/code/options.ts
@@ -29,7 +29,7 @@ function isBrowserScenario(scenario: ir.Scenario) {
       case 'NewLocatorExpression':
       case 'ClickExpression':
       case 'ClickOptionsExpression':
-      case 'TypeTextExpression':
+      case 'FillTextExpression':
       case 'CheckExpression':
       case 'SelectOptionsExpression':
         return true

--- a/src/codegen/browser/code/scenario.ts
+++ b/src/codegen/browser/code/scenario.ts
@@ -103,13 +103,13 @@ function emitClickExpression(
 
 function emitTypeTextExpression(
   context: ScenarioContext,
-  expression: ir.TypeTextExpression
+  expression: ir.FillTextExpression
 ): ts.Expression {
   const target = emitExpression(context, expression.target)
   const value = emitExpression(context, expression.value)
 
   return new ExpressionBuilder(target)
-    .member('type')
+    .member('fill')
     .call([value])
     .await(context)
     .done()
@@ -222,7 +222,7 @@ function emitExpression(
     case 'ClickOptionsExpression':
       return emitClickOptionsExpression(context, expression)
 
-    case 'TypeTextExpression':
+    case 'FillTextExpression':
       return emitTypeTextExpression(context, expression)
 
     case 'CheckExpression':

--- a/src/codegen/browser/intermediate/ast.ts
+++ b/src/codegen/browser/intermediate/ast.ts
@@ -35,8 +35,8 @@ export interface ClickOptionsExpression {
   modifiers: Array<'Control' | 'Shift' | 'Alt' | 'Meta'>
 }
 
-export interface TypeTextExpression {
-  type: 'TypeTextExpression'
+export interface FillTextExpression {
+  type: 'FillTextExpression'
   target: Expression
   value: Expression
 }
@@ -93,7 +93,7 @@ export type Expression =
   | ReloadExpression
   | ClickExpression
   | ClickOptionsExpression
-  | TypeTextExpression
+  | FillTextExpression
   | CheckExpression
   | SelectOptionsExpression
   | ExpectExpression

--- a/src/codegen/browser/intermediate/index.ts
+++ b/src/codegen/browser/intermediate/index.ts
@@ -104,7 +104,7 @@ function emitTypeTextNode(context: IntermediateContext, node: m.TypeTextNode) {
   context.emit({
     type: 'ExpressionStatement',
     expression: {
-      type: 'TypeTextExpression',
+      type: 'FillTextExpression',
       target: locator,
       value: {
         type: 'StringLiteral',

--- a/src/codegen/browser/intermediate/variables.ts
+++ b/src/codegen/browser/intermediate/variables.ts
@@ -70,9 +70,9 @@ function substituteExpression(
         locator: substituteExpression(node.locator, substitutions),
       }
 
-    case 'TypeTextExpression':
+    case 'FillTextExpression':
       return {
-        type: 'TypeTextExpression',
+        type: 'FillTextExpression',
         target: substituteExpression(node.target, substitutions),
         value: substituteExpression(node.value, substitutions),
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the method used when filling in an input from `.type()` to the recommended `.fill()` method.

## How to Test

1. Start a recording
2. Type something in an input
3. Stop the recording
4. Export a script
5. Run the script

The script should use `.fill()`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
