### PR TITLE
fix: Border can be seen though Sidebar expand button

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -48,9 +48,13 @@ export function Layout() {
           css={css`
             position: absolute;
             top: var(--space-4);
-            left: 64px;
-            transform: translateX(-50%);
+            left: calc(64px - var(--space-2));
+            background-color: var(--color-background);
             z-index: 10000;
+
+            &:hover {
+              background-color: var(--accent-3);
+            }
           `}
         >
           <PanelLeftOpenIcon />


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/356

## Description
A small fix borrowed from [this PR](https://github.com/grafana/k6-studio/pull/847/changes) that was created by @allansson, but closed for reasons unrelated to this specific issue.

Before:
<img width="100" height="127" alt="grafik" src="https://github.com/user-attachments/assets/bb73d816-fe5b-4906-9d66-53ebdddf2f71" />


After:
<img width="102" height="132" alt="grafik" src="https://github.com/user-attachments/assets/a19a9577-e34f-4c8e-8475-b107ccd1ed21" />


## How to Test
Verify that the button works as expected

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
