### PR TITLE
internal(browser): Add Check/Uncheck action to Browser Test Editor

### DIFF
--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -396,6 +396,24 @@ function buildBrowserNodeGraphFromActions(
             locator: getLocator(action.locator),
           },
         }
+      case 'locator.check':
+        return {
+          type: 'check',
+          nodeId: crypto.randomUUID(),
+          checked: true,
+          inputs: {
+            locator: getLocator(action.locator),
+          },
+        }
+      case 'locator.uncheck':
+        return {
+          type: 'check',
+          nodeId: crypto.randomUUID(),
+          checked: false,
+          inputs: {
+            locator: getLocator(action.locator),
+          },
+        }
       case 'locator.fill':
         return {
           type: 'type-text',
@@ -410,8 +428,6 @@ function buildBrowserNodeGraphFromActions(
       case 'page.*':
       case 'locator.dblclick':
       case 'locator.type':
-      case 'locator.check':
-      case 'locator.uncheck':
       case 'locator.selectOption':
       case 'locator.hover':
       case 'locator.setChecked':

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
@@ -40,6 +40,10 @@ export function GetByRoleForm({
   onBlur,
   suggestedRoles,
 }: GetByRoleFormProps) {
+  const roleOptions = allowedRoles
+    ? ALL_ROLE_OPTIONS.filter((opt) => allowedRoles.includes(opt.value))
+    : ALL_ROLE_OPTIONS
+
   return (
     <Flex direction="column" gap="2" align="stretch">
       <FieldGroup

--- a/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/locators/GetByRoleForm.tsx
@@ -40,10 +40,6 @@ export function GetByRoleForm({
   onBlur,
   suggestedRoles,
 }: GetByRoleFormProps) {
-  const roleOptions = allowedRoles
-    ? ALL_ROLE_OPTIONS.filter((opt) => allowedRoles.includes(opt.value))
-    : ALL_ROLE_OPTIONS
-
   return (
     <Flex direction="column" gap="2" align="stretch">
       <FieldGroup

--- a/src/views/BrowserTestEditor/Actions/CheckAction/CheckActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/CheckAction/CheckActionBody.tsx
@@ -1,0 +1,33 @@
+import { Grid } from '@radix-ui/themes'
+
+import { LocatorCheckAction } from '@/main/runner/schema'
+
+import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
+import { WithEditorMetadata } from '../../types'
+
+const CHECK_ROLES = ['checkbox', 'radio', 'switch']
+
+interface CheckActionBodyProps {
+  action: WithEditorMetadata<LocatorCheckAction>
+  onChange: (action: WithEditorMetadata<LocatorCheckAction>) => void
+}
+
+export function CheckActionBody({ action, onChange }: CheckActionBodyProps) {
+  const handleChangeLocator = (
+    locator: WithEditorMetadata<LocatorCheckAction>['locator']
+  ) => {
+    onChange({ ...action, locator })
+  }
+
+  return (
+    <Grid
+      columns="max-content minmax(0, max-content) 1fr"
+      gap="2"
+      align="center"
+      width="100%"
+    >
+      Check input
+      <LocatorForm state={action.locator} suggestedRoles={CHECK_ROLES} onChange={handleChangeLocator} />
+    </Grid>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/CheckAction/index.ts
+++ b/src/views/BrowserTestEditor/Actions/CheckAction/index.ts
@@ -1,0 +1,1 @@
+export * from './CheckActionBody'

--- a/src/views/BrowserTestEditor/Actions/UncheckAction/UncheckActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/UncheckAction/UncheckActionBody.tsx
@@ -1,0 +1,36 @@
+import { Grid } from '@radix-ui/themes'
+
+import { LocatorUncheckAction } from '@/main/runner/schema'
+
+import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
+import { WithEditorMetadata } from '../../types'
+
+const UNCHECK_ROLES = ['checkbox', 'radio', 'switch']
+
+interface UncheckActionBodyProps {
+  action: WithEditorMetadata<LocatorUncheckAction>
+  onChange: (action: WithEditorMetadata<LocatorUncheckAction>) => void
+}
+
+export function UncheckActionBody({
+  action,
+  onChange,
+}: UncheckActionBodyProps) {
+  const handleChangeLocator = (
+    locator: WithEditorMetadata<LocatorUncheckAction>['locator']
+  ) => {
+    onChange({ ...action, locator })
+  }
+
+  return (
+    <Grid
+      columns="max-content minmax(0, max-content) 1fr"
+      gap="2"
+      align="center"
+      width="100%"
+    >
+      Uncheck input
+      <LocatorForm state={action.locator} suggestedRoles={UNCHECK_ROLES} onChange={handleChangeLocator} />
+    </Grid>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/UncheckAction/index.ts
+++ b/src/views/BrowserTestEditor/Actions/UncheckAction/index.ts
@@ -1,0 +1,1 @@
+export * from './UncheckActionBody'

--- a/src/views/BrowserTestEditor/Actions/index.ts
+++ b/src/views/BrowserTestEditor/Actions/index.ts
@@ -1,5 +1,7 @@
+export * from './CheckAction'
 export * from './ClickAction'
 export * from './FillAction'
 export * from './GoToAction'
 export * from './PageReloadAction'
+export * from './UncheckAction'
 export * from './WaitForAction'

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -78,24 +78,10 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
       <DropdownMenu.Content>
         <DropdownMenu.Item
           onClick={() => {
-            onAddAction('locator.check')
-          }}
-        >
-          Check input
-        </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => {
             onAddAction('locator.click')
           }}
         >
           Click element
-        </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.uncheck')
-          }}
-        >
-          Uncheck input
         </DropdownMenu.Item>
         <DropdownMenu.Item
           onClick={() => {
@@ -104,19 +90,37 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
         >
           Fill input
         </DropdownMenu.Item>
+        <DropdownMenu.Separator />
         <DropdownMenu.Item
           onClick={() => {
-            onAddAction('page.goto')
+            onAddAction('locator.check')
           }}
         >
-          Navigate to URL
+          Check input
         </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
+            onAddAction('locator.uncheck')
+          }}
+        >
+          Uncheck input
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+
         <DropdownMenu.Item
           onClick={() => {
             onAddAction('locator.waitFor')
           }}
         >
           Wait for element
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item
+          onClick={() => {
+            onAddAction('page.goto')
+          }}
+        >
+          Navigate to URL
         </DropdownMenu.Item>
         <DropdownMenu.Item
           onClick={() => {

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -78,10 +78,24 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
       <DropdownMenu.Content>
         <DropdownMenu.Item
           onClick={() => {
+            onAddAction('locator.check')
+          }}
+        >
+          Check input
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
             onAddAction('locator.click')
           }}
         >
           Click element
+        </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
+            onAddAction('locator.uncheck')
+          }}
+        >
+          Uncheck input
         </DropdownMenu.Item>
         <DropdownMenu.Item
           onClick={() => {

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -4,16 +4,20 @@ import {
   GlobeIcon,
   MousePointerClickIcon,
   RefreshCwIcon,
+  SquareCheckBigIcon,
+  SquareIcon,
   TextCursorInputIcon,
   TimerIcon,
 } from 'lucide-react'
 import { ReactElement, ReactNode } from 'react'
 
 import {
+  CheckActionBody,
   ClickActionBody,
   FillActionBody,
   GoToActionBody,
   PageReloadActionBody,
+  UncheckActionBody,
   WaitForActionBody,
 } from './Actions'
 import { BrowserActionInstance } from './types'
@@ -58,6 +62,28 @@ const notImplementedCreate = <M extends BrowserActionInstance['method']>(
 }
 
 const actionEditors: ActionEditorRegistry = {
+  'locator.check': {
+    icon: <SquareCheckBigIcon aria-hidden="true" />,
+    render: ({ action, onChange }) => (
+      <CheckActionBody action={action} onChange={onChange} />
+    ),
+    create: () => ({
+      id: crypto.randomUUID(),
+      method: 'locator.check',
+      locator: createDefaultLocatorOptions(),
+    }),
+  },
+  'locator.uncheck': {
+    icon: <SquareIcon aria-hidden="true" />,
+    render: ({ action, onChange }) => (
+      <UncheckActionBody action={action} onChange={onChange} />
+    ),
+    create: () => ({
+      id: crypto.randomUUID(),
+      method: 'locator.uncheck',
+      locator: createDefaultLocatorOptions(),
+    }),
+  },
   'locator.click': {
     icon: <MousePointerClickIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -70,7 +70,15 @@ const actionEditors: ActionEditorRegistry = {
     create: () => ({
       id: crypto.randomUUID(),
       method: 'locator.check',
-      locator: createDefaultLocatorOptions(),
+      locator: {
+        current: 'role',
+        values: {
+          role: {
+            type: 'role',
+            role: 'checkbox',
+          },
+        },
+      },
     }),
   },
   'locator.uncheck': {
@@ -81,7 +89,15 @@ const actionEditors: ActionEditorRegistry = {
     create: () => ({
       id: crypto.randomUUID(),
       method: 'locator.uncheck',
-      locator: createDefaultLocatorOptions(),
+      locator: {
+        current: 'role',
+        values: {
+          role: {
+            type: 'role',
+            role: 'checkbox',
+          },
+        },
+      },
     }),
   },
   'locator.click': {
@@ -104,7 +120,15 @@ const actionEditors: ActionEditorRegistry = {
       id: crypto.randomUUID(),
       method: 'locator.fill',
       value: '',
-      locator: createDefaultLocatorOptions(),
+      locator: {
+        current: 'role',
+        values: {
+          role: {
+            type: 'role',
+            role: 'textbox',
+          },
+        },
+      },
     }),
   },
   'page.goto': {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add support for check input/uncheck input actions
- ⚠️ This PR doesn't include the options yet

<img width="1448" height="897" alt="grafik" src="https://github.com/user-attachments/assets/a8c811e9-f241-4f3f-bf39-b7505a7d1d2e" />


## How to Test
- Add a new "Check input" action, configure the locator, verify that the action is translated into code
- Repeat the previous step for the "Uncheck input" action ⚠️ until https://github.com/grafana/k6-studio/pull/1148 is merged, you won't see `locator.uncheck` in the actual code - this is a pre-existing issue

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new browser action types and codegen mapping for `locator.check`/`locator.uncheck`, which can affect generated test behavior if locators/defaults are wrong. Changes are localized to the Browser Test Editor UI and action-to-test conversion logic.
> 
> **Overview**
> Adds **Check input** and **Uncheck input** actions to the Browser Test Editor, including new action bodies using `LocatorForm` with suggested roles (`checkbox`/`radio`/`switch`) and new menu entries for creating them.
> 
> Updates the editor registry to render these actions with new icons and default locator presets, and extends browser action→test conversion (`src/codegen/browser/test.ts`) to emit `check` nodes with `checked: true/false`. Also adjusts the default locator preset for `locator.fill` to start as role-based `textbox` instead of the generic default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc312a887b02063a0456c709758e10c1e61f9cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->