### PR TITLE
fix: Clicks are not recorded on inputs with type button, submit or reset

### DIFF
--- a/extension/src/frontend/index.ts
+++ b/extension/src/frontend/index.ts
@@ -9,6 +9,7 @@ import {
   isNativeButton,
   isNativeCheckbox,
   isNativeRadio,
+  isNonButtonInput,
 } from '../utils/dom'
 
 import { WindowEventManager } from './manager'
@@ -62,7 +63,7 @@ manager.capture('click', (ev, manager) => {
   // We don't want to capture clicks on form elements since they will be
   // interacted with using e.g. the `selectOption` or `type` functions.
   if (
-    clickTarget instanceof HTMLInputElement ||
+    isNonButtonInput(clickTarget) ||
     clickTarget instanceof HTMLTextAreaElement ||
     clickTarget instanceof HTMLSelectElement ||
     clickTarget instanceof HTMLOptionElement

--- a/extension/src/utils/dom.ts
+++ b/extension/src/utils/dom.ts
@@ -131,5 +131,21 @@ export function isNativeButton(element: Element) {
     return false
   }
 
-  return element.type === 'button' || element.type === 'submit'
+  return (
+    element.type === 'button' ||
+    element.type === 'submit' ||
+    element.type === 'reset'
+  )
+}
+
+export function isNonButtonInput(element: Element) {
+  if (element instanceof HTMLInputElement === false) {
+    return false
+  }
+
+  return (
+    element.type !== 'button' &&
+    element.type !== 'submit' &&
+    element.type !== 'reset'
+  )
 }

--- a/vite.extension.config.mts
+++ b/vite.extension.config.mts
@@ -20,6 +20,7 @@ export default defineConfig((env) => {
   ]
 
   const build: BuildOptions = {
+    minify: false,
     outDir: `.vite/build/extension`,
     sourcemap: 'inline',
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where clicks would not be recorded on buttons implemented using `<input />` with type `"button"`, `"submit"` or `"reset"`. 

## How to Test

1. Find a form with a button that's implemented using type `"button"`, `"submit"` or `"reset"`. (https://quickpizza.grafana.com/my_messages.php).
2. Click it
3. Verify that a click was recorded

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

BEGIN_COMMIT_OVERRIDE
fix(browser): Clicks are not recorded on inputs with type button, submit or reset
END_COMMIT_OVERRIDE