### PR TITLE
fix: Clicking the label of a checkbox/radio records two events

### DIFF
--- a/extension/src/frontend/index.ts
+++ b/extension/src/frontend/index.ts
@@ -3,10 +3,16 @@ import './view'
 import { BrowserEvent } from '@/schemas/recording'
 
 import { generateSelector } from '../selectors'
-import { findInteractiveElement } from '../utils/dom'
+import {
+  findAssociatedElement,
+  findInteractiveElement,
+  isNativeButton,
+  isNativeCheckbox,
+  isNativeRadio,
+} from '../utils/dom'
 
+import { WindowEventManager } from './manager'
 import { client } from './routing'
-import { shouldSkipEvent } from './view/utils'
 
 function getButton(button: number) {
   switch (button) {
@@ -31,66 +37,90 @@ function recordEvents(events: BrowserEvent[] | BrowserEvent) {
   })
 }
 
-window.addEventListener(
-  'click',
-  (ev) => {
-    if (shouldSkipEvent(ev)) {
-      return
-    }
+const manager = new WindowEventManager()
 
-    if (ev.target instanceof Element === false) {
-      return
-    }
+manager.capture('click', (ev, manager) => {
+  if (ev.target instanceof Element === false) {
+    return
+  }
 
-    // From the user's point of view, they clicked a button and not a `<span />` inside a
-    // button. So whenever we record a click we try to find the underlying interactive
-    // element. Only if there's no such element do we record a click on the actual
-    // target.
-    //
-    // In the future, we might want to have this behavior configurable:
-    //
-    // - Ignore any click on non-interactive elements
-    // - Record click on the interactive element with fallback (current behavior).
-    // - Record all clicks exactly as they happened.
-    //
-    // The first option would be especially useful since it can reduce noise
-    // in the recordings.
-    const clickTarget = findInteractiveElement(ev.target) ?? ev.target
+  // From the user's point of view, they clicked a button and not a `<span />` inside a
+  // button. So whenever we record a click we try to find the underlying interactive
+  // element. Only if there's no such element do we record a click on the actual
+  // target.
+  //
+  // In the future, we might want to have this behavior configurable:
+  //
+  // - Ignore any click on non-interactive elements
+  // - Record click on the interactive element with fallback (current behavior).
+  // - Record all clicks exactly as they happened.
+  //
+  // The first option would be especially useful since it can reduce noise
+  // in the recordings.
+  const clickTarget = findInteractiveElement(ev.target) ?? ev.target
 
-    // We don't want to capture clicks on form elements since they will be
-    // interacted with using e.g. the `selectOption` or `type` functions.
+  // We don't want to capture clicks on form elements since they will be
+  // interacted with using e.g. the `selectOption` or `type` functions.
+  if (
+    clickTarget instanceof HTMLInputElement ||
+    clickTarget instanceof HTMLTextAreaElement ||
+    clickTarget instanceof HTMLSelectElement ||
+    clickTarget instanceof HTMLOptionElement
+  ) {
+    return
+  }
+
+  const associatedElement = findAssociatedElement(clickTarget)
+
+  if (associatedElement !== null) {
+    // When you click on a label that is associated with a checkbox or radio,
+    // the checkbox/radio will be toggled as a side-effect. This would normally
+    // be recorded as a 'change' event.
+    //
+    // The problem is that it is a common pattern to hide the actual input element
+    // and use a label as the trigger for a custom styled checkboxes/radios. This
+    // doesn't play well with k6/browser, because it relies on clicks to simulate
+    // checking/unchecking and if the input is obscured in some way, it will fail
+    // to click it.
+    //
+    // So in this case, recording the click on the label is the most
+    // reliable way to ensure that the action can be replayed.
     if (
-      clickTarget instanceof HTMLInputElement ||
-      clickTarget instanceof HTMLTextAreaElement ||
-      clickTarget instanceof HTMLSelectElement ||
-      clickTarget instanceof HTMLOptionElement
+      isNativeCheckbox(associatedElement) ||
+      isNativeRadio(associatedElement)
     ) {
-      return
+      manager.block('change', associatedElement)
     }
 
-    const button = getButton(ev.button)
-
-    if (button === null) {
-      return
+    // If a label is associated with a button, clicking the label will
+    // trigger a simulated click on the button. To avoid recording duplicate
+    // clicks, we block that second click event on the button.
+    if (isNativeButton(associatedElement)) {
+      manager.block('click', associatedElement)
     }
+  }
 
-    recordEvents({
-      type: 'click',
-      eventId: crypto.randomUUID(),
-      timestamp: Date.now(),
-      selector: generateSelector(clickTarget),
-      button,
-      modifiers: {
-        ctrl: ev.ctrlKey,
-        shift: ev.shiftKey,
-        alt: ev.altKey,
-        meta: ev.metaKey,
-      },
-      tab: '',
-    })
-  },
-  { capture: true, passive: true }
-)
+  const button = getButton(ev.button)
+
+  if (button === null) {
+    return
+  }
+
+  recordEvents({
+    type: 'click',
+    eventId: crypto.randomUUID(),
+    timestamp: Date.now(),
+    selector: generateSelector(clickTarget),
+    button,
+    modifiers: {
+      ctrl: ev.ctrlKey,
+      shift: ev.shiftKey,
+      alt: ev.altKey,
+      meta: ev.metaKey,
+    },
+    tab: '',
+  })
+})
 
 function handleSelectChange(target: HTMLSelectElement) {
   recordEvents({
@@ -169,39 +199,27 @@ function handleInputChange(target: HTMLInputElement) {
   })
 }
 
-window.addEventListener(
-  'change',
-  (ev) => {
-    if (shouldSkipEvent(ev)) {
-      return
-    }
+manager.capture('change', (ev) => {
+  if (ev.target instanceof HTMLTextAreaElement) {
+    handleTextAreaChange(ev.target)
 
-    if (ev.target instanceof HTMLTextAreaElement) {
-      handleTextAreaChange(ev.target)
-
-      return
-    }
-
-    if (ev.target instanceof HTMLSelectElement) {
-      handleSelectChange(ev.target)
-
-      return
-    }
-
-    if (ev.target instanceof HTMLInputElement) {
-      handleInputChange(ev.target)
-
-      return
-    }
-  },
-  { capture: true, passive: true }
-)
-
-window.addEventListener('submit', (ev) => {
-  if (shouldSkipEvent(ev)) {
     return
   }
 
+  if (ev.target instanceof HTMLSelectElement) {
+    handleSelectChange(ev.target)
+
+    return
+  }
+
+  if (ev.target instanceof HTMLInputElement) {
+    handleInputChange(ev.target)
+
+    return
+  }
+})
+
+manager.capture('submit', (ev) => {
   if (ev.target instanceof Element === false) {
     return
   }

--- a/extension/src/frontend/manager.ts
+++ b/extension/src/frontend/manager.ts
@@ -68,6 +68,15 @@ export class WindowEventManager {
       return false
     }
 
-    return this.#blockedEvents[ev.type]?.delete(ev.target) ?? false
+    const blockedForType = this.#blockedEvents[ev.type]
+
+    if (blockedForType === undefined) {
+      return false
+    }
+
+    // We only want to block the first occurence of the event for the target
+    // and `delete` will return `true` if the target was present in the set
+    // and therefore blocked.
+    return blockedForType.delete(ev.target)
   }
 }

--- a/extension/src/frontend/manager.ts
+++ b/extension/src/frontend/manager.ts
@@ -1,0 +1,73 @@
+import { shouldSkipEvent } from './view/utils'
+
+type EventBlockerMap = Record<string, WeakSet<EventTarget>>
+
+/**
+ * Since we can't use `preventDefault`, `stopPropagation` or similar methods without
+ * affecting the actual page, we need a way to block events that are side-effects of
+ * other events. This manager adds logic on top of `addEventListener` that allows
+ * blocking the next event of a given type on a given target.
+ */
+export class WindowEventManager {
+  #blockedEvents: EventBlockerMap = {}
+
+  /**
+   * Blocks the next event of the given type on the given target. This is useful to
+   * avoid recording follow-up events that are triggered as a side-effect of the
+   * original event.
+   */
+  block<T extends keyof WindowEventMap>(type: T, target: EventTarget): this {
+    let blockedForType = this.#blockedEvents[type]
+
+    if (blockedForType === undefined) {
+      blockedForType = new WeakSet()
+
+      this.#blockedEvents[type] = blockedForType
+    }
+
+    blockedForType.add(target)
+
+    // Queue cleanup of the blocked target for the next event loop iteration. If we
+    // don't do this, we might end up blocking an event we actually want to capture.
+    //
+    // For example, imagine a user clicking a label that is associated with a checkbox.
+    // This would trigger a follow-up `click` event on the checkbox which we don't want
+    // to record. However, if the recorded page calls `preventDefault` on the original
+    // click event, the follow-up click on the checkbox will never happen. So the block
+    // would never be removed and we would end up blocking the next legitimate click.
+    setTimeout(() => {
+      blockedForType.delete(target)
+    }, 1)
+
+    return this
+  }
+
+  capture<K extends keyof WindowEventMap>(
+    type: K,
+    listener: (ev: WindowEventMap[K], manager: WindowEventManager) => void
+  ) {
+    window.addEventListener(
+      type,
+      (ev) => {
+        if (shouldSkipEvent(ev)) {
+          return
+        }
+
+        if (this.#isBlocked(ev)) {
+          return
+        }
+
+        listener(ev, this)
+      },
+      { capture: true }
+    )
+  }
+
+  #isBlocked(ev: Event) {
+    if (ev.target === null) {
+      return false
+    }
+
+    return this.#blockedEvents[ev.type]?.delete(ev.target) ?? false
+  }
+}

--- a/extension/src/frontend/view/ElementInspector/ElementMenu.utils.ts
+++ b/extension/src/frontend/view/ElementInspector/ElementMenu.utils.ts
@@ -1,42 +1,10 @@
 import { ElementSelector } from '@/schemas/recording'
 import { generateSelector } from 'extension/src/selectors'
 import { ElementRole, getElementRoles } from 'extension/src/utils/aria'
+import { findAssociatedElement } from 'extension/src/utils/dom'
 
 import { TrackedElement } from './ElementInspector.hooks'
 import { CheckAssertionData } from './assertions/types'
-
-function findByForAttribute(target: HTMLLabelElement) {
-  const forAttribute = target.getAttribute('for')
-
-  if (forAttribute === null) {
-    return null
-  }
-
-  return document.getElementById(forAttribute)
-}
-
-const CHILD_INPUT_SELECTOR = [
-  // Hidden inputs are not labelable per the HTML specification
-  'input:not([type="hidden"])',
-  'select',
-  'textarea',
-  '[role="checkbox"]',
-  '[role="radio"]',
-].join(', ')
-
-function findInChildren(target: HTMLLabelElement) {
-  // According to the HTML specification, the labelled element is the first one
-  // in "tree order" which is the same order that `querySelector` searches in.
-  return target.querySelector(CHILD_INPUT_SELECTOR)
-}
-
-function findByLabelledBy(target: HTMLLabelElement) {
-  if (target.id === '') {
-    return null
-  }
-
-  return target.querySelector(`[aria-labelledby="${target.id}"]`)
-}
 
 function* getAncestors(element: Element) {
   let currentElement: Element | null = element
@@ -80,10 +48,7 @@ export function findAssociatedControl({
     return null
   }
 
-  const associatedElement =
-    findByForAttribute(label) ??
-    findInChildren(label) ??
-    findByLabelledBy(label)
+  const associatedElement = findAssociatedElement(label)
 
   if (associatedElement === null) {
     return null


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes some issues with clicking on labels:

1. If the label is associated with a checkbox/radio, both a click and check event would be recorded
2. If the label is associated with a button, two click events would be recorded (one for the label and one for the button)

This caused issues especially for checkboxes, because the duplicated events would toggle the checkbox on and off again, which is not what really happened in the browser.

## How to Test

1. Find a checkbox with a label (quickpizza has one, radix-ui has another)
2. Click the label
3. Check that a single click event was recorded.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6-studio/issues/790

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
