### PR TITLE
ci: Disable dependency pinning in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":preserveSemverRanges"],
   "packageRules": [
     {
       // This will get stuck forever in the minimumReleaseAge check because


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have a [PR](https://github.com/grafana/k6-studio/pull/912) up to pin all the dependencies in `package.json`. After some internal discussion we decided that we don't see the need to do so in this project.

## How to Test

Not really much to test. We need to merge this and then close renovate's PR. If it works, renovate shouldn't open the PR again.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
