### PR TITLE
internal(fix): Session replay does not work in production builds

### DIFF
--- a/vite.script.config.ts
+++ b/vite.script.config.ts
@@ -9,6 +9,7 @@ export default defineConfig((env) => {
     mode: env.mode,
     build: {
       sourcemap: false,
+      minify: false,
       target: 'esnext',
       lib: {
         entry: 'src/main/runner/entrypoint.ts',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Session replay doesn't work in production builds. This is because the variable names in the entrypoint script are mangled during minification and we rely on there being a specific variable called `SESSION_REPLAY_SCRIPT` where we inject the script to be loaded into the browser.

## How to Test

1. Run `npm run make`
2. Check that the `resources/entrypoint.js` script contains a variable called `SESSION_REPLAY_SCRIPT` and that its value is an empty string.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
