### PR TITLE
internal(fix): Console drawer in browser debugger is not scrollable

### DIFF
--- a/src/views/Validator/Browser/BrowserDebugDrawer.tsx
+++ b/src/views/Validator/Browser/BrowserDebugDrawer.tsx
@@ -17,6 +17,7 @@ function TabContent({
         css={css`
           flex: 1 1 0;
         `}
+        overflow="hidden"
         align="stretch"
         direction="column"
       >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The console tab in the browser debugger is not scrollable.

## How to Test

1. Write a browser script that logs a bunch of lines to the console
2. Debug the script

The console drawer should be scrollable.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
