### PR TITLE
fix: Ipv6 binding error on windows

### DIFF
--- a/extension/src/background/routing.ts
+++ b/extension/src/background/routing.ts
@@ -9,7 +9,7 @@ const frontend = new BrowserExtensionClient('frontend', new PortTransport())
 
 const studio = new BrowserExtensionClient(
   'studio',
-  new BufferedTransport(new WebSocketTransport('ws://localhost:7554'))
+  new BufferedTransport(new WebSocketTransport('ws://127.0.0.1:7554'))
 )
 
 background.forward('events-recorded', [studio, frontend])

--- a/extension/src/cdp/routing.ts
+++ b/extension/src/cdp/routing.ts
@@ -6,7 +6,7 @@ const frontend = new BrowserExtensionClient('frontend')
 
 const studio = new BrowserExtensionClient(
   'recorder',
-  new BufferedTransport(new WebSocketTransport('ws://localhost:7554'))
+  new BufferedTransport(new WebSocketTransport('ws://127.0.0.1:7554'))
 )
 
 frontend.forward('record-events', [studio])

--- a/src/services/browser/server.ts
+++ b/src/services/browser/server.ts
@@ -25,7 +25,7 @@ export class BrowserServer extends EventEmitter<BrowserExtensionServerEvents> {
   #settings = new Map<string, InBrowserSettings>()
 
   static async start() {
-    const transport = await WebSocketServerTransport.create('localhost', 7554)
+    const transport = await WebSocketServerTransport.create('127.0.0.1', 7554)
 
     return new BrowserServer(
       new BrowserExtensionClient('studio-server', transport)


### PR DESCRIPTION
## Description
On some Windows machines, the system picks IPv6 (::1) by default, which can cause permission errors or binding failures.
the error I got randomly:
`listen EACCES ::1:7554`
https://github.com/grafana/k6-studio/pull/985#issuecomment-3738315620

> on windows OS whenever you write localhost, the system can resolve it to either:
> 1. IPv4: 127.0.0.1 (older, simpler)
> 2.  IPv6: ::1 (newer, but sometimes causes issues on Windows)

This pull request aims to standardize the hostname to 127.0.0.1 (IPV4 format) to avoid any strange windows OS issues

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have tested my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Compliments this merged PR #985 and this issue #984
