### PR TITLE
fix: App becomes unusable if Documents access is revoked

### DIFF
--- a/src/main/permissions.ts
+++ b/src/main/permissions.ts
@@ -1,0 +1,96 @@
+import { app, dialog, shell } from 'electron'
+import log from 'electron-log/main'
+import { readdirSync } from 'fs'
+
+import { getPlatform } from '@/utils/electron'
+import { exhaustive, isNodeJsErrnoException } from '@/utils/typescript'
+
+export function checkDocumentsAccess(): 'granted' | 'denied' | 'unknown' {
+  const docsPath = app.getPath('documents')
+
+  try {
+    readdirSync(docsPath)
+    return 'granted'
+  } catch (error) {
+    if (
+      isNodeJsErrnoException(error) &&
+      (error.code === 'EPERM' || error.code === 'EACCES')
+    ) {
+      return 'denied'
+    }
+
+    log.error('Unexpected error while checking Documents access:', error)
+    return 'unknown'
+  }
+}
+
+async function openPermissionsSettings() {
+  const platform = getPlatform()
+  switch (platform) {
+    case 'mac':
+      await shell.openExternal(
+        'x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders'
+      )
+      break
+    case 'win':
+      await shell.openExternal('ms-settings:privacy-documents')
+      break
+    case 'linux':
+      await dialog.showMessageBox({
+        type: 'info',
+        title: 'Open System Settings',
+        message: 'Open your system settings manually.',
+        detail:
+          'Look for Privacy or Permissions settings and grant file access to Grafana k6 Studio.',
+      })
+      break
+    default:
+      exhaustive(platform)
+  }
+}
+
+export async function verifyDocumentsAccess(): Promise<boolean> {
+  const accessStatus = checkDocumentsAccess()
+  const platform = getPlatform()
+
+  // Only show our custom dialog if access was explicitly denied
+  // If it's 'unknown', let the OS handle the permission prompt naturally
+  if (accessStatus === 'denied') {
+    let detailMessage = ''
+    switch (platform) {
+      case 'mac':
+        detailMessage =
+          'Grant Documents folder access in System Settings → Privacy & Security → Files and Folders.'
+        break
+      case 'win':
+        detailMessage =
+          'Grant file system access in Settings → Privacy → File system.'
+        break
+      case 'linux':
+        detailMessage = 'Grant file access permissions in your system settings.'
+        break
+      default:
+        exhaustive(platform)
+    }
+
+    const response = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Documents Folder Access Required',
+      message:
+        'Grafana k6 Studio needs access to your Documents folder to store files.',
+      detail: detailMessage,
+      buttons: ['Open System Settings', 'Quit'],
+      defaultId: 0,
+      cancelId: 1,
+    })
+
+    if (response.response === 0) {
+      await openPermissionsSettings()
+    }
+
+    return false
+  }
+
+  // If access is granted or unknown (OS will handle), return true
+  return true
+}

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'fs'
 import { mkdir } from 'fs/promises'
 import path from 'path'
 
+import { verifyDocumentsAccess } from '@/main/permissions'
+
 import {
   DATA_FILES_PATH,
   PROJECT_PATH,
@@ -12,6 +14,11 @@ import {
 } from '../constants/workspace'
 
 export const setupProjectStructure = async () => {
+  const hasAccess = await verifyDocumentsAccess()
+  if (!hasAccess) {
+    throw new Error('Documents folder access denied')
+  }
+
   if (!existsSync(PROJECT_PATH)) {
     await mkdir(PROJECT_PATH)
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<img width="372" height="412" alt="grafik" src="https://github.com/user-attachments/assets/8c2fc7c1-a6e6-4698-8c35-a538ea33beed" />


<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

## How to Test
- On Mac, go to `System Settings -> Privacy & Security -> Files & Folders`, look for your terminal* and revoke its access to the Documents folder
- `npm start`
- You should see the dialog from the screenshot - the button should open System Settings, where you should be able to grant the access again, at which point you'll be notified that the app needs a restart
- Once restarted, you should see you files as expected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
