### PR TITLE
feat(Recorder): Add create test menu to make exporting browser tests easier

### DIFF
--- a/src/views/Recorder/BrowserEventLog.tsx
+++ b/src/views/Recorder/BrowserEventLog.tsx
@@ -1,27 +1,14 @@
-import { Flex, Button, ScrollArea } from '@radix-ui/themes'
-import { useState } from 'react'
+import { Flex, ScrollArea } from '@radix-ui/themes'
 
 import { BrowserEventList } from '@/components/BrowserEventList'
 import { BrowserEvent } from '@/schemas/recording'
 import { HighlightSelector } from 'extension/src/messaging/types'
 
-import { ExportScriptDialog } from '../Generator/ExportScriptDialog'
-
 interface BrowserEventLogProps {
   events: BrowserEvent[]
-  onExportScript?: (fileName: string) => void
 }
 
-export function BrowserEventLog({
-  events,
-  onExportScript,
-}: BrowserEventLogProps) {
-  const [showExportDialog, setShowExportDialog] = useState(false)
-
-  const handleExportScriptClick = () => {
-    setShowExportDialog(true)
-  }
-
+export function BrowserEventLog({ events }: BrowserEventLogProps) {
   const handleNavigate = (url: string) => {
     window.studio.browserRemote.navigateTo(url)
   }
@@ -32,19 +19,6 @@ export function BrowserEventLog({
 
   return (
     <Flex direction="column" minHeight="0" height="100%">
-      {onExportScript && (
-        <Flex justify="end" align="center" p="1" pr="2">
-          <Flex gap="2" align="center">
-            <Button
-              size="2"
-              variant="outline"
-              onClick={handleExportScriptClick}
-            >
-              Export script
-            </Button>
-          </Flex>
-        </Flex>
-      )}
       <ScrollArea>
         <BrowserEventList
           events={events}
@@ -52,14 +26,6 @@ export function BrowserEventLog({
           onHighlight={handleHighlight}
         />
       </ScrollArea>
-      {onExportScript && (
-        <ExportScriptDialog
-          open={showExportDialog}
-          scriptName="my-browser-script.js"
-          onOpenChange={setShowExportDialog}
-          onExport={onExportScript}
-        />
-      )}
     </Flex>
   )
 }

--- a/src/views/Recorder/RecordingInspector.tsx
+++ b/src/views/Recorder/RecordingInspector.tsx
@@ -18,7 +18,6 @@ interface RecordingInspectorProps {
   onUpdateGroup?: (group: Group) => void
   onCreateGroup?: (name: string) => void
   onResetRecording?: () => void
-  onExportBrowserScript?: (fileName: string) => void
 }
 
 const styles = {
@@ -36,7 +35,6 @@ export function RecordingInspector({
   onUpdateGroup,
   onCreateGroup,
   onResetRecording,
-  onExportBrowserScript,
 }: RecordingInspectorProps) {
   return (
     <Tabs.Root
@@ -91,10 +89,7 @@ export function RecordingInspector({
         />
       </Tabs.Content>
       <Tabs.Content value="browser-events" css={styles.content}>
-        <BrowserEventLog
-          events={browserEvents}
-          onExportScript={onExportBrowserScript}
-        />
+        <BrowserEventLog events={browserEvents} />
       </Tabs.Content>
     </Tabs.Root>
   )

--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -1,19 +1,12 @@
-import { Button, DropdownMenu, IconButton } from '@radix-ui/themes'
-import { EllipsisVerticalIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
-import { emitScript } from '@/codegen/browser'
-import { convertToTest } from '@/codegen/browser/test'
 import { FileNameHeader } from '@/components/FileNameHeader'
 import { View } from '@/components/Layout/View'
-import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
 import { useSettings } from '@/hooks/useSettings'
-import { getRoutePath } from '@/routeMap'
 import { BrowserEvent } from '@/schemas/recording'
-import { useToast } from '@/store/ui/useToast'
 import { ProxyData, StudioFile } from '@/types'
 import { getFileNameWithoutExtension } from '@/utils/file'
 import { harToProxyData } from '@/utils/harToProxyData'
@@ -21,24 +14,20 @@ import { harToProxyData } from '@/utils/harToProxyData'
 import { RecordingInspector } from '../Recorder/RecordingInspector'
 import { RequestLog } from '../Recorder/RequestLog'
 
+import { RecordingPreviewControls } from './RecordingPreviewerControls'
+
 export function RecordingPreviewer() {
   const { data: settings } = useSettings()
 
   const [proxyData, setProxyData] = useState<ProxyData[]>([])
   const [browserEvents, setBrowserEvents] = useState<BrowserEvent[]>([])
 
-  const showToast = useToast()
-
   const [isLoading, setIsLoading] = useState(true)
   const { fileName } = useParams()
   const navigate = useNavigate()
-  const createTestGenerator = useCreateGenerator()
-  // TODO: https://github.com/grafana/k6-studio/issues/277
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const { state } = useLocation()
-  // TODO: https://github.com/grafana/k6-studio/issues/277
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const isDiscardable = Boolean(state?.discardable)
+
+  const isBrowserRecorderEnabled =
+    settings?.recorder.enableBrowserRecorder ?? false
   invariant(fileName, 'fileName is required')
   const file: StudioFile = {
     fileName,
@@ -67,87 +56,24 @@ export function RecordingPreviewer() {
 
   const groups = useProxyDataGroups(proxyData)
 
-  const handleCreateGenerator = () => createTestGenerator(fileName)
-
-  const handleDeleteRecording = async () => {
-    await window.studio.ui.deleteFile(file)
-    navigate(getRoutePath('home'))
-  }
-
-  const handleDiscard = async () => {
-    await window.studio.ui.deleteFile(file)
-    navigate(getRoutePath('recorder'))
-  }
-
-  const handleExportBrowserScript = (fileName: string) => {
-    const test = convertToTest({
-      browserEvents,
-    })
-
-    emitScript(test)
-      .then((script) => window.studio.script.saveScript(script, fileName))
-      .then(() => {
-        navigate(
-          getRoutePath('validator', {
-            fileName: encodeURIComponent(fileName),
-          })
-        )
-      })
-      .catch((err) => {
-        console.error(err)
-
-        showToast({
-          title: 'Failed to export browser script.',
-          status: 'error',
-        })
-      })
-  }
-
   return (
     <View
       title="Recording"
       subTitle={<FileNameHeader file={file} />}
       loading={isLoading}
       actions={
-        <>
-          {isDiscardable && (
-            <Button onClick={handleDiscard} variant="outline" color="red">
-              Discard
-            </Button>
-          )}
-
-          {!isDiscardable && (
-            <Button variant="outline" asChild>
-              <Link to={getRoutePath('recorder')}>New recording</Link>
-            </Button>
-          )}
-
-          <Button onClick={handleCreateGenerator}>Create test generator</Button>
-          <DropdownMenu.Root>
-            <DropdownMenu.Trigger>
-              <IconButton variant="ghost" aria-label="Actions" color="gray">
-                <EllipsisVerticalIcon />
-              </IconButton>
-            </DropdownMenu.Trigger>
-            <DropdownMenu.Content>
-              <DropdownMenu.Item color="red" onClick={handleDeleteRecording}>
-                Delete
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Root>
-        </>
+        <RecordingPreviewControls file={file} browserEvents={browserEvents} />
       }
     >
-      {!isLoading && settings?.recorder.enableBrowserRecorder && (
+      {!isLoading && isBrowserRecorderEnabled && (
         <RecordingInspector
           groups={groups}
           requests={proxyData}
           browserEvents={browserEvents}
-          onExportBrowserScript={handleExportBrowserScript}
         />
       )}
 
-      {!isLoading && !settings?.recorder.enableBrowserRecorder && (
+      {!isLoading && !isBrowserRecorderEnabled && (
         <RequestLog groups={groups} requests={proxyData} />
       )}
     </View>

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -92,7 +92,7 @@ export function RecordingPreviewControls({
         <DropdownMenu.Content>
           <MenuItem
             label="HTTP test"
-            description="Set up a test generator to turn the recorded HTTP requests into a k6 script"
+            description="Generate a k6 script from HTTP requests using rules"
             onClick={handleCreateGenerator}
           />
           <MenuItem

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -1,0 +1,150 @@
+import { css } from '@emotion/react'
+import { Button, DropdownMenu, Flex, IconButton, Text } from '@radix-ui/themes'
+import { ChevronDownIcon, EllipsisVerticalIcon } from 'lucide-react'
+import { useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+
+import { emitScript } from '@/codegen/browser'
+import { convertToTest } from '@/codegen/browser/test'
+import { useCreateGenerator } from '@/hooks/useCreateGenerator'
+import { getRoutePath } from '@/routeMap'
+import { BrowserEvent } from '@/schemas/recording'
+import { useToast } from '@/store/ui/useToast'
+import { StudioFile } from '@/types'
+
+import { ExportScriptDialog } from '../Generator/ExportScriptDialog'
+
+interface RecordingPreviewControlsProps {
+  file: StudioFile
+  browserEvents: BrowserEvent[]
+}
+
+export function RecordingPreviewControls({
+  file,
+  browserEvents,
+}: RecordingPreviewControlsProps) {
+  const [showExportDialog, setShowExportDialog] = useState(false)
+  const showToast = useToast()
+  const navigate = useNavigate()
+  const createTestGenerator = useCreateGenerator()
+  const { fileName } = useParams()
+
+  // TODO: https://github.com/grafana/k6-studio/issues/277
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const { state } = useLocation()
+  // TODO: https://github.com/grafana/k6-studio/issues/277
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const isDiscardable = Boolean(state?.discardable)
+
+  const handleCreateGenerator = () => createTestGenerator(fileName)
+
+  const handleDeleteRecording = async () => {
+    await window.studio.ui.deleteFile(file)
+    navigate(getRoutePath('home'))
+  }
+
+  const handleDiscard = async () => {
+    await window.studio.ui.deleteFile(file)
+    navigate(getRoutePath('recorder'))
+  }
+
+  const handleExportBrowserScript = (fileName: string) => {
+    const test = convertToTest({
+      browserEvents,
+    })
+
+    emitScript(test)
+      .then((script) => window.studio.script.saveScript(script, fileName))
+      .then(() => {
+        navigate(
+          getRoutePath('validator', {
+            fileName: encodeURIComponent(fileName),
+          })
+        )
+      })
+      .catch((err) => {
+        console.error(err)
+
+        showToast({
+          title: 'Failed to export browser script.',
+          status: 'error',
+        })
+      })
+  }
+
+  return (
+    <>
+      {isDiscardable ? (
+        <Button onClick={handleDiscard} variant="outline" color="red">
+          Discard
+        </Button>
+      ) : (
+        <Button variant="outline" asChild>
+          <Link to={getRoutePath('recorder')}>New recording</Link>
+        </Button>
+      )}
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <Button>
+            Create test <ChevronDownIcon />
+          </Button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <MenuItem
+            label="Protocol-level test"
+            description="Turn the recorded HTTP requests into a protocol-level k6 test script by defining the test logic in a test generator"
+            onClick={handleCreateGenerator}
+          />
+          <MenuItem
+            label="Browser script"
+            description="Export a k6 browser test script to simulate user interactions in a real browser"
+            disabled={browserEvents.length === 0}
+            onClick={() => setShowExportDialog(true)}
+          />
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <IconButton variant="ghost" aria-label="Actions" color="gray">
+            <EllipsisVerticalIcon />
+          </IconButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item color="red" onClick={handleDeleteRecording}>
+            Delete
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+      <ExportScriptDialog
+        open={showExportDialog}
+        scriptName="my-browser-script.js"
+        onOpenChange={setShowExportDialog}
+        onExport={handleExportBrowserScript}
+      />
+    </>
+  )
+}
+
+interface MenuItemProps {
+  label: string
+  description?: string
+  disabled?: boolean
+  onClick?: () => void
+}
+
+function MenuItem({ label, description, disabled, onClick }: MenuItemProps) {
+  return (
+    <DropdownMenu.Item
+      disabled={disabled}
+      onClick={onClick}
+      css={css`
+        height: auto;
+      `}
+    >
+      <Flex direction="column" align="start" py="1" maxWidth="320px">
+        <Text>{label}</Text>
+        {description && <Text size="1">{description}</Text>}
+      </Flex>
+    </DropdownMenu.Item>
+  )
+}

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -91,13 +91,13 @@ export function RecordingPreviewControls({
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           <MenuItem
-            label="Protocol-level test"
-            description="Turn the recorded HTTP requests into a protocol-level k6 test script by defining the test logic in a test generator"
+            label="HTTP test"
+            description="Set up a test generator to turn the recorded HTTP requests into a k6 script"
             onClick={handleCreateGenerator}
           />
           <MenuItem
-            label="Browser script"
-            description="Export a k6 browser test script to simulate user interactions in a real browser"
+            label="Browser test"
+            description="Export a k6 script simulating browser interactions"
             disabled={browserEvents.length === 0}
             onClick={() => setShowExportDialog(true)}
           />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Improve discoverability of the `Export browser script` option, by lifting it to the top of the View and putting both the generator flow and the browser flow into the same `Create test` dropdown menu.

<img width="354" height="158" alt="image" src="https://github.com/user-attachments/assets/4a24f344-c765-484f-bd39-e1b15252cf4d" />



## How to Test
1. Open/create a recording and:
    - Verify that you can create a generator
    - Verify that you can export a browser script

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
