### PR TITLE
fix(autocorrelation): Handle quota exceeded error in the UI

### DIFF
--- a/src/views/Generator/AutoCorrelation/ErrorMessage.tsx
+++ b/src/views/Generator/AutoCorrelation/ErrorMessage.tsx
@@ -1,7 +1,12 @@
 import { Button, Flex, Text } from '@radix-ui/themes'
-import { ExternalLink, KeyIcon, RefreshCw } from 'lucide-react'
+import {
+  ExternalLink as ExternalLinkIcon,
+  KeyIcon,
+  RefreshCw,
+} from 'lucide-react'
 
 import grotCrashed from '@/assets/grot-crashed.svg'
+import { ExternalLink } from '@/components/ExternalLink'
 import { useSettingsChanged } from '@/hooks/useSettings'
 import { useStudioUIStore } from '@/store/ui'
 
@@ -36,7 +41,7 @@ export function ErrorMessage({ error, onRetry }: AutoCorrelationErrorProps) {
 
   const reportIssueButton = (
     <Button onClick={() => window.studio.ui.reportIssue()} variant="outline">
-      <ExternalLink />
+      <ExternalLinkIcon />
       Report issue
     </Button>
   )
@@ -46,6 +51,25 @@ export function ErrorMessage({ error, onRetry }: AutoCorrelationErrorProps) {
       <MessageContent
         title="Incorrect API key"
         message="The OpenAI API key is incorrect or has been revoked. Check your API key in settings."
+      >
+        {openSettingsButton}
+      </MessageContent>
+    )
+  }
+
+  if (errorMessage.includes('insufficient_quota')) {
+    return (
+      <MessageContent
+        title="Quota exceeded"
+        message={
+          <>
+            You have exceeded your OpenAI API quota. Check your{' '}
+            <ExternalLink href="https://platform.openai.com/account/billing">
+              plan and billing details
+            </ExternalLink>{' '}
+            on the OpenAI platform.
+          </>
+        }
       >
         {openSettingsButton}
       </MessageContent>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Currently, we show generic "Something went wrong" screen when there's not enough credit in OpenAI account. This adds an error case to show user-friendly message with link to OpenAI billing.

<img width="1978" height="1526" alt="screencapture 2026-03-12 at 09 09 24@2x" src="https://github.com/user-attachments/assets/d50eac47-c85e-44d1-bd2c-5c93036573b7" />


## How to Test
Create new OpenAI account without any credits and verify user-friendly error is displayed.

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error handling change gated on a specific error string; main risk is mismatched/changed upstream error messages causing the case to not trigger.
> 
> **Overview**
> Autocorrelation’s error UI now detects OpenAI `insufficient_quota` errors and shows a **Quota exceeded** message with a link to OpenAI billing plus a quick path to AI settings.
> 
> It also switches the “Report issue” button to use the lucide `ExternalLink` icon under a distinct name to avoid clashing with the app’s `ExternalLink` component.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2767a98caa7c685074391b80d1b1523e22a38aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->