### PR TITLE
style: Remove application menu

### DIFF
--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,64 +1,9 @@
-import { Menu, shell } from 'electron'
+import { Menu } from 'electron'
 
-import { reportNewIssue } from '../utils/bugReport'
 import { getPlatform } from '../utils/electron'
 
-import { openLogFolder } from './logger'
-
-const isDevEnv = process.env.NODE_ENV === 'development'
-const isMac = getPlatform() === 'mac'
-
-// Custom application menu
-// https://www.electronjs.org/docs/latest/api/menu
-const template: Electron.MenuItemConstructorOptions[] = [
-  ...getAppMenu(),
-  { role: 'fileMenu' },
-  { role: 'editMenu' },
-  {
-    label: 'View',
-    submenu: [
-      ...getDevToolsMenu(),
-      { type: 'separator' },
-      { role: 'resetZoom' },
-      { role: 'zoomIn' },
-      { role: 'zoomOut' },
-      { type: 'separator' },
-      { role: 'togglefullscreen' },
-    ],
-  },
-  { role: 'windowMenu' },
-  {
-    role: 'help',
-    submenu: [
-      {
-        label: 'Documentation',
-        click: async () => {
-          await shell.openExternal('https://grafana.com/docs/k6-studio/')
-        },
-      },
-      {
-        label: 'Report an issue',
-        click: reportNewIssue,
-      },
-      {
-        label: 'Application logs',
-        click: () => openLogFolder(),
-      },
-    ],
-  },
-]
-
-function getAppMenu(): Electron.MenuItemConstructorOptions[] {
-  return isMac ? [{ role: 'appMenu' }] : []
-}
-
-function getDevToolsMenu(): Electron.MenuItemConstructorOptions[] {
-  return isDevEnv
-    ? [{ role: 'reload' }, { role: 'forceReload' }, { role: 'toggleDevTools' }]
-    : []
-}
-
 export function configureApplicationMenu() {
-  const menu = Menu.buildFromTemplate(template)
+  const isMac = getPlatform() === 'mac'
+  const menu = Menu.buildFromTemplate(isMac ? [{ role: 'appMenu' }] : [])
   Menu.setApplicationMenu(menu)
 }


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/326 as "not planned"
Closes https://github.com/grafana/k6-studio/issues/889 as "not planned"

## Description
This is small improvement for Windows and Linux, where the application menu is located inside the application window. We don't really use the application menu (except for some items in the Help menu, which are also present in the UI), so it doesn't provide much value.

Before:
<img width="1400" height="795" alt="image" src="https://github.com/user-attachments/assets/0207ba5a-e597-49d6-b697-3a02b5258637" />

After:
<img width="1400" height="799" alt="image" src="https://github.com/user-attachments/assets/44a329fc-1fe0-469b-914b-11c03128133a" />

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
