### PR TITLE
fix(autocorrelation): Handle streaming errors in AI chat handler

### DIFF
--- a/src/handlers/ai/index.test.ts
+++ b/src/handlers/ai/index.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { UIMessage } from 'ai'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { AiHandler, StreamChatChunk, StreamChatEnd } from './types'
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    on: vi.fn(),
+  },
+}))
+
+vi.mock('./model', () => ({
+  getOpenAiModel: vi.fn(),
+  getGrafanaAssistantModel: vi.fn(),
+}))
+
+vi.mock('./a2a/assistantAuth', () => ({
+  initialize: vi.fn(),
+}))
+
+function createMockWebContents() {
+  return { send: vi.fn() } as unknown as Electron.WebContents
+}
+
+function createUserMessage(text: string): UIMessage {
+  return {
+    id: 'msg-1',
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  }
+}
+
+async function getStreamChatHandler() {
+  const { ipcMain } = await import('electron')
+  const { initialize } = await import('./index')
+  initialize()
+
+  const calls = vi.mocked(ipcMain.on).mock.calls
+  const entry = calls.find(
+    ([channel]) => channel === (AiHandler.StreamChat as string)
+  )
+  return entry![1] as (...args: unknown[]) => Promise<void>
+}
+
+function getSentChunks(webContents: Electron.WebContents) {
+  return vi
+    .mocked(webContents.send)
+    .mock.calls.filter(
+      (call): call is [string, StreamChatChunk] =>
+        call[0] === (AiHandler.StreamChatChunk as string)
+    )
+    .map(([, data]) => data)
+}
+
+function getSentEnds(webContents: Electron.WebContents) {
+  return vi
+    .mocked(webContents.send)
+    .mock.calls.filter(
+      (call): call is [string, StreamChatEnd] =>
+        call[0] === (AiHandler.StreamChatEnd as string)
+    )
+    .map(([, data]) => data)
+}
+
+describe('handleStreamChat error handling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('forwards the error chunk and sends StreamChatEnd when the model throws', async () => {
+    const { getOpenAiModel } = await import('./model')
+    vi.mocked(getOpenAiModel).mockResolvedValue({
+      specificationVersion: 'v2',
+      provider: 'test',
+      modelId: 'test',
+      supportedUrls: {},
+      // eslint-disable-next-line @typescript-eslint/require-await
+      doStream: async () => {
+        throw new Error('insufficient_quota: You exceeded your current quota')
+      },
+      // eslint-disable-next-line @typescript-eslint/require-await
+      doGenerate: async () => {
+        throw new Error('not implemented')
+      },
+    })
+
+    const handler = await getStreamChatHandler()
+    const webContents = createMockWebContents()
+
+    await handler(
+      { sender: webContents },
+      {
+        id: 'req-1',
+        trigger: 'submit-message',
+        messages: [createUserMessage('Hello')],
+      }
+    )
+
+    // The AI SDK's toUIMessageStream emits an error chunk with the real error
+    const chunks = getSentChunks(webContents)
+    const errorChunk = chunks.find((data) => data.chunk?.type === 'error')
+    expect(errorChunk).toBeDefined()
+    expect(errorChunk?.chunk).toHaveProperty('errorText')
+
+    // StreamChatEnd must always be sent so the renderer doesn't hang
+    const ends = getSentEnds(webContents)
+    expect(ends).toHaveLength(1)
+    expect(ends[0]?.id).toBe('req-1')
+  })
+
+  it('sends an error chunk and StreamChatEnd when message conversion fails', async () => {
+    const handler = await getStreamChatHandler()
+    const webContents = createMockWebContents()
+
+    await handler(
+      { sender: webContents },
+      {
+        id: 'req-2',
+        trigger: 'submit-message',
+        // Messages with null parts cause convertToModelMessages to throw
+        messages: [
+          { role: 'user', id: 'x', parts: null } as unknown as UIMessage,
+        ],
+      }
+    )
+
+    // Should send an error chunk from the catch block
+    const chunks = getSentChunks(webContents)
+    const errorChunk = chunks.find((data) => data.chunk?.type === 'error')
+    expect(errorChunk).toBeDefined()
+
+    // StreamChatEnd must always be sent
+    const ends = getSentEnds(webContents)
+    expect(ends).toHaveLength(1)
+    expect(ends[0]?.id).toBe('req-2')
+  })
+})

