### PR TITLE
internal: Unwrap AggregateErrors before logging

### DIFF
--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -9,6 +9,21 @@ import { getPlatform } from '../utils/electron'
 
 let watcher: FSWatcher
 
+/**
+ * Recursively unwraps an AggregateError into its constituent errors. A new line
+ * will be added between each error for better readability in the logs.
+ */
+function unwrapAggregateError(error: unknown): unknown[] {
+  if (error instanceof AggregateError) {
+    return [
+      error,
+      ...error.errors.flatMap((err) => ['\n', ...unwrapAggregateError(err)]),
+    ]
+  }
+
+  return [error]
+}
+
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
   // https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
@@ -23,9 +38,21 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
+
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'
   }
+
+  log.hooks.push((msg) => {
+    // If data contains an AggregateError, then we want to know what each individual
+    // error inside it is.
+    const data = msg.data.flatMap<unknown>(unwrapAggregateError)
+
+    return {
+      ...msg,
+      data,
+    }
+  })
 
   // initialize chokidar watcher to watch log file
   watcher = watch(log.transports.file.getFile().path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the logging so that `AggregateError`s are unwrapped. Unwrapping the errors gives us more insight into the actual cause of an error.

## How to Test

Modify the code to throw an AggregateError somewhere where it will be logged. The log should be a list of errors, with the `AggregateError` followed by all of its wrapped errors. It should work recursively so any nested `AggregateError`s should also be unwrapped.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
