### PR TITLE
internal(fix): Infinite loop when recording clicks

### DIFF
--- a/extension/src/utils/dom.ts
+++ b/extension/src/utils/dom.ts
@@ -25,40 +25,36 @@ const SIMPLE_CLICK_WIDGET_ROLES = [
 export function findInteractiveElement(element: Element): Element | null {
   let current: Element | null = element
 
-  while (element !== null) {
+  while (current !== null) {
     // https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#interactive_content
     if (
-      element instanceof HTMLButtonElement ||
-      element instanceof HTMLLabelElement ||
-      element instanceof HTMLTextAreaElement ||
-      element instanceof HTMLSelectElement
+      current instanceof HTMLButtonElement ||
+      current instanceof HTMLLabelElement ||
+      current instanceof HTMLTextAreaElement ||
+      current instanceof HTMLSelectElement
     ) {
-      return element
+      return current
     }
 
-    if (element instanceof HTMLAnchorElement && element.hasAttribute('href')) {
-      return element
+    if (current instanceof HTMLAnchorElement && current.hasAttribute('href')) {
+      return current
     }
 
-    if (element instanceof HTMLImageElement && element.hasAttribute('usemap')) {
-      return element
+    if (current instanceof HTMLImageElement && current.hasAttribute('usemap')) {
+      return current
     }
 
-    if (element instanceof HTMLInputElement && element.type !== 'hidden') {
-      return element
+    if (current instanceof HTMLInputElement && current.type !== 'hidden') {
+      return current
     }
 
-    const role = element.getAttribute('role')
+    const role = current.getAttribute('role')
 
     if (role !== null && SIMPLE_CLICK_WIDGET_ROLES.includes(role)) {
-      return element
+      return current
     }
 
-    if (element.parentElement === null) {
-      return null
-    }
-
-    current = element.parentElement
+    current = current.parentElement
   }
 
   return current


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a regression introduced in a previous PR. Due to some bad coding, courtesy of yours truly, clicking anything would create an infinite loop basically locking the page.

## How to Test

Start a recording. You should be able to click around in pages.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
