### PR TITLE
docs: Add instructions for compiling local binaries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,59 @@ After the command has finished, you start the app locally with:
 ```
 npm start
 ```
+
+### Compile a local binary (packaged app)
+
+To produce a local packaged build, set `SENTRY_DSN` and `NODE_OPTIONS` in your shell first, then run Electron Forge.
+The CI/release workflow defaults are:
+
+- `SENTRY_DSN="sentry"`
+- `NODE_OPTIONS="--max_old_space_size=8192"`
+
+Example:
+
+```bash
+export SENTRY_DSN="sentry"
+export NODE_OPTIONS="--max_old_space_size=8192"
+
+npm install
+npm run package
+```
+
+If you want installable artifacts (`.deb`, `.rpm`, etc.) instead of only a packaged app directory:
+
+```bash
+export SENTRY_DSN="sentry"
+export NODE_OPTIONS="--max_old_space_size=8192"
+
+npm install
+npm run make
+```
+
+Common output paths:
+
+- `out/` for packaged app output
+- `out/make/` for installer artifacts
+
+### Override the k6 binary used by k6 Studio
+
+This repository currently loads k6 from packaged resources, not from a `PATH` lookup or env var.
+If you need to test with a custom k6 build, replace the bundled binary in `resources` before packaging:
+
+- Linux:
+  - `resources/linux/x86_64/k6`
+  - `resources/linux/arm64/k6`
+- macOS:
+  - `resources/mac/x86_64/k6`
+  - `resources/mac/arm64/k6`
+- Windows:
+  - `resources/win/x86_64/k6.exe`
+
+Example (Linux x86_64):
+
+```bash
+cp ./k6 resources/linux/x86_64/k6
+chmod +x resources/linux/x86_64/k6
+```
+
+After replacing the binary, run `npm run package` or `npm run make` to include it in your local build.


### PR DESCRIPTION
## Description
Add instructions for compiling local binaries and to override k6 binaries to the README. 

This should help anyone trying to work on the project to more easily test their changes.
## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no impact on runtime behavior or release artifacts.
> 
> **Overview**
> Adds a new README section describing how to build a local packaged app or installer via Electron Forge, including required env vars (`SENTRY_DSN`, `NODE_OPTIONS`) and expected output directories.
> 
> Documents how to test with a custom `k6` build by replacing the bundled executables under `resources/` per OS/arch before running `npm run package`/`npm run make`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 550442b5abb44911c16db894ee74e69a9f28ca9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->