### PR TITLE
style: Display spinner when opening large recordings

### DIFF
--- a/src/components/Layout/View.tsx
+++ b/src/components/Layout/View.tsx
@@ -1,7 +1,38 @@
-import { Box, Flex } from '@radix-ui/themes'
-import { PropsWithChildren, ReactNode } from 'react'
+import { css } from '@emotion/react'
+import { Flex, Spinner } from '@radix-ui/themes'
+import { PropsWithChildren, ReactNode, useEffect, useState } from 'react'
 
 import { ViewHeading } from './ViewHeading'
+
+function LoadingSpinner() {
+  const [showSpinner, setShowSpinner] = useState(false)
+
+  useEffect(() => {
+    // Only show the spinner if loading takes more than 50ms to avoid flickering
+    setTimeout(() => {
+      setShowSpinner(true)
+    }, 50)
+  }, [])
+
+  return (
+    <Flex
+      css={css`
+        flex: 1 1 0;
+      `}
+      align="center"
+      justify="center"
+      maxHeight="800px"
+    >
+      {showSpinner && (
+        <Spinner
+          css={css`
+            transform: translateY(-50%);
+          `}
+        />
+      )}
+    </Flex>
+  )
+}
 
 interface ViewProps {
   title: string
@@ -22,7 +53,7 @@ export function View({
       <ViewHeading title={title} subTitle={subTitle}>
         {actions}
       </ViewHeading>
-      {loading ? <Box p="2">Loading...</Box> : children}
+      {loading ? <LoadingSpinner /> : children}
     </Flex>
   )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR changes the "Loading..." message for a spinner when opening large recordings.

## How to Test

1. Open a large recording (i.e. on that takes a long while to load)
2. You should see a spinner
3. Open a small recording (i.e. on that's almost instantaneous)
4. You shouldn't see a spinner (in some cases it will flash by)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
