### PR TITLE
refactor: Use consistent naming for enum members

### DIFF
--- a/src/handlers/app/index.ts
+++ b/src/handlers/app/index.ts
@@ -8,12 +8,12 @@ import { browserWindowFromEvent } from '@/utils/electron'
 import { AppHandler } from './types'
 
 export function initialize() {
-  ipcMain.on(AppHandler.CHANGE_ROUTE, (_, route: string) => {
+  ipcMain.on(AppHandler.ChangeRoute, (_, route: string) => {
     k6StudioState.currentClientRoute = route
   })
 
-  ipcMain.on(AppHandler.CLOSE, (event) => {
-    console.log(`${AppHandler.CLOSE} event received`)
+  ipcMain.on(AppHandler.Close, (event) => {
+    console.log(`${AppHandler.Close} event received`)
 
     k6StudioState.wasAppClosedByClient = true
     if (k6StudioState.appShuttingDown) {
@@ -24,8 +24,8 @@ export function initialize() {
     browserWindow.close()
   })
 
-  ipcMain.on(AppHandler.SPLASHSCREEN_CLOSE, (event) => {
-    console.log(`${AppHandler.SPLASHSCREEN_CLOSE} event received`)
+  ipcMain.on(AppHandler.SplashscreenClose, (event) => {
+    console.log(`${AppHandler.SplashscreenClose} event received`)
 
     const browserWindow = browserWindowFromEvent(event)
 
@@ -38,7 +38,7 @@ export function initialize() {
     }
   })
 
-  ipcMain.on(AppHandler.TRACK_EVENT, (_, event: UsageEvent) => {
+  ipcMain.on(AppHandler.TrackEvent, (_, event: UsageEvent) => {
     trackEvent(event)
   })
 }

--- a/src/handlers/app/preload.ts
+++ b/src/handlers/app/preload.ts
@@ -9,25 +9,25 @@ import { AppHandler } from './types'
 export const platform = process.platform
 
 export function closeSplashscreen() {
-  ipcRenderer.send(AppHandler.SPLASHSCREEN_CLOSE)
+  ipcRenderer.send(AppHandler.SplashscreenClose)
 }
 
 export function onApplicationClose(callback: () => void) {
-  return createListener(AppHandler.CLOSE, callback)
+  return createListener(AppHandler.Close, callback)
 }
 
 export function closeApplication() {
-  ipcRenderer.send(AppHandler.CLOSE)
+  ipcRenderer.send(AppHandler.Close)
 }
 
 export function changeRoute(route: string) {
-  return ipcRenderer.send(AppHandler.CHANGE_ROUTE, route)
+  return ipcRenderer.send(AppHandler.ChangeRoute, route)
 }
 
 export function trackEvent(event: UsageEvent) {
-  return ipcRenderer.send(AppHandler.TRACK_EVENT, event)
+  return ipcRenderer.send(AppHandler.TrackEvent, event)
 }
 
 export function onDeepLink(callback: (url: string) => void) {
-  return createListener(AppHandler.DEEP_LINK, callback)
+  return createListener(AppHandler.DeepLink, callback)
 }

--- a/src/handlers/app/types.ts
+++ b/src/handlers/app/types.ts
@@ -1,7 +1,7 @@
 export enum AppHandler {
-  CLOSE = 'app:close',
-  CHANGE_ROUTE = 'app:change-route',
-  SPLASHSCREEN_CLOSE = 'app:splashscreen-close',
-  DEEP_LINK = 'app:deep-link',
-  TRACK_EVENT = 'app:track-event',
+  Close = 'app:close',
+  ChangeRoute = 'app:change-route',
+  SplashscreenClose = 'app:splashscreen-close',
+  DeepLink = 'app:deep-link',
+  TrackEvent = 'app:track-event',
 }

--- a/src/handlers/log/index.ts
+++ b/src/handlers/log/index.ts
@@ -5,13 +5,13 @@ import { openLogFolder, getLogContent } from '@/main/logger'
 import { LogHandler } from './types'
 
 export function initialize() {
-  ipcMain.on(LogHandler.OPEN, () => {
-    console.info(`${LogHandler.OPEN} event received`)
+  ipcMain.on(LogHandler.Open, () => {
+    console.info(`${LogHandler.Open} event received`)
     openLogFolder()
   })
 
-  ipcMain.handle(LogHandler.READ, () => {
-    console.info(`${LogHandler.READ} event received`)
+  ipcMain.handle(LogHandler.Read, () => {
+    console.info(`${LogHandler.Read} event received`)
     return getLogContent()
   })
 }

--- a/src/handlers/log/preload.ts
+++ b/src/handlers/log/preload.ts
@@ -5,13 +5,13 @@ import { createListener } from '../utils'
 import { LogHandler } from './types'
 
 export function openLogFolder() {
-  ipcRenderer.send(LogHandler.OPEN)
+  ipcRenderer.send(LogHandler.Open)
 }
 
 export function getLogContent() {
-  return ipcRenderer.invoke(LogHandler.READ) as Promise<string>
+  return ipcRenderer.invoke(LogHandler.Read) as Promise<string>
 }
 
 export function onLogChange(callback: (content: string) => void) {
-  return createListener(LogHandler.CHANGE, callback)
+  return createListener(LogHandler.Change, callback)
 }

--- a/src/handlers/log/types.ts
+++ b/src/handlers/log/types.ts
@@ -1,5 +1,5 @@
 export enum LogHandler {
-  OPEN = 'log:open',
-  READ = 'log:read',
-  CHANGE = 'log:change',
+  Open = 'log:open',
+  Read = 'log:read',
+  Change = 'log:change',
 }

--- a/src/handlers/ui/index.ts
+++ b/src/handlers/ui/index.ts
@@ -22,13 +22,13 @@ import { isNodeJsErrnoException } from '@/utils/typescript'
 import { UIHandler } from './types'
 
 export function initialize() {
-  ipcMain.on(UIHandler.TOGGLE_THEME, () => {
-    console.info(`${UIHandler.TOGGLE_THEME} event received`)
+  ipcMain.on(UIHandler.ToggleTheme, () => {
+    console.info(`${UIHandler.ToggleTheme} event received`)
     nativeTheme.themeSource = nativeTheme.shouldUseDarkColors ? 'light' : 'dark'
   })
 
-  ipcMain.handle(UIHandler.DETECT_BROWSER, async () => {
-    console.info(`${UIHandler.DETECT_BROWSER} event received`)
+  ipcMain.handle(UIHandler.DetectBrowser, async () => {
+    console.info(`${UIHandler.DetectBrowser} event received`)
     try {
       const browserPath = await getBrowserPath()
       return browserPath !== ''
@@ -39,27 +39,27 @@ export function initialize() {
     return false
   })
 
-  ipcMain.handle(UIHandler.DELETE_FILE, async (_, file: StudioFile) => {
-    console.info(`${UIHandler.DELETE_FILE} event received`)
+  ipcMain.handle(UIHandler.DeleteFile, async (_, file: StudioFile) => {
+    console.info(`${UIHandler.DeleteFile} event received`)
 
     const filePath = getFilePath(file)
     return unlink(filePath)
   })
 
-  ipcMain.on(UIHandler.OPEN_FOLDER, (_, file: StudioFile) => {
-    console.info(`${UIHandler.OPEN_FOLDER} event received`)
+  ipcMain.on(UIHandler.OpenFolder, (_, file: StudioFile) => {
+    console.info(`${UIHandler.OpenFolder} event received`)
     const filePath = getFilePath(file)
     return shell.showItemInFolder(filePath)
   })
 
-  ipcMain.handle(UIHandler.OPEN_FILE_IN_DEFAULT_APP, (_, file: StudioFile) => {
-    console.info(`${UIHandler.OPEN_FILE_IN_DEFAULT_APP} event received`)
+  ipcMain.handle(UIHandler.OpenFileInDefaultApp, (_, file: StudioFile) => {
+    console.info(`${UIHandler.OpenFileInDefaultApp} event received`)
     const filePath = getFilePath(file)
     return shell.openPath(filePath)
   })
 
-  ipcMain.handle(UIHandler.GET_FILES, async () => {
-    console.info(`${UIHandler.GET_FILES} event received`)
+  ipcMain.handle(UIHandler.GetFiles, async () => {
+    console.info(`${UIHandler.GetFiles} event received`)
     const recordings = (await readdir(RECORDINGS_PATH, { withFileTypes: true }))
       .filter((f) => f.isFile())
       .map((f) => getStudioFileFromPath(path.join(RECORDINGS_PATH, f.name)))
@@ -88,20 +88,20 @@ export function initialize() {
     }
   })
 
-  ipcMain.handle(UIHandler.REPORT_ISSUE, () => {
-    console.info(`${UIHandler.REPORT_ISSUE} event received`)
+  ipcMain.handle(UIHandler.ReportIssue, () => {
+    console.info(`${UIHandler.ReportIssue} event received`)
     return reportNewIssue()
   })
 
   ipcMain.handle(
-    UIHandler.RENAME_FILE,
+    UIHandler.RenameFile,
     async (
       e,
       oldFileName: string,
       newFileName: string,
       type: StudioFile['type']
     ) => {
-      console.info(`${UIHandler.RENAME_FILE} event received`)
+      console.info(`${UIHandler.RenameFile} event received`)
       const browserWindow = BrowserWindow.fromWebContents(e.sender)
 
       try {

--- a/src/handlers/ui/preload.ts
+++ b/src/handlers/ui/preload.ts
@@ -8,30 +8,30 @@ import { createListener } from '../utils'
 import { GetFilesResponse, UIHandler } from './types'
 
 export function toggleTheme() {
-  ipcRenderer.send(UIHandler.TOGGLE_THEME)
+  ipcRenderer.send(UIHandler.ToggleTheme)
 }
 
 export function detectBrowser() {
-  return ipcRenderer.invoke(UIHandler.DETECT_BROWSER) as Promise<boolean>
+  return ipcRenderer.invoke(UIHandler.DetectBrowser) as Promise<boolean>
 }
 
 export function openContainingFolder(file: StudioFile) {
-  ipcRenderer.send(UIHandler.OPEN_FOLDER, file)
+  ipcRenderer.send(UIHandler.OpenFolder, file)
 }
 
 export function openFileInDefaultApp(file: StudioFile) {
   return ipcRenderer.invoke(
-    UIHandler.OPEN_FILE_IN_DEFAULT_APP,
+    UIHandler.OpenFileInDefaultApp,
     file
   ) as Promise<string>
 }
 
 export function deleteFile(file: StudioFile) {
-  return ipcRenderer.invoke(UIHandler.DELETE_FILE, file) as Promise<void>
+  return ipcRenderer.invoke(UIHandler.DeleteFile, file) as Promise<void>
 }
 
 export function getFiles() {
-  return ipcRenderer.invoke(UIHandler.GET_FILES) as Promise<GetFilesResponse>
+  return ipcRenderer.invoke(UIHandler.GetFiles) as Promise<GetFilesResponse>
 }
 
 export function renameFile(
@@ -40,7 +40,7 @@ export function renameFile(
   type: StudioFile['type']
 ) {
   return ipcRenderer.invoke(
-    UIHandler.RENAME_FILE,
+    UIHandler.RenameFile,
     oldFileName,
     newFileName,
     type
@@ -48,17 +48,17 @@ export function renameFile(
 }
 
 export function reportIssue() {
-  return ipcRenderer.invoke(UIHandler.REPORT_ISSUE) as Promise<void>
+  return ipcRenderer.invoke(UIHandler.ReportIssue) as Promise<void>
 }
 
 export function onAddFile(callback: (file: StudioFile) => void) {
-  return createListener(UIHandler.ADD_FILE, callback)
+  return createListener(UIHandler.AddFile, callback)
 }
 
 export function onRemoveFile(callback: (file: StudioFile) => void) {
-  return createListener(UIHandler.REMOVE_FILE, callback)
+  return createListener(UIHandler.RemoveFile, callback)
 }
 
 export function onToast(callback: (toast: AddToastPayload) => void) {
-  return createListener(UIHandler.TOAST, callback)
+  return createListener(UIHandler.Toast, callback)
 }

--- a/src/handlers/ui/types.ts
+++ b/src/handlers/ui/types.ts
@@ -8,15 +8,15 @@ export interface GetFilesResponse {
 }
 
 export enum UIHandler {
-  TOGGLE_THEME = 'ui:toggle-theme',
-  DETECT_BROWSER = 'ui:detect-browser',
-  OPEN_FOLDER = 'ui:open-folder',
-  OPEN_FILE_IN_DEFAULT_APP = 'ui:open-file-in-default-app',
-  DELETE_FILE = 'ui:delete-file',
-  GET_FILES = 'ui:get-files',
-  RENAME_FILE = 'ui:rename-file',
-  REPORT_ISSUE = 'ui:report-issue',
-  ADD_FILE = 'ui:add-file',
-  REMOVE_FILE = 'ui:remove-file',
-  TOAST = 'ui:toast',
+  ToggleTheme = 'ui:toggle-theme',
+  DetectBrowser = 'ui:detect-browser',
+  OpenFolder = 'ui:open-folder',
+  OpenFileInDefaultApp = 'ui:open-file-in-default-app',
+  DeleteFile = 'ui:delete-file',
+  GetFiles = 'ui:get-files',
+  RenameFile = 'ui:rename-file',
+  ReportIssue = 'ui:report-issue',
+  AddFile = 'ui:add-file',
+  RemoveFile = 'ui:remove-file',
+  Toast = 'ui:toast',
 }

--- a/src/main/deepLinks.ts
+++ b/src/main/deepLinks.ts
@@ -33,7 +33,7 @@ function listenMacOsDeepLink() {
   })
 
   // Handle the case when the app is launched with a custom protocol link
-  ipcMain.on(AppHandler.SPLASHSCREEN_CLOSE, () => {
+  ipcMain.on(AppHandler.SplashscreenClose, () => {
     if (deepLinkUrl) {
       handleDeepLink(deepLinkUrl)
       deepLinkUrl = null
@@ -89,7 +89,7 @@ function handleDeepLink(url: string) {
 
   const path = parsedUrl.searchParams.get('path')
 
-  mainWindow.webContents.send(AppHandler.DEEP_LINK, path)
+  mainWindow.webContents.send(AppHandler.DeepLink, path)
 
   // Restore and focus the main window, needed for windows
   if (mainWindow.isMinimized()) {

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -27,7 +27,7 @@ export function configureWatcher(browserWindow: BrowserWindow) {
       return
     }
 
-    browserWindow.webContents.send(UIHandler.ADD_FILE, file)
+    browserWindow.webContents.send(UIHandler.AddFile, file)
   })
 
   k6StudioState.watcher.on('unlink', (filePath) => {
@@ -37,7 +37,7 @@ export function configureWatcher(browserWindow: BrowserWindow) {
       return
     }
 
-    browserWindow.webContents.send(UIHandler.REMOVE_FILE, file)
+    browserWindow.webContents.send(UIHandler.RemoveFile, file)
   })
 }
 

--- a/src/utils/electron.ts
+++ b/src/utils/electron.ts
@@ -44,7 +44,7 @@ export function getArch(): Arch {
  * Show a toast in React
  */
 export function sendToast(webContents: WebContents, toast: AddToastPayload) {
-  webContents.send(UIHandler.TOAST, toast)
+  webContents.send(UIHandler.Toast, toast)
 }
 
 export const findOpenPort = (startPort: number = 3000): Promise<number> => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR makes all enum members follow a consistent code style. Previously some used UPPER_CASE and others used PascalCase. After this PR, all members follow PascalCase.

The reasons for picking PascalCase over UPPER_CASE:

* Most of our enums already used PascalCase
* Follows the stylistic choice of the [TypeScript docs](https://www.typescriptlang.org/docs/handbook/enums.html)  

## How to Test

1. Check that the app works.

This is as straightforward as it can be. All the changes were made using Rename-refactor, so the behavior should not have changed.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
