### PR TITLE
feat: Capture network traffic when running browser scripts

### DIFF
--- a/src/handlers/browser/launch.ts
+++ b/src/handlers/browser/launch.ts
@@ -11,7 +11,7 @@ import os from 'os'
 import path from 'path'
 import { promisify } from 'util'
 
-import { getCertificateSPKI } from '@/main/proxy'
+import { getProxyArguments } from '@/main/proxy'
 import { ChromeDevtoolsClient } from '@/utils/cdp/client'
 import { WebSocketServerError } from 'extension/src/messaging/transports/webSocketServer'
 
@@ -109,7 +109,6 @@ export const launchBrowser = async (
 
   const userDataDir = await createUserDataDir()
   console.log(userDataDir)
-  const certificateSPKI = await getCertificateSPKI()
 
   const extensionPath = getExtensionPath()
   console.info(`extension path: ${extensionPath}`)
@@ -133,6 +132,8 @@ export const launchBrowser = async (
     })
   }
 
+  const proxyArgs = await getProxyArguments(k6StudioState.appSettings.proxy)
+
   const browserRecordingArgs = capture.browser ? BROWSER_RECORDING_ARGS : []
 
   const args = [
@@ -146,9 +147,8 @@ export const launchBrowser = async (
     '--disable-background-networking',
     '--disable-component-update',
     '--disable-search-engine-choice-screen',
-    `--proxy-server=http://localhost:${k6StudioState.appSettings.proxy.port}`,
-    `--ignore-certificate-errors-spki-list=${certificateSPKI}`,
     `--disable-features=${FEATURES_TO_DISABLE.join(',')}`,
+    ...proxyArgs,
     ...browserRecordingArgs,
     url?.trim() || 'about:blank',
   ]

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -59,7 +59,7 @@ export function initialize() {
       currentk6Process = await runScript({
         browserWindow,
         scriptPath: resolvedScriptPath,
-        proxyPort: k6StudioState.appSettings.proxy.port,
+        proxySettings: k6StudioState.appSettings.proxy,
         usageReport: k6StudioState.appSettings.telemetry.usageReport,
       })
 
@@ -91,7 +91,7 @@ export function initialize() {
       currentk6Process = await runScript({
         browserWindow,
         scriptPath: TEMP_GENERATOR_SCRIPT_PATH,
-        proxyPort: k6StudioState.appSettings.proxy.port,
+        proxySettings: k6StudioState.appSettings.proxy,
         usageReport: k6StudioState.appSettings.telemetry.usageReport,
       })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ const createSplashWindow = async () => {
 const createWindow = async () => {
   const icon = getAppIcon(process.env.NODE_ENV === 'development')
   if (getPlatform() === 'mac') {
-    app.dock.setIcon(icon)
+    app.dock?.setIcon(icon)
   }
   app.setName('Grafana k6 Studio')
 

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -286,13 +286,13 @@ export const getProxyCertificateContent = () => {
 
 export async function getProxyArguments(
   settings: ProxySettings,
-  prefix = '--'
+  options: { prefix: string } = { prefix: '--' }
 ): Promise<string[]> {
   const spki = await getCertificateSPKI()
   const port = settings.port
 
   return [
-    `${prefix}proxy-server=http://localhost:${port}`,
-    `${prefix}ignore-certificate-errors-spki-list=${spki}`,
+    `${options.prefix}proxy-server=http://localhost:${port}`,
+    `${options.prefix}ignore-certificate-errors-spki-list=${spki}`,
   ]
 }

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -144,7 +144,7 @@ export const getCertificatesPath = () => {
   }
 }
 
-export const getCertificateSPKI = async () => {
+const getCertificateSPKI = async () => {
   const certificatePath = path.join(
     getCertificatesPath(),
     'mitmproxy-ca-cert.pem'
@@ -282,4 +282,17 @@ export const getProxyCertificateContent = () => {
     return readFileSync(certPath)
   }
   return undefined
+}
+
+export async function getProxyArguments(
+  settings: ProxySettings,
+  prefix = '--'
+): Promise<string[]> {
+  const spki = await getCertificateSPKI()
+  const port = settings.port
+
+  return [
+    `${prefix}proxy-server=http://localhost:${port}`,
+    `${prefix}ignore-certificate-errors-spki-list=${spki}`,
+  ]
 }

--- a/src/main/script.ts
+++ b/src/main/script.ts
@@ -119,7 +119,9 @@ export const runScript = async ({
   // 4. Delete the temp script file
   await unlink(tempScriptPath)
 
-  const proxyArgs = await getProxyArguments(proxySettings, '')
+  const proxyArgs = await getProxyArguments(proxySettings, {
+    prefix: '',
+  })
 
   // 5. Run the test
   const k6 = spawnK6({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR configures k6 browser to run using the proxy recorder when validating a script. This means that users can view the browser's network traffic in order to debug issues.

## How to Test

1. Create a browser script.
2. Validate the script

You should the network requests that were made by the browser.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`npm run lint`) and all checks pass.
- [x] I have run tests locally (`npm test`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
