### PR TITLE
feat(Browser): Add getByTestId support

### DIFF
--- a/extension/src/selectors.ts
+++ b/extension/src/selectors.ts
@@ -5,5 +5,6 @@ import { ElementSelector } from '@/schemas/recording'
 export function generateSelector(element: Element): ElementSelector {
   return {
     css: finder(element, {}),
+    testId: element.getAttribute('data-testid') || undefined,
   }
 }

--- a/src/codegen/browser/code/options.ts
+++ b/src/codegen/browser/code/options.ts
@@ -31,7 +31,7 @@ function isBrowserScenario(scenario: ir.Scenario) {
       case 'NewPageExpression':
       case 'GotoExpression':
       case 'ReloadExpression':
-      case 'NewCSSLocatorExpression':
+      case 'NewCssLocatorExpression':
       case 'NewTestIdLocatorExpression':
       case 'ClickExpression':
       case 'ClickOptionsExpression':

--- a/src/codegen/browser/code/options.ts
+++ b/src/codegen/browser/code/options.ts
@@ -31,7 +31,8 @@ function isBrowserScenario(scenario: ir.Scenario) {
       case 'NewPageExpression':
       case 'GotoExpression':
       case 'ReloadExpression':
-      case 'NewLocatorExpression':
+      case 'NewCSSLocatorExpression':
+      case 'NewTestIdLocatorExpression':
       case 'ClickExpression':
       case 'ClickOptionsExpression':
       case 'FillTextExpression':

--- a/src/codegen/browser/code/scenario.ts
+++ b/src/codegen/browser/code/scenario.ts
@@ -33,7 +33,7 @@ function emitNewPageExpression(
 
 function emitNewCSSLocatorExpression(
   context: ScenarioContext,
-  expression: ir.NewCSSLocatorExpression
+  expression: ir.NewCssLocatorExpression
 ): ts.Expression {
   const page = emitExpression(context, expression.page)
   const selector = emitExpression(context, expression.selector)
@@ -275,7 +275,7 @@ function emitExpression(
     case 'NewPageExpression':
       return emitNewPageExpression(context, expression)
 
-    case 'NewCSSLocatorExpression':
+    case 'NewCssLocatorExpression':
       return emitNewCSSLocatorExpression(context, expression)
 
     case 'NewTestIdLocatorExpression':

--- a/src/codegen/browser/code/scenario.ts
+++ b/src/codegen/browser/code/scenario.ts
@@ -31,14 +31,24 @@ function emitNewPageExpression(
     .done()
 }
 
-function emitNewLocatorExpression(
+function emitNewCSSLocatorExpression(
   context: ScenarioContext,
-  expression: ir.NewLocatorExpression
+  expression: ir.NewCSSLocatorExpression
 ): ts.Expression {
   const page = emitExpression(context, expression.page)
   const selector = emitExpression(context, expression.selector)
 
   return new ExpressionBuilder(page).member('locator').call([selector]).done()
+}
+
+function emitNewTestIdLocatorExpression(
+  context: ScenarioContext,
+  expression: ir.NewTestIdLocatorExpression
+): ts.Expression {
+  const page = emitExpression(context, expression.page)
+  const testId = emitExpression(context, expression.testId)
+
+  return new ExpressionBuilder(page).member('getByTestId').call([testId]).done()
 }
 
 function emitGotoExpression(
@@ -265,8 +275,11 @@ function emitExpression(
     case 'NewPageExpression':
       return emitNewPageExpression(context, expression)
 
-    case 'NewLocatorExpression':
-      return emitNewLocatorExpression(context, expression)
+    case 'NewCSSLocatorExpression':
+      return emitNewCSSLocatorExpression(context, expression)
+
+    case 'NewTestIdLocatorExpression':
+      return emitNewTestIdLocatorExpression(context, expression)
 
     case 'GotoExpression':
       return emitGotoExpression(context, expression)

--- a/src/codegen/browser/codegen.test.ts
+++ b/src/codegen/browser/codegen.test.ts
@@ -86,7 +86,7 @@ it('should emit click on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -126,7 +126,7 @@ it('should emit right-click on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -166,7 +166,7 @@ it('should emit click with modifier keys on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -206,7 +206,7 @@ it('should emit type text on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input',
+          selector: { css: 'input' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -240,7 +240,7 @@ it('should emit check on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="checkbox"]',
+          selector: { css: 'input[type="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -274,7 +274,7 @@ it('should emit uncheck on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="checkbox"]',
+          selector: { css: 'input[type="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -308,7 +308,7 @@ it('should emit select single option on element', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'select',
+          selector: { css: 'select' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -345,7 +345,7 @@ it('should emit select with multiple options on element', async ({
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'select',
+          selector: { css: 'select' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -380,7 +380,7 @@ it('should assert that element contains text', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -417,7 +417,7 @@ it('should assert that element is visible', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -454,7 +454,7 @@ it('should assert that element is hidden', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'button',
+          selector: { css: 'button' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -491,7 +491,7 @@ it('should assert that html input is checked', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="checkbox"]',
+          selector: { css: 'input[type="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -529,7 +529,7 @@ it('should assert that html input is not checked', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="checkbox"]',
+          selector: { css: 'input[type="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -567,7 +567,7 @@ it('should assert that html input is indeterminate', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="checkbox"]',
+          selector: { css: 'input[type="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -605,7 +605,7 @@ it('should assert that aria input is checked', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: '[role="checkbox"]',
+          selector: { css: '[role="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -643,7 +643,7 @@ it('should assert that aria input is not checked', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: '[role="checkbox"]',
+          selector: { css: '[role="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -681,7 +681,7 @@ it('should assert that aria input is indeterminate', async ({ expect }) => {
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: '[role="checkbox"]',
+          selector: { css: '[role="checkbox"]' },
           inputs: {
             page: { nodeId: 'page' },
           },
@@ -721,7 +721,7 @@ it('should assert that input has single value using toHaveValue', async ({
         {
           type: 'locator',
           nodeId: 'locator',
-          selector: 'input[type="text"]',
+          selector: { css: 'input[type="text"]' },
           inputs: {
             page: { nodeId: 'page' },
           },

--- a/src/codegen/browser/intermediate/ast.ts
+++ b/src/codegen/browser/intermediate/ast.ts
@@ -12,9 +12,15 @@ export interface NewPageExpression {
   type: 'NewPageExpression'
 }
 
-export interface NewLocatorExpression {
-  type: 'NewLocatorExpression'
+export interface NewCSSLocatorExpression {
+  type: 'NewCSSLocatorExpression'
   selector: Expression
+  page: Expression
+}
+
+export interface NewTestIdLocatorExpression {
+  type: 'NewTestIdLocatorExpression'
+  testId: Expression
   page: Expression
 }
 
@@ -116,7 +122,8 @@ export type Expression =
   | Identifier
   | StringLiteral
   | NewPageExpression
-  | NewLocatorExpression
+  | NewCSSLocatorExpression
+  | NewTestIdLocatorExpression
   | GotoExpression
   | ReloadExpression
   | ClickExpression

--- a/src/codegen/browser/intermediate/ast.ts
+++ b/src/codegen/browser/intermediate/ast.ts
@@ -12,8 +12,8 @@ export interface NewPageExpression {
   type: 'NewPageExpression'
 }
 
-export interface NewCSSLocatorExpression {
-  type: 'NewCSSLocatorExpression'
+export interface NewCssLocatorExpression {
+  type: 'NewCssLocatorExpression'
   selector: Expression
   page: Expression
 }
@@ -122,7 +122,7 @@ export type Expression =
   | Identifier
   | StringLiteral
   | NewPageExpression
-  | NewCSSLocatorExpression
+  | NewCssLocatorExpression
   | NewTestIdLocatorExpression
   | GotoExpression
   | ReloadExpression

--- a/src/codegen/browser/intermediate/index.ts
+++ b/src/codegen/browser/intermediate/index.ts
@@ -51,19 +51,30 @@ function emitReloadNode(context: IntermediateContext, node: m.ReloadNode) {
 function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
   const page = context.reference(node.inputs.page)
 
-  const expression: ir.NewLocatorExpression = {
-    type: 'NewLocatorExpression',
-    selector: {
-      type: 'StringLiteral',
-      value: node.selector,
-    },
-    page,
+  if (node.selector.testId) {
+    // We always inline locator nodes for readability. If we implement better
+    // logic for generating variable names, then we could consider declaring
+    // a variable for it if there are multiple references.
+    context.inline(node, {
+      type: 'NewTestIdLocatorExpression',
+      testId: {
+        type: 'StringLiteral',
+        value: node.selector.testId,
+      },
+      page,
+    })
+    return
   }
 
-  // We always inline locator nodes for readability. If we implement better
-  // logic for generating variable names, then we could consider declaring
-  // a variable for it if there are multiple references.
-  context.inline(node, expression)
+  // Default to CSS locator
+  context.inline(node, {
+    type: 'NewCSSLocatorExpression',
+    selector: {
+      type: 'StringLiteral',
+      value: node.selector.css,
+    },
+    page,
+  })
 }
 
 function getClickOptions(node: m.ClickNode): ir.ClickOptionsExpression | null {

--- a/src/codegen/browser/intermediate/index.ts
+++ b/src/codegen/browser/intermediate/index.ts
@@ -68,7 +68,7 @@ function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
 
   // Default to CSS locator
   context.inline(node, {
-    type: 'NewCSSLocatorExpression',
+    type: 'NewCssLocatorExpression',
     selector: {
       type: 'StringLiteral',
       value: node.selector.css,

--- a/src/codegen/browser/intermediate/variables.ts
+++ b/src/codegen/browser/intermediate/variables.ts
@@ -60,9 +60,9 @@ function substituteExpression(
         name: substitutions.get(node.name) ?? node.name,
       }
 
-    case 'NewCSSLocatorExpression':
+    case 'NewCssLocatorExpression':
       return {
-        type: 'NewCSSLocatorExpression',
+        type: 'NewCssLocatorExpression',
         page: substituteExpression(node.page, substitutions),
         selector: substituteExpression(node.selector, substitutions),
       }

--- a/src/codegen/browser/intermediate/variables.ts
+++ b/src/codegen/browser/intermediate/variables.ts
@@ -60,11 +60,18 @@ function substituteExpression(
         name: substitutions.get(node.name) ?? node.name,
       }
 
-    case 'NewLocatorExpression':
+    case 'NewCSSLocatorExpression':
       return {
-        type: 'NewLocatorExpression',
+        type: 'NewCSSLocatorExpression',
         page: substituteExpression(node.page, substitutions),
         selector: substituteExpression(node.selector, substitutions),
+      }
+
+    case 'NewTestIdLocatorExpression':
+      return {
+        type: 'NewTestIdLocatorExpression',
+        page: substituteExpression(node.page, substitutions),
+        testId: substituteExpression(node.testId, substitutions),
       }
 
     case 'GotoExpression':

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -86,14 +86,16 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
     // await input.focus()
     // await input.type("Hello")
     // await input.press("Enter")
+
+    // TODO: is it enough to compare just the CSS selector?
     if (
-      previousLocator?.selector !== selector.css ||
+      previousLocator?.selector.css !== selector.css ||
       previousLocator?.inputs.page.nodeId !== page.nodeId
     ) {
       previousLocator = {
         type: 'locator',
         nodeId: crypto.randomUUID(),
-        selector: selector.css,
+        selector,
         inputs: {
           page,
         },

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -87,7 +87,6 @@ function buildBrowserNodeGraph(events: BrowserEvent[]) {
     // await input.type("Hello")
     // await input.press("Enter")
 
-    // TODO: is it enough to compare just the CSS selector?
     if (
       previousLocator?.selector.css !== selector.css ||
       previousLocator?.inputs.page.nodeId !== page.nodeId

--- a/src/codegen/browser/types.ts
+++ b/src/codegen/browser/types.ts
@@ -1,4 +1,4 @@
-import { CheckState } from '@/schemas/recording'
+import { CheckState, ElementSelector } from '@/schemas/recording'
 
 export type NodeId = string
 
@@ -16,7 +16,7 @@ export interface PageNode extends NodeBase {
 
 export interface LocatorNode extends NodeBase {
   type: 'locator'
-  selector: string
+  selector: ElementSelector
   inputs: {
     page: NodeRef
   }

--- a/src/components/BrowserEventList/BrowserEventList.tsx
+++ b/src/components/BrowserEventList/BrowserEventList.tsx
@@ -39,6 +39,9 @@ export function BrowserEventList({
                   <EventIcon event={event} />
                   <div
                     css={css`
+                      display: flex;
+                      align-items: center;
+                      gap: 0.25rem;
                       flex: 1 1 0;
                       overflow: hidden;
                       white-space: nowrap;

--- a/src/components/BrowserEventList/EventDescription/Selector.tsx
+++ b/src/components/BrowserEventList/EventDescription/Selector.tsx
@@ -44,7 +44,7 @@ export function Selector({ selector, onHighlight }: SelectorProps) {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {selector.css}
+      {selector.testId ?? selector.css}
     </strong>
   )
 }

--- a/src/components/BrowserEventList/EventDescription/Selector.tsx
+++ b/src/components/BrowserEventList/EventDescription/Selector.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/react'
-import { Badge, Code } from '@radix-ui/themes'
 import { BracesIcon, TestTubeDiagonalIcon } from 'lucide-react'
 
 import { ElementSelector } from '@/schemas/recording'
@@ -30,25 +29,42 @@ export function Selector({ selector, onHighlight }: SelectorProps) {
   }
 
   return (
-    <Badge
-      highContrast
-      color="gray"
-      css={css`
-        flex-shrink: 1;
-        overflow: hidden;
-        cursor: ${isRecording ? 'pointer' : 'default'};
-
-        &:hover {
-          background-color: ${isRecording ? 'var(--gray-4)' : undefined};
-        }
-      `}
+    <div
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      css={css`
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: calc(var(--studio-spacing-1) * 1.5);
+        flex-shrink: 1;
+        padding: calc(var(--studio-spacing-1) * 0.5)
+          calc(var(--studio-spacing-1) * 1.5);
+        overflow: hidden;
+        background-color: var(--gray-3);
+        color: var(--gray-12);
+        border-radius: 3px;
+        font-size: var(--studio-font-size-1);
+
+        ${isRecording &&
+        css`
+          &:hover {
+            cursor: pointer;
+            background-color: var(--gray-4);
+          }
+        `}
+      `}
     >
       {selector.testId ? <TestTubeDiagonalIcon /> : <BracesIcon />}
-      <Code variant="ghost" truncate>
+      <code
+        css={css`
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        `}
+      >
         {selector.testId ?? selector.css}
-      </Code>
-    </Badge>
+      </code>
+    </div>
   )
 }

--- a/src/components/BrowserEventList/EventDescription/Selector.tsx
+++ b/src/components/BrowserEventList/EventDescription/Selector.tsx
@@ -1,4 +1,6 @@
 import { css } from '@emotion/react'
+import { Badge, Code } from '@radix-ui/themes'
+import { BracesIcon, TestTubeDiagonalIcon } from 'lucide-react'
 
 import { ElementSelector } from '@/schemas/recording'
 import { useIsRecording } from '@/views/Recorder/RecordingContext'
@@ -28,23 +30,25 @@ export function Selector({ selector, onHighlight }: SelectorProps) {
   }
 
   return (
-    <strong
+    <Badge
+      highContrast
+      color="gray"
       css={css`
-        font-weight: bold;
-        border-radius: var(--radius-2);
+        flex-shrink: 1;
+        overflow: hidden;
+        cursor: ${isRecording ? 'pointer' : 'default'};
 
-        ${isRecording &&
-        css`
-          &:hover {
-            cursor: pointer;
-            background-color: var(--gray-3);
-          }
-        `}
+        &:hover {
+          background-color: ${isRecording ? 'var(--gray-4)' : undefined};
+        }
       `}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {selector.testId ?? selector.css}
-    </strong>
+      {selector.testId ? <TestTubeDiagonalIcon /> : <BracesIcon />}
+      <Code variant="ghost" truncate>
+        {selector.testId ?? selector.css}
+      </Code>
+    </Badge>
   )
 }

--- a/src/schemas/recording/v1/browser.ts
+++ b/src/schemas/recording/v1/browser.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 
 const ElementSelectorSchema = z.object({
   css: z.string(),
+  testId: z.string().optional(),
 })
 
 const BrowserEventBaseSchema = z.object({


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/834

## Description


## How to Test
- Find a website that uses `data-testid` on its elements
- Start a recording and interact with these elements
- Verify that the testId selectors are displayed in the event log
- Verify that, when exported, the browser script uses `getByTestId`

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`npm run lint`) and all checks pass.
- [ ] I have run tests locally (`npm test`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Screenshots (if appropriate):

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
