### PR TITLE
chore: Don't allow to use basic-text encryption on linux

### DIFF
--- a/src/main/encryption.ts
+++ b/src/main/encryption.ts
@@ -11,5 +11,15 @@ export function decryptString(encrypted: string): string {
 }
 
 export function isEncryptionAvailable(): boolean {
-  return safeStorage.isEncryptionAvailable()
+  const isEncryptionAvailable = safeStorage.isEncryptionAvailable()
+
+  if (process.platform === 'linux') {
+    return isEncryptionAvailable && isLinuxEncryptionSecure()
+  }
+
+  return isEncryptionAvailable
+}
+
+function isLinuxEncryptionSecure() {
+  return safeStorage.getSelectedStorageBackend() !== 'basic_text'
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Electron's safeStorage will fallback to `basic-text` when no other encryption backend is available on the system. This change prevents this and will not allow using unsafe encryption.

## How to Test

No way to test without spinning up a linux system, I trust the electron's [documentation](https://www.electronjs.org/docs/latest/api/safe-storage) on this
## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
