### PR TITLE
feat: Add SessionPlayer as default tab in browser test editor

### DIFF
--- a/src/views/BrowserTestEditor/BrowserTestEditor.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.tsx
@@ -10,6 +10,7 @@ import { Group, Panel, Separator } from '@/components/primitives/ResizablePanel'
 import { routeMap } from '@/routeMap'
 import { BrowserTestFile } from '@/schemas/browserTest/v1'
 import { StudioFile } from '@/types'
+import { SessionPlayer } from '@src/views/Validator/Browser/SessionPlayer/SessionPlayer'
 
 import { NetworkInspector } from '../Validator/Browser/NetworkInspector'
 import { useDebugSession } from '../Validator/Validator.hooks'
@@ -95,27 +96,25 @@ function BrowserTestEditorView({ file, data }: BrowserTestEditorViewProps) {
                   `}
                 >
                   <Panel id="main" minSize={200}>
-                    <Tabs.Root asChild defaultValue="script">
+                    <Tabs.Root asChild defaultValue="replay">
                       <Flex direction="column" height="100%" width="100%">
                         <Tabs.List>
-                          <Tabs.Trigger
-                            disabled
-                            css={css`
-                              /* 
-                             * Since we currently only have a single tab, we disable the
-                             * hover styling. This should be removed once we have more tabs.
-                             */
-                              cursor: default;
-
-                              &:hover .rt-TabsTriggerInner {
-                                background-color: transparent;
-                              }
-                            `}
-                            value="script"
-                          >
-                            Script
-                          </Tabs.Trigger>
+                          <Tabs.Trigger value="replay">Replay</Tabs.Trigger>
+                          <Tabs.Trigger value="script">Script</Tabs.Trigger>
                         </Tabs.List>
+                        <Tabs.Content
+                          css={css`
+                            flex: 1 1 0;
+                            overflow: hidden;
+                          `}
+                          value="replay"
+                        >
+                          <SessionPlayer
+                            key={session.id}
+                            session={session}
+                            highlightedSelector={null}
+                          />
+                        </Tabs.Content>
                         <Tabs.Content
                           css={css`
                             flex: 1 1 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@src/*": ["src/*"]
     },
     "types": [
       "vite/client",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a **Replay** tab next to **Script** in the browser test editor’s main panel. The replay view uses the existing `SessionPlayer` from `src/views/Validator/Browser/SessionPlayer` (imported via `@src/...` so incoming merges can align with that path). **Replay** is the first tab and the default (`defaultValue="replay"`).

Introduces a `@src/*` TypeScript path alias (same resolution as `@/*`) so the `@src/views/...` import resolves in the IDE and Vite.

`SessionPlayer` receives `highlightedSelector={null}` for now (no locator highlight wiring in the editor yet).

## How to Test

1. Open a browser test in the editor (`#/editor/<name>.k6b`).
2. Confirm the main left panel shows **Replay** first and opens on that tab by default.
3. Start a run from the controls; confirm replay UI behaves as in the validator (timeline, viewport).
4. Switch to **Script** and confirm the generated TypeScript preview still appears.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dd61bdd-cf69-43ad-90f2-0559c50e0f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dd61bdd-cf69-43ad-90f2-0559c50e0f3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

