### PR TITLE
chore: Improve error logging

### DIFF
--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -27,7 +27,9 @@ function unwrapAggregateError(error: unknown): unknown[] {
 export function initializeLogger() {
   // allow logs to be triggered from the renderer process
   // https://github.com/megahertz/electron-log/blob/master/docs/initialize.md
-  log.initialize()
+  log.initialize({
+    spyRendererConsole: true,
+  })
 
   // log electron core events
   // https://github.com/megahertz/electron-log/blob/master/docs/events.md
@@ -38,9 +40,11 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
+  log.transports.file.level = 'error'
 
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'
+    log.transports.file.level = 'debug'
   }
 
   log.hooks.push((msg) => {

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -16,6 +16,11 @@ export function configureRendererProcess(
         }
         return null
       },
+      integrations: [
+        SentryRenderer.captureConsoleIntegration({
+          levels: ['error'],
+        }),
+      ],
     })
 
     // attach event listener to catch unhandled promise rejections


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have a bunch of places where we use `console.error` which helps with debugging issues locally, but there's no visibility into those logs in production app. To solve this:
1. Enable Sentry's `captureConsoleIntegration` to capture exception (when telemetry is enabled)
2. Enable `spyRendererConsole` in `electron-log` to write render console calls to logs file - this allows us to request logs to inspect when telemetry is disabled.


## How to Test

Add a `console.error` somewhere in renderer code, verify it's reflected in application logs.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production logging/telemetry behavior by capturing renderer console errors, which could increase data volume or inadvertently include sensitive details in logs/Sentry if misused.
> 
> **Overview**
> Improves production error visibility by capturing renderer `console.error` output both locally and remotely.
> 
> In `electron-log`, `initializeLogger` now enables `spyRendererConsole` and sets file transport levels to `error` in production and `debug` in development, reducing log noise while still persisting console errors. In the renderer Sentry setup, adds `captureConsoleIntegration` (errors only) so `console.error` is reported when user telemetry (`telemetry.errorReport`) is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17edeff5b03923fb4faa44c936e91eed138c100f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->