### PR TITLE
fix: close websocket server when browser recording exits

### DIFF
--- a/src/handlers/browser/recorders/extension.ts
+++ b/src/handlers/browser/recorders/extension.ts
@@ -33,6 +33,13 @@ class BrowserExtensionRecordingSession
 
     process.once('exit', () => {
       this.emit('stop', undefined)
+      // Ensure the WebSocket server is disposed when the browser exits
+      this.#server.stop()
+    })
+
+    this.#process.on('error', (error) => {
+      this.emit('error', { error })
+      this.#server.stop()
     })
 
     server.on('stop', () => {


### PR DESCRIPTION
## Description
In the extension recorder, the process exit function does not stop the Browser Server, so the WebSocket server remains bound even after the browser closes.
The server is only stopped when it emits a stop event via recording stopping, but it is not stopped on process exit or browser errors along this path.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Resolves #984 

<!-- Thanks for your contribution! 🙏🏼 -->
