### PR TITLE
fix: Navigation events are captures while typing in address bar

### DIFF
--- a/extension/src/background/navigation.ts
+++ b/extension/src/background/navigation.ts
@@ -9,14 +9,7 @@ function isReload({ transitionType }: WebNavigation.OnCommittedDetailsType) {
 function isAddressBarNavigation({
   transitionType,
 }: WebNavigation.OnCommittedDetailsType) {
-  return (
-    transitionType === 'typed' ||
-    transitionType === 'generated' ||
-    transitionType === 'start_page' ||
-    transitionType === 'auto_bookmark' ||
-    transitionType === 'keyword' ||
-    transitionType === 'keyword_generated'
-  )
+  return transitionType === 'typed' || transitionType === 'start_page'
 }
 
 function isHistoryNavigation({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where navigation events would be recorded for suggestions while typing in the address bar.

## How to Test

1. Start a recording
2. Go to various domains by typing them in the address bar

There should be no extra navigation events to e.g. google.com

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

Resolves https://github.com/grafana/k6-studio/issues/687

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
