### PR TITLE
build: Use `bundler` and `esnext` for module resolution

### DIFF
--- a/extension/src/frontend/view/ToolBox/index.tsx
+++ b/extension/src/frontend/view/ToolBox/index.tsx
@@ -163,34 +163,31 @@ export function ToolBox({
             </Toolbar.ToggleItem>
           </ToolBoxTooltip>
         </Toolbar.ToggleGroup>
-        {
-          // @ts-expect-error we have commonjs set as module option
-          import.meta.env.DEV && (
-            <>
-              <Toolbar.Separator />
-              <ToolBoxTooltip content="Reload extension (dev only)">
-                <Toolbar.Button
-                  onClick={() => {
-                    client.send({
-                      type: 'reload-extension',
-                    })
+        {import.meta.env.DEV && (
+          <>
+            <Toolbar.Separator />
+            <ToolBoxTooltip content="Reload extension (dev only)">
+              <Toolbar.Button
+                onClick={() => {
+                  client.send({
+                    type: 'reload-extension',
+                  })
 
-                    setTimeout(() => {
-                      window.location.reload()
-                    }, 500)
-                  }}
-                >
-                  <RotateCcwIcon
-                    css={css`
-                      stroke-width: 2px !important;
-                      color: var(--red-10);
-                    `}
-                  />
-                </Toolbar.Button>
-              </ToolBoxTooltip>
-            </>
-          )
-        }
+                  setTimeout(() => {
+                    window.location.reload()
+                  }, 500)
+                }}
+              >
+                <RotateCcwIcon
+                  css={css`
+                    stroke-width: 2px !important;
+                    color: var(--red-10);
+                  `}
+                />
+              </Toolbar.Button>
+            </ToolBoxTooltip>
+          </>
+        )}
       </ToolBoxRoot>
     </DndContext>
   )

--- a/src/components/CodeSnippet.tsx
+++ b/src/components/CodeSnippet.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@radix-ui/themes'
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'
+import type * as monaco from 'monaco-editor'
 import { useMemo } from 'react'
 
 import { ReadOnlyEditor } from './Monaco/ReadOnlyEditor'

--- a/src/components/DevToolsDialog.tsx
+++ b/src/components/DevToolsDialog.tsx
@@ -50,5 +50,4 @@ function ProdModeDialog() {
 }
 
 export const DevToolsDialog =
-  // @ts-expect-error we have commonjs set as module option
   import.meta.env.MODE === 'development' ? DevModeDialog : ProdModeDialog

--- a/src/components/Monaco/ConstrainedCodeEditor.tsx
+++ b/src/components/Monaco/ConstrainedCodeEditor.tsx
@@ -4,7 +4,7 @@ import constrainedEditor, {
   ConstrainedEditorInstance,
   RestrictionObject,
 } from 'constrained-editor-plugin'
-import * as monacoTypes from 'monaco-editor/esm/vs/editor/editor.api'
+import type * as monacoTypes from 'monaco-editor'
 import { useEffect, useRef, useState } from 'react'
 
 import { ReactMonacoEditor } from './ReactMonacoEditor'

--- a/src/components/SearchField.tsx
+++ b/src/components/SearchField.tsx
@@ -1,5 +1,4 @@
 import { IconButton, TextField } from '@radix-ui/themes'
-import { RootProps } from '@radix-ui/themes/dist/cjs/components/text-field'
 import { SearchIcon, XIcon } from 'lucide-react'
 import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
 
@@ -8,7 +7,7 @@ export interface SearchFieldHandle {
   clear(): void
 }
 
-type SearchFieldProps = Omit<RootProps, 'onChange'> & {
+type SearchFieldProps = Omit<TextField.RootProps, 'onChange'> & {
   filter: string
   onChange: (filter: string) => void
   children?: React.ReactNode

--- a/src/components/WebLogView/Filter.tsx
+++ b/src/components/WebLogView/Filter.tsx
@@ -1,5 +1,4 @@
 import { IconButton, TextField, Tooltip } from '@radix-ui/themes'
-import { RootProps } from '@radix-ui/themes/dist/cjs/components/text-field'
 import { CodeXmlIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { useKeyPressEvent } from 'react-use'
@@ -13,7 +12,7 @@ export function Filter({
   filterAllData,
   setFilterAllData,
   ...inputProps
-}: RootProps & {
+}: TextField.RootProps & {
   filter: string
   setFilter: (filter: string) => void
   filterAllData?: boolean

--- a/src/handlers/browser/recorders/extension.ts
+++ b/src/handlers/browser/recorders/extension.ts
@@ -72,7 +72,6 @@ class BrowserExtensionRecordingSession
 }
 
 function getExtensionPath() {
-  // @ts-expect-error - Electron apps are built as CJS.
   if (import.meta.env.DEV) {
     return path.join(app.getAppPath(), '.vite/build/extension')
   }

--- a/src/handlers/browser/recorders/utils.ts
+++ b/src/handlers/browser/recorders/utils.ts
@@ -28,7 +28,6 @@ const createUserDataDir = async () => {
   // with some preferences that make developing the extension easier
   // (e.g. whitelisting content scripts in the debugger).
   //
-  // @ts-expect-error - Electron apps are built as CJS.
   if (import.meta.env.DEV) {
     try {
       const defaultProfilePath = path.join(userDataDir, 'Default')

--- a/src/rules/correlation.ts
+++ b/src/rules/correlation.ts
@@ -584,9 +584,7 @@ correlation_vars['correlation_${generatedUniqueId}'] = resp.json()${json_path}`
   }
 }
 
-// @ts-expect-error we have commonjs set as module option
 if (import.meta.vitest) {
-  // @ts-expect-error we have commonjs set as module option
   const { it, expect } = import.meta.vitest
 
   const generateResponse = (content: string): Response => {

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -64,9 +64,7 @@ export function urlToQueryParams(url: string): Query[] {
   }
 }
 
-// @ts-expect-error we have commonjs set as module option
 if (import.meta.vitest) {
-  // @ts-expect-error we have commonjs set as module option
   const { it, expect } = import.meta.vitest
 
   const generateResponse = (

--- a/src/store/features/useFeaturesStore.ts
+++ b/src/store/features/useFeaturesStore.ts
@@ -11,7 +11,6 @@ interface FeaturesStore {
 export const defaultFeatures: Record<Feature, boolean> = {
   'dummy-feature': false,
   'typeahead-json': false,
-  // @ts-expect-error - Electron apps are built as CJS.
   'browser-test-editor': import.meta.env.DEV,
 }
 

--- a/src/utils/k6/client.ts
+++ b/src/utils/k6/client.ts
@@ -14,7 +14,6 @@ import { TestRun } from './testRun'
 const EXECUTABLE_NAME = getPlatform() === 'win' ? 'k6.exe' : 'k6'
 
 function getDefaultExecutablePath() {
-  // @ts-expect-error - import.meta doesn't exist because we're targeting CommonJS
   const resourcesPath = import.meta.env.DEV
     ? path.join(app.getAppPath(), 'resources', getPlatform())
     : process.resourcesPath

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -11,7 +11,6 @@ const RESOURCE_INDEX = {
 export type ResourceName = keyof typeof RESOURCE_INDEX
 
 function getResourceRootPath() {
-  // @ts-expect-error We are targeting CommonJS so import.meta is not available
   return !import.meta.env.PROD
     ? path.join(app.getAppPath(), 'resources')
     : process.resourcesPath

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "target": "ESNext",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -10,7 +11,6 @@
     "sourceMap": true,
     "baseUrl": ".",
     "outDir": "dist",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "noUncheckedIndexedAccess": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

So far we've been using `commonjs` modules in `tsconfig.json`, but there's no technical reason for us to do so. Electron is based on CommonJS, but Vite is transforming ES moduels to CJS for us so typescript doesn't really have to worry about it.

The biggest drawback has been that we've had to add `@ts-expect-error` to any place where we want to use `import.meta`, but I recently tried adding a new package and typescript couldn't find the correct types without setting `moduleResolution` to `bundler`.

The changes are pretty small. Besides the changes to `tsconfig.json`, all of the `@ts-expect-error` directives related to `import.meta` have been removed. In a couple of places there's been some changes to type imports.

## How to Test

* Start k6 Studio and check that everything works
* Run the type checker

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
