### PR TITLE
feat: Expand selection to parent elements when adding text assertions

### DIFF
--- a/extension/src/frontend/view/ElementInspector/ElementInspector.hooks.ts
+++ b/extension/src/frontend/view/ElementInspector/ElementInspector.hooks.ts
@@ -1,91 +1,12 @@
-import { last } from 'lodash-es'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
-import { ElementSelector } from '@/schemas/recording'
-import { uuid } from '@/utils/uuid'
-import { ElementRole, getElementRoles } from 'extension/src/utils/aria'
-
-import { generateSelectors } from '../../../selectors'
 import { useGlobalClass } from '../GlobalStyles'
 import { useHighlightDebounce } from '../hooks/useHighlightDebounce'
 import { usePreventClick } from '../hooks/usePreventClick'
 import { Bounds, Position } from '../types'
-import { getElementBounds } from '../utils'
 
-function* getAncestors(element: Element) {
-  let current: Element | null = element.parentElement
-
-  while (current !== null) {
-    yield current
-
-    if (current === document.documentElement) {
-      break
-    }
-
-    current = current.parentElement
-  }
-}
-
-function findLabelFor(label: HTMLLabelElement): Element | null {
-  const id = label.getAttribute('for')
-
-  if (id === null) {
-    return null
-  }
-
-  return document.getElementById(id)
-}
-
-function findInChildren(label: HTMLLabelElement): Element | null {
-  return label.querySelector('input, select, textarea')
-}
-
-function findLabelledBy(label: HTMLLabelElement): Element | null {
-  if (label.id === '') {
-    return null
-  }
-
-  return document.querySelector(`[aria-labelledby="${label.id}"]`)
-}
-
-export function findRelatedInput(element: Element): TrackedElement | null {
-  const label = [...getAncestors(element)].find(
-    (ancestor) => ancestor instanceof HTMLLabelElement
-  )
-
-  if (label === undefined) {
-    return null
-  }
-
-  const input =
-    findLabelFor(label) ?? findInChildren(label) ?? findLabelledBy(label)
-
-  if (input === null) {
-    return null
-  }
-
-  return toTrackedElement(input)
-}
-
-export interface TrackedElement {
-  id: string
-  roles: ElementRole[]
-  selector: ElementSelector
-  target: Element
-  bounds: Bounds
-}
-
-function toTrackedElement(element: Element): TrackedElement {
-  const roles = getElementRoles(element)
-
-  return {
-    id: uuid(),
-    roles: [...roles],
-    selector: generateSelectors(element),
-    target: element,
-    bounds: getElementBounds(element),
-  }
-}
+import { usePinnedElement } from './hooks'
+import { toTrackedElement, TrackedElement } from './utils'
 
 function isInsideBounds(
   position: Position,
@@ -118,8 +39,9 @@ export function useInspectedElement() {
    *    the selection and removed when the user contracts the selection. If the
    *    stack is empty, then no element is pinned.
    */
-  const [pinnedEl, setPinnedElement] = useState<TrackedElement[]>([])
   const [hoveredEl, setHoveredEl] = useState<TrackedElement | null>(null)
+
+  const { selected, pinned, pin, unpin, expand, contract } = usePinnedElement()
 
   useGlobalClass('inspecting')
 
@@ -155,14 +77,14 @@ export function useInspectedElement() {
     }
   }, [])
 
