### PR TITLE
feat: record OpenWindow and ResizeWindow events

### DIFF
--- a/extension/src/frontend/recording.ts
+++ b/extension/src/frontend/recording.ts
@@ -17,6 +17,8 @@ import { WindowEventManager } from './manager'
 import { getTabId } from './utils'
 
 export function startRecording(client: BrowserExtensionClient) {
+  const RESIZE_DEBOUNCE_MS = 250
+
   function getButton(button: number) {
     switch (button) {
       case 0:
@@ -41,6 +43,53 @@ export function startRecording(client: BrowserExtensionClient) {
   }
 
   const manager = new WindowEventManager()
+
+  // Record initial window size once when recording starts.
+  recordEvents({
+    type: 'open-window',
+    eventId: nanoid(),
+    timestamp: Date.now(),
+    tab: getTabId(),
+    dimensions: { width: window.innerWidth, height: window.innerHeight },
+  })
+
+  // Record resize once the resize interaction has "settled".
+  let resizeDebounce: ReturnType<typeof setTimeout> | null = null
+  let lastEmittedSize: { width: number; height: number } | null = null
+
+  window.addEventListener(
+    'resize',
+    () => {
+      if (resizeDebounce !== null) {
+        clearTimeout(resizeDebounce)
+      }
+
+      resizeDebounce = setTimeout(() => {
+        resizeDebounce = null
+
+        const dimensions = { width: window.innerWidth, height: window.innerHeight }
+
+        if (
+          lastEmittedSize !== null &&
+          lastEmittedSize.width === dimensions.width &&
+          lastEmittedSize.height === dimensions.height
+        ) {
+          return
+        }
+
+        lastEmittedSize = dimensions
+
+        recordEvents({
+          type: 'resize-window',
+          eventId: nanoid(),
+          timestamp: Date.now(),
+          tab: getTabId(),
+          dimensions,
+        })
+      }, RESIZE_DEBOUNCE_MS)
+    },
+    { capture: true }
+  )
 
   manager.capture('click', (ev, manager) => {
     if (ev.target instanceof Element === false) {

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -139,6 +139,10 @@ function buildBrowserNodeGraphFromEvents(events: BrowserEvent[]) {
     nextEvent?: BrowserEvent
   ): TestNode | null {
     switch (event.type) {
+      case 'open-window':
+      case 'resize-window':
+        return null
+
       case 'navigate-to-page':
         if (event.source === 'implicit') {
           return null

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -22,6 +22,20 @@ export function EventDescription({
   onHighlight,
 }: EventDescriptionProps) {
   switch (event.type) {
+    case 'open-window':
+      return (
+        <>
+          Opened window ({event.dimensions.width}×{event.dimensions.height})
+        </>
+      )
+
+    case 'resize-window':
+      return (
+        <>
+          Resized window to ({event.dimensions.width}×{event.dimensions.height})
+        </>
+      )
+
     case 'navigate-to-page':
       return <PageNavigationDescription event={event} onNavigate={onNavigate} />
 

--- a/src/components/BrowserEventList/EventIcon.tsx
+++ b/src/components/BrowserEventList/EventIcon.tsx
@@ -6,6 +6,7 @@ import {
   EyeIcon,
   GlobeIcon,
   ListFilterPlusIcon,
+  MonitorIcon,
   RefreshCwIcon,
   TargetIcon,
   TextCursorInputIcon,
@@ -21,6 +22,10 @@ interface EventIconProps {
 
 export function EventIcon({ event }: EventIconProps) {
   switch (event.type) {
+    case 'open-window':
+    case 'resize-window':
+      return <MonitorIcon />
+
     case 'navigate-to-page':
       return <GlobeIcon />
 

--- a/src/schemas/recording/browser/v2/index.ts
+++ b/src/schemas/recording/browser/v2/index.ts
@@ -31,6 +31,23 @@ const BrowserEventBaseSchema = z.object({
   timestamp: z.number(),
 })
 
+const WindowDimensionsSchema = z.object({
+  width: z.number().int().nonnegative(),
+  height: z.number().int().nonnegative(),
+})
+
+const OpenWindowEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('open-window'),
+  tab: z.string(),
+  dimensions: WindowDimensionsSchema,
+})
+
+const ResizeWindowEventSchema = BrowserEventBaseSchema.extend({
+  type: z.literal('resize-window'),
+  tab: z.string(),
+  dimensions: WindowDimensionsSchema,
+})
+
 const NavigateToPageEventSchema = BrowserEventBaseSchema.extend({
   type: z.literal('navigate-to-page'),
   tab: z.string(),
@@ -163,6 +180,8 @@ const WaitForEventSchema = BrowserEventBaseSchema.extend({
 })
 
 export const BrowserEventSchema = z.discriminatedUnion('type', [
+  OpenWindowEventSchema,
+  ResizeWindowEventSchema,
   NavigateToPageEventSchema,
   ReloadPageEventSchema,
   ClickEventSchema,
@@ -197,6 +216,8 @@ export type SelectChangeEvent = z.infer<typeof SelectChangeEventSchema>
 export type SubmitFormEvent = z.infer<typeof SubmitFormEventSchema>
 export type AssertEvent = z.infer<typeof AssertEventSchema>
 export type WaitForEvent = z.infer<typeof WaitForEventSchema>
+export type OpenWindowEvent = z.infer<typeof OpenWindowEventSchema>
+export type ResizeWindowEvent = z.infer<typeof ResizeWindowEventSchema>
 
 export type TextAssertion = z.infer<typeof TextAssertionSchema>
 export type VisibilityAssertion = z.infer<typeof VisibilityAssertionSchema>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds two new browser recording events:

- `open-window`: emitted once when the recording starts, includes initial window `dimensions`.
- `resize-window`: emitted after a resize interaction settles (debounced), includes final window `dimensions`.

Codegen treats these as no-ops for now.

Demo:

[demo_open_and_resize_window.mp4](https://cursor.com/agents/bc-d169d27f-59c8-4cdf-813c-6d8833b7d760/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo_open_and_resize_window.mp4)

[Recorder browser events list showing open-window and resize-window](https://cursor.com/agents/bc-d169d27f-59c8-4cdf-813c-6d8833b7d760/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frecorder_window_open_resize_events.webp)

## How to Test

- Start the app in recorder mode, begin recording.
- Confirm an `open-window` event appears with the current size.
- Resize the browser window and stop resizing.
- Confirm exactly one `resize-window` event is recorded with the final size.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

N/A


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d169d27f-59c8-4cdf-813c-6d8833b7d760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d169d27f-59c8-4cdf-813c-6d8833b7d760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

