### PR TITLE
internal(browser): Add Click action support to Browser Test Editor

### DIFF
--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -381,10 +381,24 @@ function buildBrowserNodeGraphFromActions(
           },
           options: action.options,
         }
+      case 'locator.click':
+        return {
+          type: 'click',
+          nodeId: crypto.randomUUID(),
+          button: 'left',
+          modifiers: {
+            ctrl: false,
+            shift: false,
+            alt: false,
+            meta: false,
+          },
+          inputs: {
+            locator: getLocator(action.locator),
+          },
+        }
       case 'page.waitForNavigation':
       case 'page.close':
       case 'page.*':
-      case 'locator.click':
       case 'locator.dblclick':
       case 'locator.fill':
       case 'locator.type':

--- a/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.tsx
@@ -1,0 +1,31 @@
+import { Grid } from '@radix-ui/themes'
+
+import { LocatorClickAction } from '@/main/runner/schema'
+
+import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
+import { WithEditorMetadata } from '../../types'
+
+interface ClickActionBodyProps {
+  action: WithEditorMetadata<LocatorClickAction>
+  onChange: (action: WithEditorMetadata<LocatorClickAction>) => void
+}
+
+export function ClickActionBody({ action, onChange }: ClickActionBodyProps) {
+  const handleChangeLocator = (
+    locator: WithEditorMetadata<LocatorClickAction>['locator']
+  ) => {
+    onChange({ ...action, locator })
+  }
+
+  return (
+    <Grid
+      columns="max-content minmax(0, max-content) 1fr"
+      gap="2"
+      align="center"
+      width="100%"
+    >
+      Click
+      <LocatorForm state={action.locator} onChange={handleChangeLocator} />
+    </Grid>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/ClickAction/index.ts
+++ b/src/views/BrowserTestEditor/Actions/ClickAction/index.ts
@@ -1,0 +1,1 @@
+export * from './ClickActionBody'

--- a/src/views/BrowserTestEditor/Actions/index.ts
+++ b/src/views/BrowserTestEditor/Actions/index.ts
@@ -1,3 +1,4 @@
+export * from './ClickAction'
 export * from './GoToAction'
 export * from './PageReloadAction'
 export * from './WaitForAction'

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -78,6 +78,13 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
       <DropdownMenu.Content>
         <DropdownMenu.Item
           onClick={() => {
+            onAddAction('locator.click')
+          }}
+        >
+          Click element
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
             onAddAction('page.goto')
           }}
         >

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -15,6 +15,7 @@ import {
   WaitForActionBody,
 } from './Actions'
 import { BrowserActionInstance } from './types'
+import { createDefaultLocatorOptions } from './utils'
 
 type ActionByMethod<M extends BrowserActionInstance['method']> = Extract<
   BrowserActionInstance,
@@ -63,15 +64,7 @@ const actionEditors: ActionEditorRegistry = {
     create: () => ({
       id: crypto.randomUUID(),
       method: 'locator.click',
-      locator: {
-        current: 'css',
-        values: {
-          css: {
-            type: 'css',
-            selector: '',
-          },
-        },
-      },
+      locator: createDefaultLocatorOptions(),
     }),
   },
   'page.goto': {
@@ -101,15 +94,7 @@ const actionEditors: ActionEditorRegistry = {
     create: () => ({
       id: crypto.randomUUID(),
       method: 'locator.waitFor',
-      locator: {
-        current: 'css',
-        values: {
-          css: {
-            type: 'css',
-            selector: '',
-          },
-        },
-      },
+      locator: createDefaultLocatorOptions(),
     }),
   },
 }

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -2,12 +2,14 @@ import { Code } from '@radix-ui/themes'
 import {
   CircleQuestionMarkIcon,
   GlobeIcon,
+  MousePointerClickIcon,
   RefreshCwIcon,
   TimerIcon,
 } from 'lucide-react'
 import { ReactElement, ReactNode } from 'react'
 
 import {
+  ClickActionBody,
   GoToActionBody,
   PageReloadActionBody,
   WaitForActionBody,
@@ -53,6 +55,25 @@ const notImplementedCreate = <M extends BrowserActionInstance['method']>(
 }
 
 const actionEditors: ActionEditorRegistry = {
+  'locator.click': {
+    icon: <MousePointerClickIcon aria-hidden="true" />,
+    render: ({ action, onChange }) => (
+      <ClickActionBody action={action} onChange={onChange} />
+    ),
+    create: () => ({
+      id: crypto.randomUUID(),
+      method: 'locator.click',
+      locator: {
+        current: 'css',
+        values: {
+          css: {
+            type: 'css',
+            selector: '',
+          },
+        },
+      },
+    }),
+  },
   'page.goto': {
     icon: <GlobeIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (

--- a/src/views/BrowserTestEditor/utils.ts
+++ b/src/views/BrowserTestEditor/utils.ts
@@ -1,0 +1,13 @@
+import { LocatorOptions } from './types'
+
+export function createDefaultLocatorOptions(): LocatorOptions {
+  return {
+    current: 'css',
+    values: {
+      css: {
+        type: 'css',
+        selector: '',
+      },
+    },
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add basic support for the click action
- ⚠️ This PR doesn't implement any options just yet

<img width="1448" height="897" alt="grafik" src="https://github.com/user-attachments/assets/2f6bb627-2e13-41f4-8915-3d421f0cc9a0" />


## How to Test

- Add a new "Click element" action
- Configure the locator
- Verify that the action appears in the generated script

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new action type that affects browser test script generation and editor behavior; mistakes could produce incorrect or non-functional generated tests, though scope is limited and options are currently hardcoded.
> 
> **Overview**
> Adds **basic `locator.click` support** end-to-end in the Browser Test Editor.
> 
> The editor can now create and edit a new “Click element” action (new `ClickActionBody`, menu item, and registry entry with icon) and uses a shared `createDefaultLocatorOptions()` helper for default locator initialization.
> 
> Code generation (`convertActionsToTest` in `src/codegen/browser/test.ts`) now converts `locator.click` actions into `click` test nodes with default left-button and no-modifier settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ab7143cfa69e6153b155ee7f4a7a1feed5070b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->