### PR TITLE
feat: Improved error handling when starting a recording

### DIFF
--- a/extension/src/messaging/transports/webSocketServer.ts
+++ b/extension/src/messaging/transports/webSocketServer.ts
@@ -2,6 +2,14 @@ import { WebSocketServer } from 'ws'
 
 import { Transport } from './transport'
 
+export class WebSocketServerError extends AggregateError {
+  constructor(errors: unknown[]) {
+    super(errors, 'WebSocket server transport error')
+
+    this.name = 'WebSocketServerError'
+  }
+}
+
 export class WebSocketServerTransport extends Transport {
   static async create(
     host: string,
@@ -14,7 +22,9 @@ export class WebSocketServerTransport extends Transport {
         resolve(new WebSocketServerTransport(server))
       })
 
-      server.on('error', reject)
+      server.on('error', (err) => {
+        reject(new WebSocketServerError([err]))
+      })
     })
   }
 

--- a/src/handlers/browser/launch.ts
+++ b/src/handlers/browser/launch.ts
@@ -127,7 +127,10 @@ export const launchBrowser = async (
   const handleBrowserLaunchError = (error: Error) => {
     log.error(error)
     browserServer.stop()
-    browserWindow.webContents.send(BrowserHandler.Error, 'browser-launch')
+    browserWindow.webContents.send(BrowserHandler.Error, {
+      reason: 'browser-launch',
+      fatal: true,
+    })
   }
 
   const browserRecordingArgs = capture.browser ? BROWSER_RECORDING_ARGS : []

--- a/src/handlers/browser/launch.ts
+++ b/src/handlers/browser/launch.ts
@@ -127,7 +127,7 @@ export const launchBrowser = async (
   const handleBrowserLaunchError = (error: Error) => {
     log.error(error)
     browserServer.stop()
-    browserWindow.webContents.send(BrowserHandler.Failed, 'browser-launch')
+    browserWindow.webContents.send(BrowserHandler.Error, 'browser-launch')
   }
 
   const browserRecordingArgs = capture.browser ? BROWSER_RECORDING_ARGS : []
@@ -182,6 +182,11 @@ export const launchBrowser = async (
       } catch (error) {
         // If we fail to load the extension, we'll log the error and continue without it.
         log.error('Failed to start browser recording: ', error)
+
+        browserWindow.webContents.send(BrowserHandler.Error, {
+          reason: 'extension-load',
+          fatal: false,
+        })
       }
 
       process.once('exit', handleBrowserClose)
@@ -192,12 +197,13 @@ export const launchBrowser = async (
 
       browserServer.stop()
 
-      browserWindow.webContents.send(
-        BrowserHandler.Failed,
-        error instanceof WebSocketServerError
-          ? 'websocket-server-error'
-          : 'browser-launch'
-      )
+      browserWindow.webContents.send(BrowserHandler.Error, {
+        fatal: true,
+        reason:
+          error instanceof WebSocketServerError
+            ? 'websocket-server-error'
+            : 'browser-launch',
+      })
 
       return null
     }

--- a/src/handlers/browser/preload.ts
+++ b/src/handlers/browser/preload.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from 'electron'
 
-import { LaunchBrowserOptions, BrowserHandler } from '@/handlers/browser/types'
+import {
+  LaunchBrowserOptions,
+  BrowserHandler,
+  LaunchBrowserFailedReason,
+} from '@/handlers/browser/types'
 import { BrowserEvent } from '@/schemas/recording'
 
 import { createListener } from '../utils'
@@ -17,7 +21,9 @@ export function onBrowserClosed(callback: () => void) {
   return createListener(BrowserHandler.Closed, callback)
 }
 
-export function onBrowserLaunchFailed(callback: () => void) {
+export function onBrowserLaunchFailed(
+  callback: (reason: LaunchBrowserFailedReason) => void
+) {
   return createListener(BrowserHandler.Failed, callback)
 }
 

--- a/src/handlers/browser/preload.ts
+++ b/src/handlers/browser/preload.ts
@@ -3,7 +3,7 @@ import { ipcRenderer } from 'electron'
 import {
   LaunchBrowserOptions,
   BrowserHandler,
-  LaunchBrowserFailedReason,
+  LaunchBrowserError,
 } from '@/handlers/browser/types'
 import { BrowserEvent } from '@/schemas/recording'
 
@@ -21,10 +21,10 @@ export function onBrowserClosed(callback: () => void) {
   return createListener(BrowserHandler.Closed, callback)
 }
 
-export function onBrowserLaunchFailed(
-  callback: (reason: LaunchBrowserFailedReason) => void
+export function onBrowserLaunchError(
+  callback: (reason: LaunchBrowserError) => void
 ) {
-  return createListener(BrowserHandler.Failed, callback)
+  return createListener(BrowserHandler.Error, callback)
 }
 
 export function openExternalLink(url: string) {

--- a/src/handlers/browser/types.ts
+++ b/src/handlers/browser/types.ts
@@ -13,3 +13,7 @@ export interface LaunchBrowserOptions {
     browser: boolean
   }
 }
+
+export type LaunchBrowserFailedReason =
+  | 'websocket-server-error'
+  | 'browser-launch'

--- a/src/handlers/browser/types.ts
+++ b/src/handlers/browser/types.ts
@@ -2,7 +2,7 @@ export enum BrowserHandler {
   Start = 'browser:start',
   Stop = 'browser:stop',
   Closed = 'browser:closed',
-  Failed = 'browser:failed',
+  Error = 'browser:error',
   OpenExternalLink = 'browser:open:external:link',
   BrowserEvent = 'browser:event',
 }
@@ -14,6 +14,12 @@ export interface LaunchBrowserOptions {
   }
 }
 
-export type LaunchBrowserFailedReason =
+export type LaunchBrowserErrorReason =
   | 'websocket-server-error'
+  | 'extension-load'
   | 'browser-launch'
+
+export interface LaunchBrowserError {
+  fatal: boolean
+  reason: LaunchBrowserErrorReason
+}

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -9,6 +9,21 @@ import { getPlatform } from '../utils/electron'
 
 let watcher: FSWatcher
 
+/**
+ * Recursively unwraps an AggregateError into its constituent errors. A new line
+ * will be added between each error for better readability in the logs.
+ */
+function unwrapAggregateError(error: unknown): unknown[] {
+  if (error instanceof AggregateError) {
+    return [
+      error,
+      ...error.errors.flatMap((err) => ['\n', ...unwrapAggregateError(err)]),
+    ]
+  }
+
+  return [error]
+}
+
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
   // https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
@@ -23,9 +38,21 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
+
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'
   }
+
+  log.hooks.push((msg) => {
+    // If data contains an AggregateError, then we want to know what each individual
+    // error inside it is.
+    const data = msg.data.flatMap<unknown>(unwrapAggregateError)
+
+    return {
+      ...msg,
+      data,
+    }
+  })
 
   // initialize chokidar watcher to watch log file
   watcher = watch(log.transports.file.getFile().path)

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -9,21 +9,6 @@ import { getPlatform } from '../utils/electron'
 
 let watcher: FSWatcher
 
-/**
- * Recursively unwraps an AggregateError into its constituent errors. A new line
- * will be added between each error for better readability in the logs.
- */
-function unwrapAggregateError(error: unknown): unknown[] {
-  if (error instanceof AggregateError) {
-    return [
-      error,
-      ...error.errors.flatMap((err) => ['\n', ...unwrapAggregateError(err)]),
-    ]
-  }
-
-  return [error]
-}
-
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
   // https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
@@ -38,21 +23,9 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
-
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'
   }
-
-  log.hooks.push((msg) => {
-    // If data contains an AggregateError, then we want to know what each individual
-    // error inside it is.
-    const data = msg.data.flatMap<unknown>(unwrapAggregateError)
-
-    return {
-      ...msg,
-      data,
-    }
-  })
 
   // initialize chokidar watcher to watch log file
   watcher = watch(log.transports.file.getFile().path)

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -225,6 +225,7 @@ export function Recorder() {
 
         default:
           exhaustive(error.reason)
+          break
       }
     })
   }, [openSettingsDialog, showToast])

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -224,7 +224,7 @@ export function Recorder() {
           break
 
         default:
-          return exhaustive(error.reason)
+          exhaustive(error.reason)
       }
     })
   }, [openSettingsDialog, showToast])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR improves the error handling when starting a recording fails because of an error with the browser recording, showing more specific error messages to the user.

## How to Test

- Modify `WebSocketServer.create` to throw a `WebSocketServerError` and start recording
  - A new toast should be shown saying that it failed to initialize browser recording
  - The recording should not start
- Modify `launchBrowser` to throw an Error inside the `try` before loading the extension
  - A new toast should be shown saying that the extension couldn't load
  - The recording should still start
- Modify `launchBrowser` to throw an Error before launching the browser
  - The old toast should be shown
  - The recording should not start 

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
