### PR TITLE
internal: Prevent autocorrelation dialog closing by clicking outside

### DIFF
--- a/src/views/Generator/AutoCorrelation/AutoCorrelationDialog.tsx
+++ b/src/views/Generator/AutoCorrelation/AutoCorrelationDialog.tsx
@@ -36,6 +36,8 @@ export function AutoCorrelationDialog({
         asChild
         width="calc(100vw - 100px)"
         height="calc(100vh - 100px)"
+        // Prevent closing the dialog when clicking outside
+        onInteractOutside={(e) => e.preventDefault()}
       >
         <Flex direction="column" height="100%">
           <Dialog.Title>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->
The autocorrelation process can take some time, and it's easy to accidentally close the modal by clicking outside of it, losing your progress. In the future, we might explore options like preserving dialog state or allowing it to run in background, meantime adding a simple fix to disable modal closing when clicking outside of it.

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
