### PR TITLE
internal(browser): Add support for fill action to Browser Test Editor

### DIFF
--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -396,11 +396,19 @@ function buildBrowserNodeGraphFromActions(
             locator: getLocator(action.locator),
           },
         }
+      case 'locator.fill':
+        return {
+          type: 'type-text',
+          nodeId: crypto.randomUUID(),
+          value: action.value,
+          inputs: {
+            locator: getLocator(action.locator),
+          },
+        }
       case 'page.waitForNavigation':
       case 'page.close':
       case 'page.*':
       case 'locator.dblclick':
-      case 'locator.fill':
       case 'locator.type':
       case 'locator.check':
       case 'locator.uncheck':

--- a/src/views/BrowserTestEditor/ActionForms/forms/FillValueForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/FillValueForm.tsx
@@ -1,0 +1,33 @@
+import { Popover, TextArea } from '@radix-ui/themes'
+import { useState } from 'react'
+
+import { FieldGroup } from '@/components/Form'
+
+import { ValuePopoverBadge } from '../components'
+
+interface FillValueFormProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export function FillValueForm({ value, onChange }: FillValueFormProps) {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false)
+
+  return (
+    <Popover.Root open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <Popover.Trigger>
+        <ValuePopoverBadge displayValue={`"${value}"`} />
+      </Popover.Trigger>
+      <Popover.Content align="start" size="1" width="300px">
+        <FieldGroup name="value" label="Value" labelSize="1" mb="0">
+          <TextArea
+            size="1"
+            name="value"
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+          />
+        </FieldGroup>
+      </Popover.Content>
+    </Popover.Root>
+  )
+}

