### PR TITLE
chore: Remove alwaysOnTop from splash window options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,6 @@ const createSplashWindow = async () => {
     height: 400,
     frame: false,
     show: false,
-    alwaysOnTop: true,
   })
 
   let splashscreenFile: string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The splash window being always-on-top leads to poor user experience when loading takes longer than expected. 

## How to Test
- Check that the app launches and the splash window is rendered on top of other windows initially
- Add a change in the main process code (e.g. a comment), save it and verify that the focus does not shift to the splash window

## Checklist
- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
