### PR TITLE
fix: discrepancy with chrome handling of whitespace in header

### DIFF
--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -66,6 +66,8 @@ export const launchProxy = (
     `${proxySettings.port}`,
     '--mode',
     getProxyMode(proxySettings),
+    '--set',
+    'validate_inbound_headers=false',
   ]
 
   if (proxySettings.sslInsecure) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

Disable the `validate_inbound_headers` option in the proxy, it should protect from request smuggling but it shouldn't be an issue for the majority of our use cases. It causes issues when receiving whitespace in headers.

issue:
- https://github.com/grafana/k6-studio/issues/887

reference:
- https://github.com/mitmproxy/mitmproxy/issues/4836#issuecomment-1073043912
- https://github.com/mitmproxy/mitmproxy/issues/5480


## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
