### PR TITLE
internal(browser): Add exact option to text-based locators

### DIFF
--- a/src/codegen/browser/code/options.ts
+++ b/src/codegen/browser/code/options.ts
@@ -37,6 +37,7 @@ function isBrowserScenario(scenario: ir.Scenario) {
       case 'ReloadExpression':
       case 'NewRoleLocatorExpression':
       case 'RoleLocatorOptionsExpression':
+      case 'TextLocatorOptionsExpression':
       case 'NewLabelLocatorExpression':
       case 'NewCssLocatorExpression':
       case 'NewAltTextLocatorExpression':

--- a/src/codegen/browser/code/scenario.ts
+++ b/src/codegen/browser/code/scenario.ts
@@ -85,6 +85,17 @@ function emitRoleLocatorOptionsExpression(
   })
 }
 
+function emitTextLocatorOptionsExpression(
+  _context: ScenarioContext,
+  expression: ir.TextLocatorOptionsExpression
+): ts.Expression {
+  const exact = expression.exact
+
+  return ObjectBuilder.from({
+    ...(exact && { exact }),
+  })
+}
+
 function emitNewLabelLocatorExpression(
   context: ScenarioContext,
   expression: ir.NewLabelLocatorExpression
@@ -92,9 +103,14 @@ function emitNewLabelLocatorExpression(
   const page = emitExpression(context, expression.page)
   const text = emitExpression(context, expression.text)
 
+  const options =
+    expression.options !== null
+      ? [emitExpression(context, expression.options)]
+      : []
+
   return new ExpressionBuilder(page)
     .member('getByLabel')
-    .call([text, ObjectBuilder.from({ exact: true })])
+    .call([text, ...options])
     .done()
 }
 
@@ -105,9 +121,14 @@ function emitNewAltTextLocatorExpression(
   const page = emitExpression(context, expression.page)
   const text = emitExpression(context, expression.text)
 
+  const options =
+    expression.options !== null
+      ? [emitExpression(context, expression.options)]
+      : []
+
   return new ExpressionBuilder(page)
     .member('getByAltText')
-    .call([text, ObjectBuilder.from({ exact: true })])
+    .call([text, ...options])
     .done()
 }
 
@@ -118,9 +139,14 @@ function emitNewPlaceholderLocatorExpression(
   const page = emitExpression(context, expression.page)
   const text = emitExpression(context, expression.text)
 
+  const options =
+    expression.options !== null
+      ? [emitExpression(context, expression.options)]
+      : []
+
   return new ExpressionBuilder(page)
     .member('getByPlaceholder')
-    .call([text, ObjectBuilder.from({ exact: true })])
+    .call([text, ...options])
     .done()
 }
 
@@ -131,9 +157,14 @@ function emitNewTitleLocatorExpression(
   const page = emitExpression(context, expression.page)
   const text = emitExpression(context, expression.text)
 
+  const options =
+    expression.options !== null
+      ? [emitExpression(context, expression.options)]
+      : []
+
   return new ExpressionBuilder(page)
     .member('getByTitle')
-    .call([text, ObjectBuilder.from({ exact: true })])
+    .call([text, ...options])
     .done()
 }
 
@@ -456,6 +487,9 @@ function emitExpression(
 
     case 'RoleLocatorOptionsExpression':
       return emitRoleLocatorOptionsExpression(context, expression)
+
+    case 'TextLocatorOptionsExpression':
+      return emitTextLocatorOptionsExpression(context, expression)
 
     case 'NewLabelLocatorExpression':
       return emitNewLabelLocatorExpression(context, expression)

--- a/src/codegen/browser/codegen.test.ts
+++ b/src/codegen/browser/codegen.test.ts
@@ -1044,7 +1044,7 @@ it('should emit a getByAltText locator', async ({ expect }) => {
           nodeId: 'locator',
           selector: {
             type: 'alt',
-            text: 'Grot is happy',
+            text: { value: 'Grot is happy', exact: true },
           },
           inputs: { page: { nodeId: 'page' } },
         },
@@ -1085,7 +1085,7 @@ it('should emit a getByLabel locator', async ({ expect }) => {
           nodeId: 'locator',
           selector: {
             type: 'label',
-            text: 'Username',
+            text: { value: 'Username', exact: true },
           },
           inputs: { page: { nodeId: 'page' } },
         },
@@ -1120,7 +1120,7 @@ it('should emit a getByPlaceholder locator', async ({ expect }) => {
           nodeId: 'locator',
           selector: {
             type: 'placeholder',
-            text: 'Enter your email',
+            text: { value: 'Enter your email', exact: true },
           },
           inputs: { page: { nodeId: 'page' } },
         },
@@ -1155,7 +1155,7 @@ it('should emit a getByTitle locator', async ({ expect }) => {
           nodeId: 'locator',
           selector: {
             type: 'title',
-            text: 'Submit your form',
+            text: { value: 'Submit your form', exact: true },
           },
           inputs: { page: { nodeId: 'page' } },
         },
@@ -1196,7 +1196,7 @@ it('should emit a waitFor statement', async ({ expect }) => {
           nodeId: 'locator',
           selector: {
             type: 'title',
-            text: 'Submit your form',
+            text: { value: 'Submit your form', exact: true },
           },
           inputs: { page: { nodeId: 'page' } },
         },

--- a/src/codegen/browser/intermediate/ast.ts
+++ b/src/codegen/browser/intermediate/ast.ts
@@ -37,24 +37,33 @@ export interface NewAltTextLocatorExpression {
   type: 'NewAltTextLocatorExpression'
   text: Expression
   page: Expression
+  options: Expression | null
 }
 
 export interface NewLabelLocatorExpression {
   type: 'NewLabelLocatorExpression'
   text: Expression
   page: Expression
+  options: Expression | null
 }
 
 export interface NewPlaceholderLocatorExpression {
   type: 'NewPlaceholderLocatorExpression'
   text: Expression
   page: Expression
+  options: Expression | null
 }
 
 export interface NewTitleLocatorExpression {
   type: 'NewTitleLocatorExpression'
   text: Expression
   page: Expression
+  options: Expression | null
+}
+
+export interface TextLocatorOptionsExpression {
+  type: 'TextLocatorOptionsExpression'
+  exact?: boolean
 }
 
 export interface RoleLocatorOptionsExpression {
@@ -196,6 +205,7 @@ export type Expression =
   | ClosePageExpression
   | NewRoleLocatorExpression
   | RoleLocatorOptionsExpression
+  | TextLocatorOptionsExpression
   | NewLabelLocatorExpression
   | NewPlaceholderLocatorExpression
   | NewTitleLocatorExpression

--- a/src/codegen/browser/intermediate/index.ts
+++ b/src/codegen/browser/intermediate/index.ts
@@ -91,9 +91,15 @@ function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
         type: 'NewLabelLocatorExpression',
         text: {
           type: 'StringLiteral',
-          value: node.selector.text,
+          value: node.selector.text.value,
         },
         page,
+        options: node.selector.text.exact
+          ? {
+              type: 'TextLocatorOptionsExpression',
+              exact: node.selector.text.exact,
+            }
+          : null,
       })
       break
 
@@ -102,9 +108,15 @@ function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
         type: 'NewPlaceholderLocatorExpression',
         text: {
           type: 'StringLiteral',
-          value: node.selector.text,
+          value: node.selector.text.value,
         },
         page,
+        options: node.selector.text.exact
+          ? {
+              type: 'TextLocatorOptionsExpression',
+              exact: node.selector.text.exact,
+            }
+          : null,
       })
       break
 
@@ -113,9 +125,15 @@ function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
         type: 'NewTitleLocatorExpression',
         text: {
           type: 'StringLiteral',
-          value: node.selector.text,
+          value: node.selector.text.value,
         },
         page,
+        options: node.selector.text.exact
+          ? {
+              type: 'TextLocatorOptionsExpression',
+              exact: node.selector.text.exact,
+            }
+          : null,
       })
       break
 
@@ -124,9 +142,15 @@ function emitLocatorNode(context: IntermediateContext, node: m.LocatorNode) {
         type: 'NewAltTextLocatorExpression',
         text: {
           type: 'StringLiteral',
-          value: node.selector.text,
+          value: node.selector.text.value,
         },
         page,
+        options: node.selector.text.exact
+          ? {
+              type: 'TextLocatorOptionsExpression',
+              exact: node.selector.text.exact,
+            }
+          : null,
       })
       break
 

--- a/src/codegen/browser/intermediate/variables.ts
+++ b/src/codegen/browser/intermediate/variables.ts
@@ -55,6 +55,7 @@ function substituteExpression(
     case 'ClickOptionsExpression':
     case 'WaitForOptionsExpression':
     case 'RoleLocatorOptionsExpression':
+    case 'TextLocatorOptionsExpression':
       return node
 
     case 'ClosePageExpression':
@@ -84,6 +85,9 @@ function substituteExpression(
         type: 'NewLabelLocatorExpression',
         text: substituteExpression(node.text, substitutions),
         page: substituteExpression(node.page, substitutions),
+        options: node.options
+          ? substituteExpression(node.options, substitutions)
+          : null,
       }
 
     case 'NewCssLocatorExpression':
@@ -96,8 +100,11 @@ function substituteExpression(
     case 'NewAltTextLocatorExpression':
       return {
         type: 'NewAltTextLocatorExpression',
-        page: substituteExpression(node.page, substitutions),
         text: substituteExpression(node.text, substitutions),
+        page: substituteExpression(node.page, substitutions),
+        options: node.options
+          ? substituteExpression(node.options, substitutions)
+          : null,
       }
 
     case 'NewPlaceholderLocatorExpression':
@@ -105,6 +112,9 @@ function substituteExpression(
         type: 'NewPlaceholderLocatorExpression',
         text: substituteExpression(node.text, substitutions),
         page: substituteExpression(node.page, substitutions),
+        options: node.options
+          ? substituteExpression(node.options, substitutions)
+          : null,
       }
 
     case 'NewTitleLocatorExpression':
@@ -112,6 +122,9 @@ function substituteExpression(
         type: 'NewTitleLocatorExpression',
         text: substituteExpression(node.text, substitutions),
         page: substituteExpression(node.page, substitutions),
+        options: node.options
+          ? substituteExpression(node.options, substitutions)
+          : null,
       }
 
     case 'NewTestIdLocatorExpression':

--- a/src/codegen/browser/selectors.ts
+++ b/src/codegen/browser/selectors.ts
@@ -37,7 +37,7 @@ function getAltTextSelector(
 
   return {
     type: 'alt',
-    text: { value: selectors.alt },
+    text: { value: selectors.alt, exact: true },
   }
 }
 
@@ -50,7 +50,7 @@ function getLabelSelector(
 
   return {
     type: 'label',
-    text: { value: selectors.label },
+    text: { value: selectors.label, exact: true },
   }
 }
 
@@ -63,7 +63,7 @@ function getPlaceholderSelector(
 
   return {
     type: 'placeholder',
-    text: { value: selectors.placeholder },
+    text: { value: selectors.placeholder, exact: true },
   }
 }
 
@@ -76,7 +76,7 @@ function getTitleSelector(
 
   return {
     type: 'title',
-    text: { value: selectors.title },
+    text: { value: selectors.title, exact: true },
   }
 }
 

--- a/src/codegen/browser/selectors.ts
+++ b/src/codegen/browser/selectors.ts
@@ -37,7 +37,7 @@ function getAltTextSelector(
 
   return {
     type: 'alt',
-    text: selectors.alt,
+    text: { value: selectors.alt },
   }
 }
 
@@ -50,7 +50,7 @@ function getLabelSelector(
 
   return {
     type: 'label',
-    text: selectors.label,
+    text: { value: selectors.label },
   }
 }
 
@@ -63,7 +63,7 @@ function getPlaceholderSelector(
 
   return {
     type: 'placeholder',
-    text: selectors.placeholder,
+    text: { value: selectors.placeholder },
   }
 }
 
@@ -76,7 +76,7 @@ function getTitleSelector(
 
   return {
     type: 'title',
-    text: selectors.title,
+    text: { value: selectors.title },
   }
 }
 
@@ -141,31 +141,31 @@ export function toNodeSelector(locator: ActionLocator): NodeSelector {
     case 'alt':
       return {
         type: 'alt',
-        text: locator.text,
+        text: { value: locator.text, exact: locator.options?.exact },
       }
 
     case 'label':
       return {
         type: 'label',
-        text: locator.label,
+        text: { value: locator.label, exact: locator.options?.exact },
       }
 
     case 'placeholder':
       return {
         type: 'placeholder',
-        text: locator.placeholder,
+        text: { value: locator.placeholder, exact: locator.options?.exact },
       }
 
     case 'title':
       return {
         type: 'title',
-        text: locator.title,
+        text: { value: locator.title, exact: locator.options?.exact },
       }
 
     case 'text':
       return {
         type: 'text',
-        text: locator.text,
+        text: { value: locator.text, exact: locator.options?.exact },
       }
 
     default:
@@ -190,19 +190,39 @@ export function isSelectorEqual(a: NodeSelector, b: NodeSelector): boolean {
       )
 
     case 'alt':
-      return b.type === 'alt' && a.text === b.text
+      return (
+        b.type === 'alt' &&
+        a.text.value === b.text.value &&
+        a.text.exact === b.text.exact
+      )
 
     case 'label':
-      return b.type === 'label' && a.text === b.text
+      return (
+        b.type === 'label' &&
+        a.text.value === b.text.value &&
+        a.text.exact === b.text.exact
+      )
 
     case 'placeholder':
-      return b.type === 'placeholder' && a.text === b.text
+      return (
+        b.type === 'placeholder' &&
+        a.text.value === b.text.value &&
+        a.text.exact === b.text.exact
+      )
 
     case 'text':
-      return b.type === 'text' && a.text === b.text
+      return (
+        b.type === 'text' &&
+        a.text.value === b.text.value &&
+        a.text.exact === b.text.exact
+      )
 
     case 'title':
-      return b.type === 'title' && a.text === b.text
+      return (
+        b.type === 'title' &&
+        a.text.value === b.text.value &&
+        a.text.exact === b.text.exact
+      )
 
     default:
       return exhaustive(a)

--- a/src/components/Browser/Locator.tsx
+++ b/src/components/Browser/Locator.tsx
@@ -5,9 +5,9 @@ import {
   CaseSensitiveIcon,
   ImageIcon,
   LucideProps,
-  SquareDashedIcon,
   TagIcon,
   TestTubeDiagonalIcon,
+  WholeWordIcon,
 } from 'lucide-react'
 
 import { NodeSelector } from '@/schemas/selectors'
@@ -38,7 +38,7 @@ export function LocatorIcon({ locator, ...props }: LocatorComponentProps) {
       return <TagIcon {...props} />
 
     case 'placeholder':
-      return <SquareDashedIcon {...props} />
+      return <WholeWordIcon {...props} />
 
     case 'title':
       return <CaptionsIcon {...props} />

--- a/src/components/Browser/Locator.tsx
+++ b/src/components/Browser/Locator.tsx
@@ -5,9 +5,9 @@ import {
   CaseSensitiveIcon,
   ImageIcon,
   LucideProps,
+  SquareDashedIcon,
   TagIcon,
   TestTubeDiagonalIcon,
-  WholeWordIcon,
 } from 'lucide-react'
 
 import { NodeSelector } from '@/schemas/selectors'
@@ -38,7 +38,7 @@ export function LocatorIcon({ locator, ...props }: LocatorComponentProps) {
       return <TagIcon {...props} />
 
     case 'placeholder':
-      return <WholeWordIcon {...props} />
+      return <SquareDashedIcon {...props} />
 
     case 'title':
       return <CaptionsIcon {...props} />
@@ -63,19 +63,19 @@ export function LocatorText({ locator }: LocatorComponentProps) {
       return locator.testId
 
     case 'label':
-      return quote(locator.text)
+      return quote(locator.text.value)
 
     case 'placeholder':
-      return quote(locator.text)
+      return quote(locator.text.value)
 
     case 'title':
-      return quote(locator.text)
+      return quote(locator.text.value)
 
     case 'alt':
-      return quote(locator.text)
+      return quote(locator.text.value)
 
     case 'text':
-      return quote(locator.text)
+      return quote(locator.text.value)
 
     case 'role':
       return (

--- a/src/main/runner/schema.ts
+++ b/src/main/runner/schema.ts
@@ -34,29 +34,40 @@ const GetByTestIdLocatorSchema = z.object({
   testId: z.string(),
 })
 
+const TextLocatorOptions = z
+  .object({
+    exact: z.boolean().optional(),
+  })
+  .optional()
+
 const GetByAltTextLocatorSchema = z.object({
   type: z.literal('alt'),
   text: z.string(),
+  options: TextLocatorOptions,
 })
 
 const GetByLabelLocatorSchema = z.object({
   type: z.literal('label'),
   label: z.string(),
+  options: TextLocatorOptions,
 })
 
 const GetByPlaceholderLocatorSchema = z.object({
   type: z.literal('placeholder'),
   placeholder: z.string(),
+  options: TextLocatorOptions,
 })
 
 const GetByTitleLocatorSchema = z.object({
   type: z.literal('title'),
   title: z.string(),
+  options: TextLocatorOptions,
 })
 
 const GetByTextLocatorSchema = z.object({
   type: z.literal('text'),
   text: z.string(),
+  options: TextLocatorOptions,
 })
 
 const ActionLocatorSchema = z.discriminatedUnion('type', [

--- a/src/main/runner/shims/browser/proxies/page.ts
+++ b/src/main/runner/shims/browser/proxies/page.ts
@@ -87,34 +87,39 @@ export function pageProxy(target: Page): ProxyOptions<Page> {
           },
         })
       },
-      getByAltText(target, text) {
+      getByAltText(target, text, options) {
         return locatorProxy(target, {
           type: 'alt',
           text: text.toString(),
+          options,
         })
       },
-      getByLabel(target, label) {
+      getByLabel(target, label, options) {
         return locatorProxy(target, {
           type: 'label',
           label: label.toString(),
+          options,
         })
       },
-      getByPlaceholder(target, placeholder) {
+      getByPlaceholder(target, placeholder, options) {
         return locatorProxy(target, {
           type: 'placeholder',
           placeholder: placeholder.toString(),
+          options,
         })
       },
-      getByTitle(target, title) {
+      getByTitle(target, title, options) {
         return locatorProxy(target, {
           type: 'title',
           title: title.toString(),
+          options,
         })
       },
-      getByText(target, text) {
+      getByText(target, text, options) {
         return locatorProxy(target, {
           type: 'text',
           text: text.toString(),
+          options,
         })
       },
       getByTestId(target, testId) {

--- a/src/schemas/selectors.ts
+++ b/src/schemas/selectors.ts
@@ -5,40 +5,40 @@ export const CssNodeSelectorSchema = z.object({
   selector: z.string(),
 })
 
+const TextWithExact = z.object({
+  value: z.string(),
+  exact: z.boolean().optional(),
+})
+
 export const GetByRoleNodeSelectorSchema = z.object({
   type: z.literal('role'),
   role: z.string(),
-  name: z
-    .object({
-      value: z.string(),
-      exact: z.boolean().optional(),
-    })
-    .optional(),
+  name: TextWithExact.optional(),
 })
 
 export const GetByAltTextNodeSelectorSchema = z.object({
   type: z.literal('alt'),
-  text: z.string(),
+  text: TextWithExact,
 })
 
 export const GetByLabelNodeSelectorSchema = z.object({
   type: z.literal('label'),
-  text: z.string(),
+  text: TextWithExact,
 })
 
 export const GetByPlaceholderNodeSelectorSchema = z.object({
   type: z.literal('placeholder'),
-  text: z.string(),
+  text: TextWithExact,
 })
 
 export const GetByTextNodeSelectorSchema = z.object({
   type: z.literal('text'),
-  text: z.string(),
+  text: TextWithExact,
 })
 
 export const GetByTitleNodeSelectorSchema = z.object({
   type: z.literal('title'),
-  text: z.string(),
+  text: TextWithExact,
 })
 
 export const GetByTestIdNodeSelectorSchema = z.object({

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -31,19 +31,29 @@ export function findElementsBySelector(
       })
 
     case 'alt':
-      return queryAllByAltText(container, selector.text.value)
+      return queryAllByAltText(container, selector.text.value, {
+        exact: selector.text.exact,
+      })
 
     case 'label':
-      return queryAllByLabelText(container, selector.text.value)
+      return queryAllByLabelText(container, selector.text.value, {
+        exact: selector.text.exact,
+      })
 
     case 'placeholder':
-      return queryAllByPlaceholderText(container, selector.text.value)
+      return queryAllByPlaceholderText(container, selector.text.value, {
+        exact: selector.text.exact,
+      })
 
     case 'text':
-      return queryAllByText(container, selector.text.value)
+      return queryAllByText(container, selector.text.value, {
+        exact: selector.text.exact,
+      })
 
     case 'title':
-      return queryAllByTitle(container, selector.text.value)
+      return queryAllByTitle(container, selector.text.value, {
+        exact: selector.text.exact,
+      })
 
     default:
       return []

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -31,19 +31,19 @@ export function findElementsBySelector(
       })
 
     case 'alt':
-      return queryAllByAltText(container, selector.text)
+      return queryAllByAltText(container, selector.text.value)
 
     case 'label':
-      return queryAllByLabelText(container, selector.text)
+      return queryAllByLabelText(container, selector.text.value)
 
     case 'placeholder':
-      return queryAllByPlaceholderText(container, selector.text)
+      return queryAllByPlaceholderText(container, selector.text.value)
 
     case 'text':
-      return queryAllByText(container, selector.text)
+      return queryAllByText(container, selector.text.value)
 
     case 'title':
-      return queryAllByTitle(container, selector.text)
+      return queryAllByTitle(container, selector.text.value)
 
     default:
       return []

--- a/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
@@ -6,7 +6,6 @@ interface TextFieldWithExactToggleProps {
   name: string
   value: string
   exact?: boolean
-  exactDisabled?: boolean
   onValueChange: (value: string) => void
   onExactChange: (exact: boolean) => void
   onBlur?: () => void
@@ -16,7 +15,6 @@ export function TextFieldWithExactToggle({
   name,
   value,
   exact,
-  exactDisabled,
   onValueChange,
   onExactChange,
   onBlur,
@@ -29,27 +27,28 @@ export function TextFieldWithExactToggle({
       onChange={(e) => onValueChange(e.target.value)}
       onBlur={onBlur}
     >
-      <TextField.Slot side="right">
-        <Tooltip content="Exact match">
-          <IconButton
-            size="1"
-            disabled={exactDisabled}
-            aria-label="Toggle exact match"
-            aria-pressed={exact ? 'true' : 'false'}
-            variant="ghost"
-            color={exact ? 'orange' : 'gray'}
-            onClick={() => {
-              onExactChange(!exact)
-              onBlur?.()
-            }}
-            css={css`
-              margin-right: -var(--space-1);
-            `}
-          >
-            <WholeWordIcon />
-          </IconButton>
-        </Tooltip>
-      </TextField.Slot>
+      {value.trim().length > 0 && (
+        <TextField.Slot side="right">
+          <Tooltip content="Exact match">
+            <IconButton
+              size="1"
+              aria-label="Toggle exact match"
+              aria-pressed={exact ? 'true' : 'false'}
+              variant="ghost"
+              color={exact ? 'orange' : 'gray'}
+              onClick={() => {
+                onExactChange(!exact)
+                onBlur?.()
+              }}
+              css={css`
+                margin-right: -var(--space-1);
+              `}
+            >
+              <WholeWordIcon />
+            </IconButton>
+          </Tooltip>
+        </TextField.Slot>
+      )}
     </TextField.Root>
   )
 }

--- a/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
@@ -26,25 +26,23 @@ export function TextFieldWithExactToggle({
       onChange={(e) => onValueChange(e.target.value)}
       onBlur={onBlur}
     >
-      {value.trim().length > 0 && (
-        <TextField.Slot side="right">
-          <Tooltip content="Exact match">
-            <IconButton
-              size="1"
-              aria-label="Toggle exact match"
-              aria-pressed={exact ? 'true' : 'false'}
-              variant="ghost"
-              color={exact ? 'orange' : 'gray'}
-              onClick={() => {
-                onExactChange(!exact)
-                onBlur?.()
-              }}
-            >
-              <WholeWordIcon />
-            </IconButton>
-          </Tooltip>
-        </TextField.Slot>
-      )}
+      <TextField.Slot side="right">
+        <Tooltip content="Exact match">
+          <IconButton
+            size="1"
+            aria-label="Toggle exact match"
+            aria-pressed={exact ? 'true' : 'false'}
+            variant="ghost"
+            color={exact ? 'orange' : 'gray'}
+            onClick={() => {
+              onExactChange(!exact)
+              onBlur?.()
+            }}
+          >
+            <WholeWordIcon />
+          </IconButton>
+        </Tooltip>
+      </TextField.Slot>
     </TextField.Root>
   )
 }

--- a/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react'
 import { IconButton, TextField, Tooltip } from '@radix-ui/themes'
 import { WholeWordIcon } from 'lucide-react'
 
@@ -40,9 +39,6 @@ export function TextFieldWithExactToggle({
                 onExactChange(!exact)
                 onBlur?.()
               }}
-              css={css`
-                margin-right: -var(--space-1);
-              `}
             >
               <WholeWordIcon />
             </IconButton>

--- a/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/components/TextFieldWithExactToggle.tsx
@@ -1,0 +1,55 @@
+import { css } from '@emotion/react'
+import { IconButton, TextField, Tooltip } from '@radix-ui/themes'
+import { WholeWordIcon } from 'lucide-react'
+
+interface TextFieldWithExactToggleProps {
+  name: string
+  value: string
+  exact?: boolean
+  exactDisabled?: boolean
+  onValueChange: (value: string) => void
+  onExactChange: (exact: boolean) => void
+  onBlur?: () => void
+}
+
+export function TextFieldWithExactToggle({
+  name,
+  value,
+  exact,
+  exactDisabled,
+  onValueChange,
+  onExactChange,
+  onBlur,
+}: TextFieldWithExactToggleProps) {
+  return (
+    <TextField.Root
+      size="1"
+      name={name}
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+      onBlur={onBlur}
+    >
+      <TextField.Slot side="right">
+        <Tooltip content="Exact match">
+          <IconButton
+            size="1"
+            disabled={exactDisabled}
+            aria-label="Toggle exact match"
+            aria-pressed={exact ? 'true' : 'false'}
+            variant="ghost"
+            color={exact ? 'orange' : 'gray'}
+            onClick={() => {
+              onExactChange(!exact)
+              onBlur?.()
+            }}
+            css={css`
+              margin-right: -var(--space-1);
+            `}
+          >
+            <WholeWordIcon />
+          </IconButton>
+        </Tooltip>
+      </TextField.Slot>
+    </TextField.Root>
+  )
+}

--- a/src/views/BrowserTestEditor/ActionForms/components/index.ts
+++ b/src/views/BrowserTestEditor/ActionForms/components/index.ts
@@ -1,2 +1,3 @@
 export * from './ComboBox'
+export * from './TextFieldWithExactToggle'
 export * from './ValuePopoverBadge'

--- a/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
@@ -315,12 +315,12 @@ function DisplayValue({
       >
         <LocatorText locator={selector} />
       </span>
-      <ExactIcon locator={selector} />
+      <ExactMatchIndicator locator={selector} />
     </Flex>
   )
 }
 
-function ExactIcon({ locator }: { locator: NodeSelector }) {
+function ExactMatchIndicator({ locator }: { locator: NodeSelector }) {
   if (locator.type === 'test-id' || locator.type === 'css') {
     return null
   }

--- a/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
@@ -295,7 +295,17 @@ function DisplayValue({
   const selector = toNodeSelector(values[current]!)
   return (
     <Flex gap="1" align="center" overflow="hidden">
-      <LocatorIcon locator={selector} />
+      <LocatorIcon
+        locator={selector}
+        css={css`
+          && {
+            width: 12px;
+            height: 12px;
+            min-width: 12px;
+            min-height: 12px;
+          }
+        `}
+      />
       <span
         css={css`
           overflow: hidden;

--- a/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
@@ -1,11 +1,20 @@
 import { css } from '@emotion/react'
-import { Flex, Grid, Popover, RadioGroup, Separator } from '@radix-ui/themes'
+import {
+  Flex,
+  Grid,
+  Popover,
+  RadioGroup,
+  Separator,
+  Tooltip,
+} from '@radix-ui/themes'
+import { WholeWordIcon } from 'lucide-react'
 import { useState } from 'react'
 
 import { toNodeSelector } from '@/codegen/browser/selectors'
 import { LocatorIcon, LocatorText } from '@/components/Browser/Locator'
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
+import { NodeSelector } from '@/schemas/selectors'
 import { exhaustive } from '@/utils/typescript'
 
 import { LocatorOptions } from '../../types'
@@ -296,8 +305,27 @@ function DisplayValue({
       >
         <LocatorText locator={selector} />
       </span>
+      <ExactIcon locator={selector} />
     </Flex>
   )
+}
+
+function ExactIcon({ locator }: { locator: NodeSelector }) {
+  if (locator.type === 'test-id' || locator.type === 'css') {
+    return null
+  }
+
+  const exact =
+    locator.type === 'role' ? locator.name?.exact : locator.text.exact
+  if (exact) {
+    return (
+      <Tooltip content="Exact match">
+        <WholeWordIcon aria-label="Exact match" />
+      </Tooltip>
+    )
+  }
+
+  return null
 }
 
 function initializeLocatorValues(type: ActionLocator['type']): ActionLocator {

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByAltTextForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByAltTextForm.tsx
@@ -1,8 +1,7 @@
-import { TextField } from '@radix-ui/themes'
-
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
+import { TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 type AltLocator = Extract<ActionLocator, { type: 'alt' }>
@@ -28,11 +27,14 @@ export function GetByAltTextForm({
       mb="0"
       errors={toFieldErrors('alt', errors?.['alt'])}
     >
-      <TextField.Root
-        size="1"
+      <TextFieldWithExactToggle
         name="alt"
         value={locator.text}
-        onChange={(e) => onChange({ ...locator, text: e.target.value })}
+        exact={locator.options?.exact}
+        onValueChange={(value) => onChange({ ...locator, text: value })}
+        onExactChange={(exact) => {
+          onChange({ ...locator, options: { ...locator.options, exact } })
+        }}
         onBlur={onBlur}
       />
     </FieldGroup>

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByLabelForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByLabelForm.tsx
@@ -1,8 +1,7 @@
-import { TextField } from '@radix-ui/themes'
-
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
+import { TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 type LabelLocator = Extract<ActionLocator, { type: 'label' }>
@@ -28,11 +27,14 @@ export function GetByLabelForm({
       mb="0"
       errors={toFieldErrors('form-label', errors?.['form-label'])}
     >
-      <TextField.Root
-        size="1"
+      <TextFieldWithExactToggle
         name="form-label"
         value={locator.label}
-        onChange={(e) => onChange({ ...locator, label: e.target.value })}
+        exact={locator.options?.exact}
+        onValueChange={(value) => onChange({ ...locator, label: value })}
+        onExactChange={(exact) => {
+          onChange({ ...locator, options: { ...locator.options, exact } })
+        }}
         onBlur={onBlur}
       />
     </FieldGroup>

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByPlaceholderForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByPlaceholderForm.tsx
@@ -1,8 +1,7 @@
-import { TextField } from '@radix-ui/themes'
-
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
+import { TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 type PlaceholderLocator = Extract<ActionLocator, { type: 'placeholder' }>
@@ -28,11 +27,14 @@ export function GetByPlaceholderForm({
       mb="0"
       errors={toFieldErrors('placeholder', errors?.['placeholder'])}
     >
-      <TextField.Root
-        size="1"
+      <TextFieldWithExactToggle
         name="placeholder"
         value={locator.placeholder}
-        onChange={(e) => onChange({ ...locator, placeholder: e.target.value })}
+        exact={locator.options?.exact}
+        onValueChange={(value) => onChange({ ...locator, placeholder: value })}
+        onExactChange={(exact) => {
+          onChange({ ...locator, options: { ...locator.options, exact } })
+        }}
         onBlur={onBlur}
       />
     </FieldGroup>

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
@@ -64,7 +64,6 @@ export function GetByRoleForm({
           name="name"
           value={locator.options?.name || ''}
           exact={locator.options?.exact}
-          exactDisabled={!locator.options?.name}
           onValueChange={(value) => {
             onChange({
               ...locator,

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
@@ -1,11 +1,9 @@
-import { css } from '@emotion/react'
-import { Flex, IconButton, TextField, Tooltip } from '@radix-ui/themes'
-import { WholeWordIcon } from 'lucide-react'
+import { Flex } from '@radix-ui/themes'
 
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
-import { ComboBox } from '../../components'
+import { ComboBox, TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 const ROLE_OPTIONS = [
@@ -62,12 +60,12 @@ export function GetByRoleForm({
         mb="0"
         errors={toFieldErrors('name', errors?.['name'])}
       >
-        <TextField.Root
-          size="1"
+        <TextFieldWithExactToggle
           name="name"
           value={locator.options?.name || ''}
-          onChange={(e) => {
-            const value = e.target.value
+          exact={locator.options?.exact}
+          exactDisabled={!locator.options?.name}
+          onValueChange={(value) => {
             onChange({
               ...locator,
               options: {
@@ -76,36 +74,17 @@ export function GetByRoleForm({
               },
             })
           }}
+          onExactChange={(exact) => {
+            onChange({
+              ...locator,
+              options: {
+                ...locator.options,
+                exact,
+              },
+            })
+          }}
           onBlur={onBlur}
-        >
-          <TextField.Slot side="right">
-            <Tooltip content="Exact match">
-              <IconButton
-                size="1"
-                disabled={!locator.options?.name}
-                aria-label="Toggle exact match"
-                aria-pressed={locator.options?.exact ? 'true' : 'false'}
-                variant="ghost"
-                color={locator.options?.exact ? 'orange' : 'gray'}
-                onClick={() => {
-                  onChange({
-                    ...locator,
-                    options: {
-                      ...locator.options,
-                      exact: !locator.options?.exact,
-                    },
-                  })
-                  onBlur?.()
-                }}
-                css={css`
-                  margin: 0;
-                `}
-              >
-                <WholeWordIcon />
-              </IconButton>
-            </Tooltip>
-          </TextField.Slot>
-        </TextField.Root>
+        />
       </FieldGroup>
     </Flex>
   )

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByTextForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByTextForm.tsx
@@ -1,8 +1,7 @@
-import { TextField } from '@radix-ui/themes'
-
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
+import { TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 type TextLocator = Extract<ActionLocator, { type: 'text' }>
@@ -28,11 +27,14 @@ export function GetByTextForm({
       mb="0"
       errors={toFieldErrors('text-content', errors?.['text-content'])}
     >
-      <TextField.Root
-        size="1"
+      <TextFieldWithExactToggle
         name="text-content"
         value={locator.text}
-        onChange={(e) => onChange({ ...locator, text: e.target.value })}
+        exact={locator.options?.exact}
+        onValueChange={(value) => onChange({ ...locator, text: value })}
+        onExactChange={(exact) => {
+          onChange({ ...locator, options: { ...locator.options, exact } })
+        }}
         onBlur={onBlur}
       />
     </FieldGroup>

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByTitleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByTitleForm.tsx
@@ -1,8 +1,7 @@
-import { TextField } from '@radix-ui/themes'
-
 import { FieldGroup } from '@/components/Form'
 import { ActionLocator } from '@/main/runner/schema'
 
+import { TextFieldWithExactToggle } from '../../components'
 import { toFieldErrors } from '../utils'
 
 type TitleLocator = Extract<ActionLocator, { type: 'title' }>
@@ -28,11 +27,14 @@ export function GetByTitleForm({
       mb="0"
       errors={toFieldErrors('title', errors?.['title'])}
     >
-      <TextField.Root
-        size="1"
+      <TextFieldWithExactToggle
         name="title"
         value={locator.title}
-        onChange={(e) => onChange({ ...locator, title: e.target.value })}
+        exact={locator.options?.exact}
+        onValueChange={(value) => onChange({ ...locator, title: value })}
+        onExactChange={(exact) => {
+          onChange({ ...locator, options: { ...locator.options, exact } })
+        }}
         onBlur={onBlur}
       />
     </FieldGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add a way to toggle exact matching on and off in `getByAltText`, `getByTitle`, `getByText`, and `getByLabel`
- When the `exact` option is set, display it in the inline preview

<img width="495" height="242" alt="grafik" src="https://github.com/user-attachments/assets/2071de21-74e4-48d5-9688-9fea9062a0c1" />

⚠️ The icon used for the exact match toggle is the same as the one we user for placeholder locator. Since this isn't user-facing yet, I decided to address this in a separate PR.

## How to Test
- Create a new "Wait for element" action and configure one of the locators mentioned above
- Toggle exact matching on and off and verify that the changes are reflected in the generated script

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates locator data shapes and codegen to pass through optional `exact` matching for multiple locator types; risk is mainly around compatibility with existing serialized locator payloads and generated scripts changing behavior when `exact` is set.
> 
> **Overview**
> Adds optional `exact` matching support across text-based locators (**alt/label/placeholder/title/text**) end-to-end: runner schemas and page proxies now accept/preserve `options.exact`, the selector model is updated to carry `{ value, exact }`, and DOM querying honors the flag when resolving selectors.
> 
> Code generation is updated to emit locator option objects (via new IR `TextLocatorOptionsExpression`) instead of forcing exact matching, and the test snapshots are updated accordingly. The Browser Test Editor UI gains a reusable `TextFieldWithExactToggle` and shows an inline *exact match* indicator in the locator preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e84dddebde7fece38297844f3cad3a1a031098a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->