--- a/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/LocatorForm.tsx
@@ -36,11 +36,13 @@ const LOCATOR_TYPES: Record<ActionLocator['type'], string> = {
 interface LocatorFormProps {
   state: LocatorOptions
   onChange: (value: LocatorOptions) => void
+  suggestedRoles?: string[]
 }
 
 export function LocatorForm({
   state: { current, values },
   onChange,
+  suggestedRoles,
 }: LocatorFormProps) {
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
   const [touchedTypes, setTouchedTypes] = useState(
@@ -133,6 +135,7 @@ export function LocatorForm({
             errors={validation.fieldErrors}
             onChange={handleLocatorChange}
             onBlur={handleFieldBlur}
+            suggestedRoles={suggestedRoles}
           />
         </Grid>
       </Popover.Content>
@@ -145,6 +148,7 @@ interface LocatorFieldsFormProps {
   errors?: Record<string, string>
   onChange: (locator: ActionLocator) => void
   onBlur?: () => void
+  suggestedRoles?: string[]
 }
 
 function LocatorFieldsForm({
@@ -152,6 +156,7 @@ function LocatorFieldsForm({
   errors,
   onChange,
   onBlur,
+  suggestedRoles,
 }: LocatorFieldsFormProps) {
   switch (locator.type) {
     case 'role':
@@ -161,6 +166,7 @@ function LocatorFieldsForm({
           errors={errors}
           onChange={onChange}
           onBlur={onBlur}
+          suggestedRoles={suggestedRoles}
         />
       )
     case 'css':

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
@@ -8,7 +8,7 @@ import { ActionLocator } from '@/main/runner/schema'
 import { ComboBox } from '../../components'
 import { toFieldErrors } from '../utils'
 
-const ROLE_OPTIONS = [
+const DEFAULT_ROLES = [
   'button',
   'link',
   'checkbox',
@@ -19,7 +19,11 @@ const ROLE_OPTIONS = [
   'combobox',
   'listbox',
   'option',
-].map((role) => ({ value: role, label: role }))
+]
+
+function toRoleOptions(roles: string[]) {
+  return roles.map((role) => ({ value: role, label: role }))
+}
 
 type RoleLocator = Extract<ActionLocator, { type: 'role' }>
 
@@ -28,6 +32,7 @@ interface GetByRoleFormProps {
   errors?: Record<string, string>
   onChange: (locator: ActionLocator) => void
   onBlur?: () => void
+  suggestedRoles?: string[]
 }
 
 export function GetByRoleForm({
@@ -35,6 +40,7 @@ export function GetByRoleForm({
   errors,
   onChange,
   onBlur,
+  suggestedRoles,
 }: GetByRoleFormProps) {
   return (
     <Flex direction="column" gap="2" align="stretch">
@@ -48,7 +54,7 @@ export function GetByRoleForm({
         <ComboBox
           id="role"
           value={locator.role}
-          options={ROLE_OPTIONS}
+          options={toRoleOptions(suggestedRoles ?? DEFAULT_ROLES)}
           onChange={(value) => {
             onChange({ ...locator, role: value.trim() })
             onBlur?.()

--- a/src/views/BrowserTestEditor/Actions/FillAction/FillActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/FillAction/FillActionBody.tsx
@@ -1,0 +1,44 @@
+import { Grid } from '@radix-ui/themes'
+
+import { LocatorFillAction } from '@/main/runner/schema'
+
+import { FillValueForm } from '../../ActionForms/forms/FillValueForm'
+import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
+import { WithEditorMetadata } from '../../types'
+
+const FILL_ROLES = ['textbox', 'searchbox', 'combobox']
+
+interface FillActionBodyProps {
+  action: WithEditorMetadata<LocatorFillAction>
+  onChange: (action: WithEditorMetadata<LocatorFillAction>) => void
+}
+
+export function FillActionBody({ action, onChange }: FillActionBodyProps) {
+  const handleChangeLocator = (
+    locator: WithEditorMetadata<LocatorFillAction>['locator']
+  ) => {
+    onChange({ ...action, locator })
+  }
+
+  const handleChangeValue = (value: string) => {
+    onChange({ ...action, value })
+  }
+
+  return (
+    <Grid
+      columns="max-content minmax(0, max-content) minmax(0, max-content) 1fr"
+      gap="2"
+      align="center"
+      width="100%"
+    >
+      Fill
+      <LocatorForm
+        state={action.locator}
+        onChange={handleChangeLocator}
+        suggestedRoles={FILL_ROLES}
+      />
+      with
+      <FillValueForm value={action.value} onChange={handleChangeValue} />
+    </Grid>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/FillAction/index.ts
+++ b/src/views/BrowserTestEditor/Actions/FillAction/index.ts
@@ -1,0 +1,1 @@
+export * from './FillActionBody'

--- a/src/views/BrowserTestEditor/Actions/index.ts
+++ b/src/views/BrowserTestEditor/Actions/index.ts
@@ -1,4 +1,5 @@
 export * from './ClickAction'
+export * from './FillAction'
 export * from './GoToAction'
 export * from './PageReloadAction'
 export * from './WaitForAction'

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -85,6 +85,13 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
         </DropdownMenu.Item>
         <DropdownMenu.Item
           onClick={() => {
+            onAddAction('locator.fill')
+          }}
+        >
+          Fill input
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
             onAddAction('page.goto')
           }}
         >

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -4,12 +4,14 @@ import {
   GlobeIcon,
   MousePointerClickIcon,
   RefreshCwIcon,
+  TextCursorInputIcon,
   TimerIcon,
 } from 'lucide-react'
 import { ReactElement, ReactNode } from 'react'
 
 import {
   ClickActionBody,
+  FillActionBody,
   GoToActionBody,
   PageReloadActionBody,
   WaitForActionBody,
@@ -64,6 +66,18 @@ const actionEditors: ActionEditorRegistry = {
     create: () => ({
       id: crypto.randomUUID(),
       method: 'locator.click',
+      locator: createDefaultLocatorOptions(),
+    }),
+  },
+  'locator.fill': {
+    icon: <TextCursorInputIcon aria-hidden="true" />,
+    render: ({ action, onChange }) => (
+      <FillActionBody action={action} onChange={onChange} />
+    ),
+    create: () => ({
+      id: crypto.randomUUID(),
+      method: 'locator.fill',
+      value: '',
       locator: createDefaultLocatorOptions(),
     }),
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Support for the `locator.fill()` action
- ⚠️ This PR doesn't include `options` to make it easier to review. Options will be added at a later stage

<img width="1448" height="897" alt="grafik" src="https://github.com/user-attachments/assets/c162324f-34dd-444e-94a1-fb454eff6d90" />


## How to Test

- Add a new `Fill input` action
- Configure the action
- Verify that the `locator.fill()` appears in the script with the value you provided

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new Browser Test Editor action and UI wiring, plus a straightforward codegen mapping for `locator.fill` to an existing `type-text` node.
> 
> **Overview**
> Adds Browser Test Editor support for a new **Fill input** action (`locator.fill`): it can be created from the action menu, edited via a new `FillActionBody` (locator + value), and is registered in `actionEditorRegistry` with an icon and default state.
> 
> Updates browser test codegen (`convertActionsToTest`) to emit a `type-text` node for `locator.fill`, and enhances locator role selection by allowing `LocatorForm`/`GetByRoleForm` to accept `suggestedRoles` (used by Fill to bias toward input-like roles).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed23d8180efbd2b4b7860c3fd50dd36c618dab22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->