### PR TITLE
feat(generator): Move Validate and Run in Cloud buttons to Header

### DIFF
--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -154,11 +154,7 @@ export function Generator() {
         />
       }
       actions={
-        <GeneratorControls
-          onSave={handleSaveGenerator}
-          isDirty={isDirty}
-          onChangeRecording={() => setSelectedRequest(null)}
-        />
+        <GeneratorControls onSave={handleSaveGenerator} isDirty={isDirty} />
       }
       loading={isLoading}
     >
@@ -167,7 +163,6 @@ export function Generator() {
           <Allotment vertical>
             <Allotment.Pane minSize={200}>
               <GeneratorTabs
-                fileName={fileName}
                 selectedRequest={selectedRequest}
                 onSelectRequest={setSelectedRequest}
               />

--- a/src/views/Generator/GeneratorControls/GeneratorControls.tsx
+++ b/src/views/Generator/GeneratorControls/GeneratorControls.tsx
@@ -1,9 +1,16 @@
-import { DropdownMenu, Flex, IconButton } from '@radix-ui/themes'
-import { EllipsisVerticalIcon } from 'lucide-react'
+import { DropdownMenu, Flex, IconButton, Tooltip } from '@radix-ui/themes'
+import {
+  CircleCheckBigIcon,
+  DownloadIcon,
+  EllipsisVerticalIcon,
+  SaveIcon,
+} from 'lucide-react'
 import { useState } from 'react'
 
 import { ButtonWithTooltip } from '@/components/ButtonWithTooltip'
 import { DeleteFileDialog } from '@/components/DeleteFileDialog'
+import { RunInCloudButton } from '@/components/RunInCloudDialog/RunInCloudButton'
+import { RunInCloudDialog } from '@/components/RunInCloudDialog/RunInCloudDialog'
 import { useDeleteFile } from '@/hooks/useDeleteFile'
 import { useProxyStatus } from '@/hooks/useProxyStatus'
 import { useScriptPreview } from '@/hooks/useScriptPreview'
@@ -12,25 +19,20 @@ import { getFileNameWithoutExtension } from '@/utils/file'
 
 import { ExportScriptDialog } from '../ExportScriptDialog'
 import { useGeneratorParams, useScriptExport } from '../Generator.hooks'
-import { RecordingSelector } from '../RecordingSelector'
 import { ValidatorDialog } from '../ValidatorDialog'
 
 interface GeneratorControlsProps {
   onSave: () => void
   isDirty: boolean
-  onChangeRecording: () => void
 }
 
-export function GeneratorControls({
-  onSave,
-  isDirty,
-  onChangeRecording,
-}: GeneratorControlsProps) {
+export function GeneratorControls({ onSave, isDirty }: GeneratorControlsProps) {
   const scriptName = useGeneratorStore((store) => store.scriptName)
 
   const [isValidatorDialogOpen, setIsValidatorDialogOpen] = useState(false)
   const [isExportScriptDialogOpen, setIsExportScriptDialogOpen] =
     useState(false)
+  const [isRunInCloudDialogOpen, setIsRunInCloudDialogOpen] = useState(false)
   const { fileName } = useGeneratorParams()
   const { preview, hasError } = useScriptPreview()
   const proxyStatus = useProxyStatus()
@@ -51,15 +53,52 @@ export function GeneratorControls({
 
   return (
     <>
-      <RecordingSelector onChangeRecording={onChangeRecording} />
       <Flex align="center" justify="between" gap="2" ml="2">
-        <ButtonWithTooltip
-          onClick={onSave}
-          disabled={!isDirty}
-          tooltip={!isDirty ? 'Changes saved' : ''}
-        >
-          Save generator
-        </ButtonWithTooltip>
+        <Flex gap="4" align="center">
+          <Tooltip content={!isDirty ? 'Changes saved' : 'Save changes'}>
+            <IconButton
+              onClick={onSave}
+              disabled={!isDirty}
+              variant="ghost"
+              color="gray"
+            >
+              <SaveIcon />
+            </IconButton>
+          </Tooltip>
+          <Tooltip content="Export script">
+            <IconButton
+              onClick={() => setIsExportScriptDialogOpen(true)}
+              disabled={!isScriptExportable}
+              variant="ghost"
+              color="gray"
+            >
+              <DownloadIcon />
+            </IconButton>
+          </Tooltip>
+        </Flex>
+        <Flex gap="4" align="center" pl="2">
+          <ButtonWithTooltip
+            variant="ghost"
+            tooltip={
+              !isScriptExportable
+                ? 'Fix script errors to enable validation'
+                : proxyStatus !== 'online'
+                  ? 'Start proxy to enable validation'
+                  : ''
+            }
+            onClick={() => setIsValidatorDialogOpen(true)}
+            disabled={!isScriptExportable || proxyStatus !== 'online'}
+          >
+            <CircleCheckBigIcon /> Validate
+          </ButtonWithTooltip>
+          <RunInCloudButton
+            variant="solid"
+            disabled={!isScriptExportable}
+            onClick={() => {
+              setIsRunInCloudDialogOpen(true)
+            }}
+          />
+        </Flex>
         <DropdownMenu.Root>
           <DropdownMenu.Trigger>
             <IconButton variant="ghost" color="gray">
@@ -67,19 +106,6 @@ export function GeneratorControls({
             </IconButton>
           </DropdownMenu.Trigger>
           <DropdownMenu.Content>
-            <DropdownMenu.Item
-              onSelect={() => setIsValidatorDialogOpen(true)}
-              disabled={!isScriptExportable || proxyStatus !== 'online'}
-            >
-              Validate script
-            </DropdownMenu.Item>
-            <DropdownMenu.Item
-              onSelect={() => setIsExportScriptDialogOpen(true)}
-              disabled={!isScriptExportable}
-            >
-              Export script
-            </DropdownMenu.Item>
-            <DropdownMenu.Separator />
             <DeleteFileDialog
               file={file}
               onConfirm={handleDelete}
@@ -96,6 +122,11 @@ export function GeneratorControls({
         </DropdownMenu.Root>
         {isScriptExportable && (
           <>
+            <RunInCloudDialog
+              open={isRunInCloudDialogOpen}
+              script={{ type: 'raw', name: fileName, content: preview }}
+              onOpenChange={setIsRunInCloudDialogOpen}
+            />
             <ValidatorDialog
               script={preview}
               open={isValidatorDialogOpen}

--- a/src/views/Generator/GeneratorTabs/GeneratorTabs.tsx
+++ b/src/views/Generator/GeneratorTabs/GeneratorTabs.tsx
@@ -19,13 +19,11 @@ import { RequestList } from './RequestList'
 import { ScriptPreview } from './ScriptPreview'
 
 interface GeneratorTabsProps {
-  fileName: string
   selectedRequest: ProxyData | null
   onSelectRequest: (request: ProxyData | null) => void
 }
 
 export function GeneratorTabs({
-  fileName,
   selectedRequest,
   onSelectRequest,
 }: GeneratorTabsProps) {
@@ -94,7 +92,7 @@ export function GeneratorTabs({
             min-height: 0;
           `}
         >
-          <ScriptPreview fileName={fileName} />
+          <ScriptPreview />
         </Tabs.Content>
       </Tabs.Root>
     </Flex>

--- a/src/views/Generator/GeneratorTabs/RequestList/Header.tsx
+++ b/src/views/Generator/GeneratorTabs/RequestList/Header.tsx
@@ -1,21 +1,25 @@
 import { Flex, Switch, Text } from '@radix-ui/themes'
 
 import { Filter } from '@/components/WebLogView/Filter'
-import { RecorderIcon } from '@/components/icons'
 import { useGeneratorStore } from '@/store/generator'
-import { getFileNameWithoutExtension } from '@/utils/file'
+
+import { RecordingSelector } from '../../RecordingSelector'
+
+interface HeaderProps {
+  filter: string
+  filterAllData?: boolean
+  onChangeRecording: () => void
+  setFilter: (filter: string) => void
+  setFilterAllData: (filterAllData: boolean) => void
+}
 
 export function Header({
   filter,
   setFilter,
   filterAllData,
   setFilterAllData,
-}: {
-  filter: string
-  setFilter: (filter: string) => void
-  filterAllData?: boolean
-  setFilterAllData: (filterAllData: boolean) => void
-}) {
+  onChangeRecording,
+}: HeaderProps) {
   const previewOriginalRequests = useGeneratorStore(
     (state) => state.previewOriginalRequests
   )
@@ -24,18 +28,9 @@ export function Header({
     (store) => store.setPreviewOriginalRequests
   )
 
-  const recordingPath = useGeneratorStore((state) => state.recordingPath)
-
   return (
     <Flex justify="between" align="center" px="2" py="1" gap="2">
-      <Text color="gray" size="2" truncate>
-        <Flex align="center" gap="1">
-          <Flex flexShrink="0">
-            <RecorderIcon width="22px" />
-          </Flex>
-          <Text truncate>{getFileNameWithoutExtension(recordingPath)}</Text>
-        </Flex>
-      </Text>
+      <RecordingSelector onChangeRecording={onChangeRecording} />
       <Flex justify="end" align="center" gap="4">
         <Text
           as="label"

--- a/src/views/Generator/GeneratorTabs/RequestList/RequestList.tsx
+++ b/src/views/Generator/GeneratorTabs/RequestList/RequestList.tsx
@@ -71,8 +71,9 @@ export function RequestList({
       {!recordingError && (
         <Header
           filter={filter}
-          setFilter={setFilter}
           filterAllData={filterAllData}
+          onChangeRecording={() => onSelectRequest(null)}
+          setFilter={setFilter}
           setFilterAllData={setFilterAllData}
         />
       )}

--- a/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
+++ b/src/views/Generator/GeneratorTabs/ScriptPreview.tsx
@@ -1,75 +1,17 @@
-import { Flex, Tooltip } from '@radix-ui/themes'
-import { CircleCheckIcon, DownloadIcon } from 'lucide-react'
-import { useState } from 'react'
+import { Flex } from '@radix-ui/themes'
 
-import { GhostButton } from '@/components/GhostButton'
 import { ReactMonacoEditor } from '@/components/Monaco/ReactMonacoEditor'
-import { RunInCloudButton } from '@/components/RunInCloudDialog/RunInCloudButton'
-import { RunInCloudDialog } from '@/components/RunInCloudDialog/RunInCloudDialog'
-import { useProxyStatus } from '@/hooks/useProxyStatus'
 import { useScriptPreview } from '@/hooks/useScriptPreview'
 import { useTrackScriptCopy } from '@/hooks/useTrackScriptCopy'
-import { useGeneratorStore } from '@/store/generator'
-
-import { ExportScriptDialog } from '../ExportScriptDialog'
-import { useScriptExport } from '../Generator.hooks'
-import { ValidatorDialog } from '../ValidatorDialog'
 
 import { ScriptPreviewError } from './ScriptPreviewError'
 
-interface ScriptPreviewProps {
-  fileName: string
-}
-
-export function ScriptPreview({ fileName }: ScriptPreviewProps) {
-  const scriptName = useGeneratorStore((store) => store.scriptName)
-
-  const [isRunInCloudDialogOpen, setIsRunInCloudDialogOpen] = useState(false)
-  const [isValidatorDialogOpen, setIsValidatorDialogOpen] = useState(false)
-  const [isExportScriptDialogOpen, setIsExportScriptDialogOpen] =
-    useState(false)
+export function ScriptPreview() {
   const { preview, error } = useScriptPreview()
-  const proxyStatus = useProxyStatus()
-
-  const isScriptExportable = !error && !!preview
-
-  const handleExportScript = useScriptExport(fileName)
   const handleCopy = useTrackScriptCopy(preview, 'generator')
 
   return (
     <Flex direction="column" height="100%" position="relative">
-      <Flex py="1" px="2" gap="2" align="center" justify="end">
-        <Tooltip
-          content={`Proxy is ${proxyStatus}`}
-          hidden={proxyStatus === 'online'}
-        >
-          <GhostButton
-            disabled={!isScriptExportable || proxyStatus !== 'online'}
-            onClick={() => {
-              setIsValidatorDialogOpen(true)
-            }}
-          >
-            <CircleCheckIcon />
-            Validate
-          </GhostButton>
-        </Tooltip>
-        <GhostButton
-          disabled={!isScriptExportable}
-          onClick={() => {
-            setIsExportScriptDialogOpen(true)
-          }}
-        >
-          <DownloadIcon />
-          Export
-        </GhostButton>
-        <RunInCloudButton
-          variant="outline"
-          disabled={!isScriptExportable}
-          onClick={() => {
-            setIsRunInCloudDialogOpen(true)
-          }}
-        />
-      </Flex>
       <ReactMonacoEditor
         showToolbar
         defaultLanguage="javascript"
@@ -81,27 +23,6 @@ export function ScriptPreview({ fileName }: ScriptPreviewProps) {
       />
 
       {!!error && <ScriptPreviewError error={error} />}
-
-      {isScriptExportable && (
-        <>
-          <RunInCloudDialog
-            open={isRunInCloudDialogOpen}
-            script={{ type: 'raw', name: fileName, content: preview }}
-            onOpenChange={setIsRunInCloudDialogOpen}
-          />
-          <ValidatorDialog
-            script={preview}
-            open={isValidatorDialogOpen}
-            onOpenChange={setIsValidatorDialogOpen}
-          />
-          <ExportScriptDialog
-            open={isExportScriptDialogOpen}
-            scriptName={scriptName}
-            onExport={handleExportScript}
-            onOpenChange={setIsExportScriptDialogOpen}
-          />
-        </>
-      )}
     </Flex>
   )
 }


### PR DESCRIPTION
Closes https://github.com/grafana/k6-studio/issues/960

## Description

<img width="1433" height="923" alt="image" src="https://github.com/user-attachments/assets/69fee30f-9210-4a63-b7ac-7bf8b9fa2bbd" />
<img width="1433" height="923" alt="image" src="https://github.com/user-attachments/assets/740cfc20-922b-4445-acae-407fdee55f20" />


<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

## How to Test
- Verify that all controls work
- Check that the layout looks okay even when the window is small

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/layout refactoring with no changes to core generator data or persistence; main risk is regressions in button enablement/visibility and dialog wiring.
> 
> **Overview**
> Moves generator action controls into the view header: `GeneratorControls` now hosts **Save**, **Export**, **Validate**, and **Run in Cloud** (with updated icon/tooltip styling) and opens the related dialogs from there rather than from the script preview/dropdown.
> 
> Relocates the `RecordingSelector` into the request list header (and clears the selected request when changing recordings), and simplifies props by removing now-unused `fileName`/`onChangeRecording` plumbing; `ScriptPreview` is reduced to the read-only editor plus error display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 268d72c7f5dd6c7c81e90de7829b21505243de5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->