### PR TITLE
fix(browser): Browser event drawer opens and closes when picking an element

### DIFF
--- a/extension/src/frontend/view/EventDrawer.tsx
+++ b/extension/src/frontend/view/EventDrawer.tsx
@@ -84,9 +84,10 @@ export function EventDrawer({ open, editing, onOpenChange }: EventDrawerProps) {
   return (
     <RecordingContext recording>
       <Dialog.Root modal={false} open={open} onOpenChange={onOpenChange}>
-        <Dialog.Portal container={container}>
+        <Dialog.Portal container={container} forceMount>
           <Dialog.Overlay />
           <Dialog.Content
+            forceMount
             css={css`
               position: fixed;
               top: 0;


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/767

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

## How to Test
- Start a new recording
- Open the event drawer
- Using the element inspector tool to pick an element on the page - the drawer should stay open without any flashing/sliding animation

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