-  const unpin = useCallback(() => {
+  const reset = useCallback(() => {
     setMousePosition({
       top: 0,
       left: 0,
     })
 
-    setPinnedElement([])
-  }, [])
+    unpin()
+  }, [unpin])
 
   usePreventClick({
     callback: (ev) => {
@@ -170,8 +92,8 @@ export function useInspectedElement() {
         return
       }
 
-      if (pinnedEl.length > 0) {
-        unpin()
+      if (pinned !== null) {
+        reset()
 
         return
       }
@@ -191,53 +113,18 @@ export function useInspectedElement() {
       }
 
       setMousePosition(position)
-      setPinnedElement([hoveredEl])
+      pin(hoveredEl)
     },
-    dependencies: [pinnedEl, hoveredEl, unpin],
+    dependencies: [pinned, hoveredEl, unpin],
   })
-
-  const expand = useMemo(() => {
-    const [head] = pinnedEl
-
-    if (head === undefined) {
-      return undefined
-    }
-
-    const parent = head.target.parentElement
-
-    if (parent === null || parent === document.documentElement) {
-      return undefined
-    }
-
-    return () => {
-      setPinnedElement((pinned) => {
-        return [toTrackedElement(parent), ...pinned]
-      })
-    }
-  }, [pinnedEl])
-
-  const contract = useMemo(() => {
-    const [head, ...tail] = pinnedEl
-
-    // If head is undefined, that means no element is pinned. If tail is
-    // empty, that means we're back at the intial element. In either case
-    // we can't decrease the selection any further.
-    if (head === undefined || tail.length === 0) {
-      return undefined
-    }
-
-    return () => {
-      setPinnedElement(tail)
-    }
-  }, [pinnedEl])
 
   const highlightedEl = useHighlightDebounce(hoveredEl)
 
   return {
-    pinned: last(pinnedEl) ?? null,
-    element: pinnedEl[0] ?? highlightedEl,
+    pinned,
+    element: selected ?? highlightedEl,
     mousePosition,
-    unpin,
+    reset,
     expand,
     contract,
   }

--- a/extension/src/frontend/view/ElementInspector/ElementMenu.tsx
+++ b/extension/src/frontend/view/ElementInspector/ElementMenu.tsx
@@ -11,7 +11,6 @@ import { ComponentProps, ReactNode } from 'react'
 import { Toolbar } from '@/components/primitives/Toolbar'
 import { ElementRole } from 'extension/src/utils/aria'
 
-import { TrackedElement } from './ElementInspector.hooks'
 import {
   findAssociatedControl,
   getCheckedState,
@@ -20,6 +19,7 @@ import {
   getTextBoxValue,
 } from './ElementMenu.utils'
 import { AssertionData, CheckAssertionData } from './assertions/types'
+import { TrackedElement } from './utils'
 
 function ToolbarRoot(props: ComponentProps<typeof Toolbar.Root>) {
   return (

--- a/extension/src/frontend/view/ElementInspector/ElementMenu.utils.ts
+++ b/extension/src/frontend/view/ElementInspector/ElementMenu.utils.ts
@@ -3,8 +3,8 @@ import { generateSelectors } from 'extension/src/selectors'
 import { ElementRole, getElementRoles } from 'extension/src/utils/aria'
 import { findAssociatedElement } from 'extension/src/utils/dom'
 
-import { TrackedElement } from './ElementInspector.hooks'
 import { CheckAssertionData } from './assertions/types'
+import { TrackedElement } from './utils'
 
 function* getAncestors(element: Element) {
   let currentElement: Element | null = element

--- a/extension/src/frontend/view/ElementInspector/ElementPopover.tsx
+++ b/extension/src/frontend/view/ElementInspector/ElementPopover.tsx
@@ -1,7 +1,13 @@
 import { css } from '@emotion/react'
+import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react'
 import { ReactNode } from 'react'
 
+import { Flex } from '@/components/primitives/Flex'
+import { IconButton } from '@/components/primitives/IconButton'
 import { Popover } from '@/components/primitives/Popover'
+import { Tooltip } from '@/components/primitives/Tooltip'
+
+import { TrackedElement } from './utils'
 
 interface ElementPopoverProps {
   open?: boolean
@@ -47,14 +53,14 @@ export function ElementPopover({
 }
 
 interface PopoverHeadingProps {
+  className?: string
   children: ReactNode
 }
 
-ElementPopover.Heading = function PopoverHeading({
-  children,
-}: PopoverHeadingProps) {
+ElementPopover.Heading = function PopoverHeading(props: PopoverHeadingProps) {
   return (
     <h1
+      {...props}
       css={css`
         display: flex;
         align-self: stretch;
@@ -64,8 +70,40 @@ ElementPopover.Heading = function PopoverHeading({
         padding: var(--studio-spacing-1);
         font-size: var(--studio-font-size-1);
       `}
-    >
-      {children}
-    </h1>
+    />
+  )
+}
+
+interface ElementSelectorProps {
+  element: TrackedElement
+  onExpand?: () => void
+  onContract?: () => void
+}
+
+ElementPopover.Selector = function ElementSelector({
+  element,
+  onExpand,
+  onContract,
+}: ElementSelectorProps) {
+  return (
+    <Flex align="center" gap="1">
+      <Tooltip asChild content="Select parent element">
+        <IconButton disabled={onExpand === undefined} onClick={onExpand}>
+          <ChevronLeftIcon />
+        </IconButton>
+      </Tooltip>
+      <ElementPopover.Heading
+        css={css`
+          flex: 1 1 0;
+        `}
+      >
+        {element.selector.css}
+      </ElementPopover.Heading>
+      <Tooltip asChild content="Select child element">
+        <IconButton disabled={onContract === undefined} onClick={onContract}>
+          <ChevronRightIcon />
+        </IconButton>
+      </Tooltip>
+    </Flex>
   )
 }

--- a/extension/src/frontend/view/ElementInspector/assertions/TextAssertionEditor.tsx
+++ b/extension/src/frontend/view/ElementInspector/assertions/TextAssertionEditor.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react'
 import { ChangeEvent, useEffect, useId } from 'react'
 
 import { Flex } from '@/components/primitives/Flex'
-import { Input } from '@/components/primitives/Input'
 import { Label } from '@/components/primitives/Label'
 import { TextArea } from '@/components/primitives/TextArea'
 
@@ -13,7 +12,6 @@ import { TextAssertionData } from './types'
 
 interface TextAssertionEditorProps {
   assertion: TextAssertionData
-  canEditSelector?: boolean
   onCancel: () => void
   onChange: (assertion: TextAssertionData) => void
   onSubmit: (assertion: TextAssertionData) => void
@@ -21,12 +19,10 @@ interface TextAssertionEditorProps {
 
 export function TextAssertionEditor({
   assertion,
-  canEditSelector = false,
   onCancel,
   onChange,
   onSubmit,
 }: TextAssertionEditorProps) {
-  const selectorId = useId()
   const containsId = useId()
 
   useEffect(() => {
@@ -37,38 +33,6 @@ export function TextAssertionEditor({
       })
     }
   }, [])
-
-  const handleSelectorFocus = () => {
-    client.send({
-      type: 'highlight-elements',
-      selector: {
-        type: 'css',
-        selector: assertion.selector,
-      },
-    })
-  }
-
-  const handleSelectorBlur = () => {
-    client.send({
-      type: 'highlight-elements',
-      selector: null,
-    })
-  }
-
-  const handleSelectorChange = (ev: ChangeEvent<HTMLInputElement>) => {
-    client.send({
-      type: 'highlight-elements',
-      selector: {
-        type: 'css',
-        selector: ev.target.value,
-      },
-    })
-
-    onChange({
-      ...assertion,
-      selector: ev.target.value,
-    })
-  }
 
   const handleTextChange = (ev: ChangeEvent<HTMLTextAreaElement>) => {
     onChange({
@@ -83,21 +47,6 @@ export function TextAssertionEditor({
 
   return (
     <AssertionForm onCancel={onCancel} onSubmit={handleSubmit}>
-      {canEditSelector && (
-        <Flex direction="column" align="stretch" gap="1">
-          <Label htmlFor={selectorId} size="1">
-            Selector
-          </Label>
-          <Input
-            id={selectorId}
-            size="1"
-            value={assertion.selector}
-            onFocus={handleSelectorFocus}
-            onBlur={handleSelectorBlur}
-            onChange={handleSelectorChange}
-          />
-        </Flex>
-      )}
       <Flex direction="column" align="stretch" gap="1">
         <Label htmlFor={containsId} size="1">
           Assert that element contains text

--- a/extension/src/frontend/view/ElementInspector/hooks.ts
+++ b/extension/src/frontend/view/ElementInspector/hooks.ts
@@ -1,0 +1,85 @@
+import { last } from 'lodash-es'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { client } from '../../routing'
+
+import { toTrackedElement, TrackedElement } from './utils'
+
+export function usePinnedElement(element?: TrackedElement | undefined) {
+  const [elements, setElements] = useState<TrackedElement[]>(
+    element !== undefined ? [element] : []
+  )
+
+  const pin = useCallback((element: TrackedElement) => {
+    setElements([element])
+  }, [])
+
+  const unpin = useCallback(() => {
+    setElements([])
+  }, [])
+
+  const expand = useMemo(() => {
+    const [head] = elements
+
+    if (head === undefined) {
+      return undefined
+    }
+
+    const parent = head.target.parentElement
+
+    if (parent === null || parent === document.documentElement) {
+      return undefined
+    }
+
+    return () => {
+      setElements((pinned) => {
+        return [toTrackedElement(parent), ...pinned]
+      })
+    }
+  }, [elements])
+
+  const contract = useMemo(() => {
+    const [head, ...tail] = elements
+
+    // If head is undefined, that means no element is pinned. If tail is
+    // empty, that means we're back at the intial element. In either case
+    // we can't decrease the selection any further.
+    if (head === undefined || tail.length === 0) {
+      return undefined
+    }
+
+    return () => {
+      setElements(tail)
+    }
+  }, [elements])
+
+  return {
+    pinned: last(elements) ?? null,
+    selected: elements[0] ?? null,
+    pin,
+    unpin,
+    expand,
+    contract,
+  }
+}
+
+export function useElementHighlight(element: TrackedElement | null) {
+  useEffect(() => {
+    client.send({
+      type: 'highlight-elements',
+      selector: element && {
+        type: 'css',
+        selector: element.selector.css,
+      },
+    })
+  }, [element])
+
+  useEffect(() => {
+    return () => {
+      client.send({
+        type: 'highlight-elements',
+        selector: null,
+      })
+    }
+  }, [])
+}

--- a/extension/src/frontend/view/ElementInspector/utils.ts
+++ b/extension/src/frontend/view/ElementInspector/utils.ts
@@ -1,0 +1,27 @@
+import { ElementSelector } from '@/schemas/recording'
+import { uuid } from '@/utils/uuid'
+import { ElementRole, getElementRoles } from 'extension/src/utils/aria'
+
+import { generateSelectors } from '../../../selectors'
+import { Bounds } from '../types'
+import { getElementBounds } from '../utils'
+
+export interface TrackedElement {
+  id: string
+  roles: ElementRole[]
+  selector: ElementSelector
+  target: Element
+  bounds: Bounds
+}
+
+export function toTrackedElement(element: Element): TrackedElement {
+  const roles = getElementRoles(element)
+
+  return {
+    id: uuid(),
+    roles: [...roles],
+    selector: generateSelectors(element),
+    target: element,
+    bounds: getElementBounds(element),
+  }
+}

--- a/extension/src/frontend/view/TextSelectionPopover.hooks.ts
+++ b/extension/src/frontend/view/TextSelectionPopover.hooks.ts
@@ -1,8 +1,8 @@
 import { useRef, useState, useEffect } from 'react'
 
 import { useContainerElement } from '@/components/primitives/ContainerProvider'
-import { generateSelectors } from 'extension/src/selectors'
 
+import { toTrackedElement } from './ElementInspector/utils'
 import { TextSelection } from './TextSelectionPopover.types'
 import { getElementBounds, toBounds } from './utils'
 
@@ -79,7 +79,7 @@ export function useTextSelection() {
 
       setSelection({
         text: range.toString(),
-        selector: generateSelectors(commonAncestor),
+        element: toTrackedElement(commonAncestor),
         range,
         ...measureRange(range),
       })

--- a/extension/src/frontend/view/TextSelectionPopover.tsx
+++ b/extension/src/frontend/view/TextSelectionPopover.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { uuid } from '@/utils/uuid'
 
@@ -8,6 +8,7 @@ import { client } from '../routing'
 import { ElementPopover } from './ElementInspector/ElementPopover'
 import { TextAssertionEditor } from './ElementInspector/assertions/TextAssertionEditor'
 import { TextAssertionData } from './ElementInspector/assertions/types'
+import { useElementHighlight, usePinnedElement } from './ElementInspector/hooks'
 import { useGlobalClass } from './GlobalStyles'
 import { Overlay } from './Overlay'
 import { useTextSelection } from './TextSelectionPopover.hooks'
@@ -26,27 +27,28 @@ function TextSelectionPopoverContent({
   onAdd,
   onClose,
 }: TextSelectionPopoverContentProps) {
+  const { selected, expand, contract } = usePinnedElement(selection.element)
+
   const [assertion, setAssertion] = useState<TextAssertionData>({
     type: 'text',
-    selector: selection.selector.css,
+    selector: selection.element.selector.css,
     text: selection.text,
   })
 
-  useEffect(() => {
-    return () => {
-      client.send({
-        type: 'highlight-elements',
-        selector: null,
-      })
-    }
-  }, [])
+  const targetElement = selected ?? selection.element
+
+  useElementHighlight(targetElement)
 
   const handleChange = (assertion: TextAssertionData) => {
     setAssertion(assertion)
   }
 
   const handleSubmit = (assertion: TextAssertionData) => {
-    onAdd(assertion)
+    onAdd({
+      ...assertion,
+      selector: targetElement.selector.css,
+    })
+
     onClose()
   }
 
@@ -54,11 +56,16 @@ function TextSelectionPopoverContent({
     <ElementPopover
       open
       anchor={<Overlay bounds={selection.bounds} />}
-      header="Add text assertion"
+      header={
+        <ElementPopover.Selector
+          element={targetElement}
+          onExpand={expand}
+          onContract={contract}
+        />
+      }
       onOpenChange={onClose}
     >
       <TextAssertionEditor
-        canEditSelector
         assertion={assertion}
         onCancel={onClose}
         onChange={handleChange}

--- a/extension/src/frontend/view/TextSelectionPopover.types.ts
+++ b/extension/src/frontend/view/TextSelectionPopover.types.ts
@@ -1,10 +1,9 @@
-import { ElementSelector } from '@/schemas/recording'
-
+import { TrackedElement } from './ElementInspector/utils'
 import { Bounds } from './types'
 
 export interface TextSelection {
   text: string
-  selector: ElementSelector
+  element: TrackedElement
   range: Range
   bounds: Bounds
   highlights: Bounds[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Before this PR, the text selection popover allowed users to type an arbitrary CSS selector. Now the popover uses the same element selector as the menu when picking elements. This makes more sense, since the text input would allow you to select elements which will never contain the selected text.

The reason for this change is to be able to generate `getBy` selectors when adding assertions. Allowing arbitrary input makes this near impossible.

### Before

https://github.com/user-attachments/assets/8961f820-7c98-427a-ab09-989bcf2a5d9c

### After

https://github.com/user-attachments/assets/25e98865-05ad-466b-a51d-2f2913b0b734

## How to Test

1. Start a recording
2. Select text selection tool and highlight some text
3. Use the left/right buttons in the popover header to expand and contract the selection.
4. Select the element picker tool and pick an element
5. Use the left/right buttons in the popover header to expand and contract the selection.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

BEGIN_COMMIT_OVERRIDE
feat(browser): Expand selection to parent elements when adding text assertions
END_COMMIT_OVERRIDE

