### PR TITLE
docs: Correct link to Code of Conduct in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Grafana k6 Studio
 
-Thank you for your interest in contributing to Grafana k6 Studio! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+Thank you for your interest in contributing to Grafana k6 Studio! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 If you want to chat with the team or the community, you can [join our community forums](https://community.grafana.com/c/grafana-k6/k6-studio/)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The link in [CONTRIBUTING.md](https://github.com/grafana/k6-studio/blob/8fbfc91481a574d860cdb49e5b3e525e7a700bfe/CONTRIBUTING.md) to Code Of Conduct documentation ([CODE_OF_CONDUCT.md](https://github.com/grafana/k6-studio/blob/8fbfc91481a574d860cdb49e5b3e525e7a700bfe/CODE_OF_CONDUCT.md)) lead to a "404 not found" page.

I changed the link to not contain the intermediate ".github/" subdirectory, the link now works as intended.

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6-studio/issues/970

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