--- a/src/handlers/ai/index.ts
+++ b/src/handlers/ai/index.ts
@@ -1,4 +1,5 @@
 import { OpenAIResponsesProviderOptions } from '@ai-sdk/openai'
+import { getErrorMessage } from '@ai-sdk/provider-utils'
 import { convertToModelMessages, streamText } from 'ai'
 import { ipcMain, IpcMainEvent } from 'electron'
 
@@ -22,12 +23,12 @@ async function handleStreamChat(
   request: StreamChatRequest
 ) {
   const provider = request.provider ?? 'openai'
-  const messages = convertToModelMessages(request.messages)
-
   const abortController = new AbortController()
   activeAbortControllers.set(request.id, abortController)
 
   try {
+    const messages = convertToModelMessages(request.messages)
+
     if (provider === 'grafana-assistant') {
       const aiModel = getGrafanaAssistantModel()
 
@@ -62,8 +63,15 @@ async function handleStreamChat(
 
       await streamMessages(event.sender, response, request.id, true)
     }
+  } catch (error) {
+    event.sender.send(AiHandler.StreamChatChunk, {
+      id: request.id,
+      chunk: { type: 'error', errorText: getErrorMessage(error) },
+    })
+    event.sender.send(AiHandler.StreamChatEnd, {
+      id: request.id,
+    })
   } finally {
-    // Clean up the AbortController after streaming completes or fails
     activeAbortControllers.delete(request.id)
   }
 }

--- a/src/handlers/ai/streamMessages.ts
+++ b/src/handlers/ai/streamMessages.ts
@@ -17,7 +17,9 @@ export async function streamMessages<Tools extends ToolSet, PARTIAL_OUTPUT>(
     })
   }
 
-  const usageData = includeUsage ? await response.usage : undefined
+  const usageData = includeUsage
+    ? await response.usage.catch(() => undefined)
+    : undefined
 
   webContents.send(AiHandler.StreamChatEnd, {
     id: requestId,


### PR DESCRIPTION
## Summary

- Errors from `streamText` (OpenAI quota exceeded, invalid prompt, etc.) were not caught in `handleStreamChat`, causing unhandled rejections (Sentry K6-STUDIO-VP, 110 events)
- The renderer never received `StreamChatEnd` after errors, leaving the UI in a broken state instead of showing the appropriate error message (quota exceeded, invalid key, etc.)
- `response.usage` threw `NoOutputGeneratedError` after stream errors, propagating a misleading error

## Changes

- **`src/handlers/ai/index.ts`**: Added `catch` block to forward errors as error chunks and always send `StreamChatEnd`
- **`src/handlers/ai/streamMessages.ts`**: Prevent `NoOutputGeneratedError` from propagating when usage data is unavailable after a stream error
- **`src/handlers/ai/index.test.ts`**: Tests for model errors and pre-stream errors (e.g., invalid messages)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the AI chat IPC streaming flow to add new error/cleanup behavior; while scoped, it changes how failures are surfaced to the renderer and could affect user-visible chat completion/termination semantics.
> 
> **Overview**
> **Prevents AI chat from hanging on streaming failures.** `handleStreamChat` now wraps message conversion + `streamText` execution in a `try/catch` and, on any error, sends an explicit `StreamChatChunk` of type `error` plus a guaranteed `StreamChatEnd`.
> 
> `streamMessages` now treats `response.usage` as best-effort (returns `undefined` if it throws after a failed stream) to avoid masking the original failure. Adds Vitest coverage for both model-stream exceptions (e.g. quota errors) and pre-stream conversion errors to ensure `StreamChatEnd` is always emitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ffd6da03810d24091bcb30ae542956b351e00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->