### PR TITLE
fix: App crashing when pasting into custom code editor

### DIFF
--- a/src/components/Monaco/ConstrainerCodeEditor.tsx
+++ b/src/components/Monaco/ConstrainerCodeEditor.tsx
@@ -30,6 +30,10 @@ export function ConstrainedCodeEditor({
     if (!model || !constrainedInstance) {
       return
     }
+    // Synchronize the editor model's content before re-applying constraints
+    if (value !== model.getValue()) {
+      model.setValue(value)
+    }
 
     // Add editable range to editor
     const constrainedModel = constrainedInstance.addRestrictionsTo(model, [
@@ -48,7 +52,7 @@ export function ConstrainedCodeEditor({
 
     // Cleanup
     return constrainedModel.disposeRestrictions
-  }, [model, constrainedInstance, editableRange, onChange])
+  }, [model, constrainedInstance, editableRange, onChange, value])
 
   const handleEditorMount = (
     editor: monacoTypes.editor.IStandaloneCodeEditor,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug when pasting code in custom code parameterization rule crashed the app.

## How to Test

1. Create a parameterization rule, select replace with -> custom code
2. Paste multi-line text into the editor
3. Verify app doesn't crash, text is pasted and function declaration is non-removable

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->
Resolves https://github.com/grafana/k6-studio/issues/792

<!-- Thanks for your contribution! 🙏🏼 -->
