### PR TITLE
ci: Configure renovate to only upgrade packages with security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [":preserveSemverRanges"],
+  "extends": [":preserveSemverRanges", "security:only-security-updates"],
   "packageRules": [
     {
       // This will get stuck forever in the minimumReleaseAge check because


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Renovate is wreaking havoc on our repository, creating PR:s to upgrade every little dependency. This PR (attempts) to configure renovate so that it only creates PR:s for security updates.

## How to Test

Approve, merge and see what happens.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
