### PR TITLE
internal: Don't track script_validated event when validation is triggered automatically 

### DIFF
--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -71,7 +71,6 @@ export function initialize() {
     trackEvent({
       event: UsageEventName.ScriptValidated,
       payload: {
-        source: 'debugger',
         isExternal: isExternalScript(resolvedScriptPath),
       },
     })
@@ -93,11 +92,7 @@ export function initialize() {
 
   ipcMain.handle(
     ScriptHandler.RunFromGenerator,
-    async (
-      event,
-      script: string,
-      source: 'generator' | 'autocorrelation' = 'generator'
-    ) => {
+    async (event, script: string, shouldTrack = true) => {
       console.info(`${ScriptHandler.RunFromGenerator} event received`)
       await writeFile(TEMP_GENERATOR_SCRIPT_PATH, script)
 
@@ -110,13 +105,14 @@ export function initialize() {
         usageReport: k6StudioState.appSettings.telemetry.usageReport,
       })
 
-      trackEvent({
-        event: UsageEventName.ScriptValidated,
-        payload: {
-          source,
-          isExternal: false,
-        },
-      })
+      if (shouldTrack) {
+        trackEvent({
+          event: UsageEventName.ScriptValidated,
+          payload: {
+            isExternal: false,
+          },
+        })
+      }
 
       await unlink(TEMP_GENERATOR_SCRIPT_PATH)
     }

--- a/src/handlers/script/preload.ts
+++ b/src/handlers/script/preload.ts
@@ -17,14 +17,11 @@ export function openScript(scriptPath: string) {
   ) as Promise<OpenScriptResult>
 }
 
-export function runScriptFromGenerator(
-  script: string,
-  source: 'generator' | 'autocorrelation' = 'generator'
-) {
+export function runScriptFromGenerator(script: string, shouldTrack = true) {
   return ipcRenderer.invoke(
     ScriptHandler.RunFromGenerator,
     script,
-    source
+    shouldTrack
   ) as Promise<void>
 }
 

--- a/src/services/usageTracking/types.ts
+++ b/src/services/usageTracking/types.ts
@@ -84,7 +84,6 @@ interface ScriptExportedEvent {
 interface ScriptValidatedEvent {
   event: UsageEventName.ScriptValidated
   payload: {
-    source: 'generator' | 'debugger' | 'autocorrelation'
     isExternal: boolean
   }
 }

--- a/src/utils/validateScript.ts
+++ b/src/utils/validateScript.ts
@@ -8,7 +8,7 @@ import { processProxyData } from './proxyData'
 export async function validateScript(
   script: string,
   signal?: AbortSignal,
-  source?: 'generator' | 'autocorrelation'
+  shouldTrack = true
 ): Promise<ProxyData[]> {
   let collectedData: ProxyData[] = []
 
@@ -53,7 +53,7 @@ export async function validateScript(
 
     // Run the script
     window.studio.script
-      .runScriptFromGenerator(script, source)
+      .runScriptFromGenerator(script, shouldTrack)
       .catch((error) => {
         cleanup()
         reject(error)

--- a/src/views/Generator/AutoCorrelation/useGenerateRules.ts
+++ b/src/views/Generator/AutoCorrelation/useGenerateRules.ts
@@ -150,7 +150,8 @@ export const useGenerateRules = ({
 
     const validationResult = await validateScript(
       script,
-      abortControllerRef.current?.signal
+      abortControllerRef.current?.signal,
+      false
     )
 
     const result = validationMatchesRecording(recording, validationResult)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR makes it possible to opt out of tracking the `script_validated` event in the `validateScript` function, so that the event won't be tracked when validation runs are triggered automatically in the autocorrelation dialog (i.e. not by the user).

## How to Test
- Run autocorrelation
- Check that `script_validated` is not logged in the console

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
