### PR TITLE
fix: Response is never sent when logs are sent from a browser test

### DIFF
--- a/src/utils/k6/tracking.ts
+++ b/src/utils/k6/tracking.ts
@@ -84,14 +84,14 @@ export async function createTrackingServer(): Promise<TestRunTrackingServer> {
     if (!parsed.success) {
       log.warn('Received invalid begin action event: ', parsed.error.format())
 
-      res.status(400).end()
+      res.status(400).send()
 
       return
     }
 
     trackingServer.emit('begin', parsed.data)
 
-    res.status(204).end()
+    res.status(204).send()
   })
 
   app.post('/track/:id/end', (req, res) => {
@@ -100,14 +100,14 @@ export async function createTrackingServer(): Promise<TestRunTrackingServer> {
     if (!parsed.success) {
       log.warn('Received invalid end action event: ', parsed.error.format())
 
-      res.status(400).end()
+      res.status(400).send()
 
       return
     }
 
     trackingServer.emit('end', parsed.data)
 
-    res.status(204).end()
+    res.status(204).send()
   })
 
   app.post('/log', (req, res) => {
@@ -116,12 +116,14 @@ export async function createTrackingServer(): Promise<TestRunTrackingServer> {
     if (!parsed.success) {
       log.warn('Received invalid log entry: ', parsed.error.format())
 
-      res.status(400).end()
+      res.status(400).send()
 
       return
     }
 
     trackingServer.emit('log', { entry: parsed.data })
+
+    res.status(204).send()
   })
 
   app.post('/session-replay', (req, res) => {
@@ -130,7 +132,7 @@ export async function createTrackingServer(): Promise<TestRunTrackingServer> {
     if (!parsed.success) {
       log.warn('Received invalid session replay event: ', parsed.error.format())
 
-      res.status(400).end()
+      res.status(400).send()
 
       return
     }
@@ -139,7 +141,7 @@ export async function createTrackingServer(): Promise<TestRunTrackingServer> {
       events: parsed.data.events,
     })
 
-    res.status(204).end()
+    res.status(204).send()
   })
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a missing `.send()` call in the `/logs` route of the tracking server used by the browser debugger. It also changes any calls to `.end()` to `.send()` for consistency.

## How to Test

1. Record a page that logs messages to the console
2. Export a script
3. Run the script

You should see logs from the browser appear in the console of the debugger.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
