### PR TITLE
internal(browser): Add Clear input action

### DIFF
--- a/src/codegen/browser/code/options.ts
+++ b/src/codegen/browser/code/options.ts
@@ -44,6 +44,7 @@ function isBrowserScenario(scenario: ir.Scenario) {
       case 'NewPlaceholderLocatorExpression':
       case 'NewTitleLocatorExpression':
       case 'NewTestIdLocatorExpression':
+      case 'ClearExpression':
       case 'ClickExpression':
       case 'ClickOptionsExpression':
       case 'FillTextExpression':

--- a/src/codegen/browser/code/scenario.ts
+++ b/src/codegen/browser/code/scenario.ts
@@ -263,6 +263,19 @@ function emitTypeTextExpression(
     .done()
 }
 
+function emitClearExpression(
+  context: ScenarioContext,
+  expression: ir.ClearExpression
+): ts.Expression {
+  const locator = emitExpression(context, expression.locator)
+
+  return new ExpressionBuilder(locator)
+    .member('clear')
+    .call([])
+    .await(context)
+    .done()
+}
+
 function emitCheckExpression(
   context: ScenarioContext,
   expression: ir.CheckExpression
@@ -523,6 +536,9 @@ function emitExpression(
 
     case 'FillTextExpression':
       return emitTypeTextExpression(context, expression)
+
+    case 'ClearExpression':
+      return emitClearExpression(context, expression)
 
     case 'CheckExpression':
       return emitCheckExpression(context, expression)

--- a/src/codegen/browser/intermediate/ast.ts
+++ b/src/codegen/browser/intermediate/ast.ts
@@ -110,6 +110,11 @@ export interface ClickExpression {
   options: Expression | null
 }
 
+export interface ClearExpression {
+  type: 'ClearExpression'
+  locator: Expression
+}
+
 export interface CheckExpression {
   type: 'CheckExpression'
   locator: Expression
@@ -214,6 +219,7 @@ export type Expression =
   | NewTestIdLocatorExpression
   | GotoExpression
   | ReloadExpression
+  | ClearExpression
   | ClickExpression
   | ClickOptionsExpression
   | FillTextExpression

--- a/src/codegen/browser/intermediate/context.ts
+++ b/src/codegen/browser/intermediate/context.ts
@@ -75,6 +75,11 @@ function buildScenarioGraph(scenario: model.Scenario) {
         connectPrevious(graph, node)
         break
 
+      case 'clear':
+        graph.connect(node.nodeId, node.inputs.locator.nodeId, 'reference')
+        connectPrevious(graph, node)
+        break
+
       case 'check':
         graph.connect(node.nodeId, node.inputs.locator.nodeId, 'reference')
         connectPrevious(graph, node)

--- a/src/codegen/browser/intermediate/index.ts
+++ b/src/codegen/browser/intermediate/index.ts
@@ -264,6 +264,18 @@ function emitTypeTextNode(context: IntermediateContext, node: m.TypeTextNode) {
   })
 }
 
+function emitClearNode(context: IntermediateContext, node: m.ClearNode) {
+  const locator = context.reference(node.inputs.locator)
+
+  context.emit({
+    type: 'ExpressionStatement',
+    expression: {
+      type: 'ClearExpression',
+      locator,
+    },
+  })
+}
+
 function emitCheckNode(context: IntermediateContext, node: m.CheckNode) {
   const locator = context.reference(node.inputs.locator)
 
@@ -419,6 +431,9 @@ function emitNode(context: IntermediateContext, node: m.TestNode) {
 
     case 'reload':
       return emitReloadNode(context, node)
+
+    case 'clear':
+      return emitClearNode(context, node)
 
     case 'click':
       return emitClickNode(context, node)

--- a/src/codegen/browser/intermediate/variables.ts
+++ b/src/codegen/browser/intermediate/variables.ts
@@ -163,6 +163,12 @@ function substituteExpression(
         value: substituteExpression(node.value, substitutions),
       }
 
+    case 'ClearExpression':
+      return {
+        type: 'ClearExpression',
+        locator: substituteExpression(node.locator, substitutions),
+      }
+
     case 'CheckExpression':
       return {
         type: 'CheckExpression',

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -423,6 +423,14 @@ function buildBrowserNodeGraphFromActions(
             locator: getLocator(action.locator),
           },
         }
+      case 'locator.clear':
+        return {
+          type: 'clear',
+          nodeId: crypto.randomUUID(),
+          inputs: {
+            locator: getLocator(action.locator),
+          },
+        }
       case 'page.waitForNavigation':
       case 'page.close':
       case 'page.*':
@@ -432,7 +440,6 @@ function buildBrowserNodeGraphFromActions(
       case 'locator.hover':
       case 'locator.setChecked':
       case 'locator.tap':
-      case 'locator.clear':
       case 'locator.press':
       case 'locator.focus':
       case 'locator.*':

--- a/src/codegen/browser/types.ts
+++ b/src/codegen/browser/types.ts
@@ -123,6 +123,14 @@ export interface AssertNode extends NodeBase {
   }
 }
 
+export interface ClearNode extends NodeBase {
+  type: 'clear'
+  inputs: {
+    previous?: NodeRef
+    locator: NodeRef
+  }
+}
+
 export interface WaitForNode extends NodeBase {
   type: 'wait-for'
   inputs: {
@@ -140,6 +148,7 @@ export type TestNode =
   | GotoNode
   | ReloadNode
   | LocatorNode
+  | ClearNode
   | ClickNode
   | TypeTextNode
   | SelectOptionsNode

--- a/src/views/BrowserTestEditor/Actions/ClearAction/ClearActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/ClearAction/ClearActionBody.tsx
@@ -1,0 +1,37 @@
+import { Grid } from '@radix-ui/themes'
+
+import { LocatorClearAction } from '@/main/runner/schema'
+
+import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
+import { WithEditorMetadata } from '../../types'
+
+const CLEAR_ROLES = ['textbox', 'searchbox', 'combobox']
+
+interface ClearActionBodyProps {
+  action: WithEditorMetadata<LocatorClearAction>
+  onChange: (action: WithEditorMetadata<LocatorClearAction>) => void
+}
+
+export function ClearActionBody({ action, onChange }: ClearActionBodyProps) {
+  const handleChangeLocator = (
+    locator: WithEditorMetadata<LocatorClearAction>['locator']
+  ) => {
+    onChange({ ...action, locator })
+  }
+
+  return (
+    <Grid
+      columns="max-content minmax(0, max-content) 1fr"
+      gap="2"
+      align="center"
+      width="100%"
+    >
+      Clear
+      <LocatorForm
+        state={action.locator}
+        onChange={handleChangeLocator}
+        suggestedRoles={CLEAR_ROLES}
+      />
+    </Grid>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/ClearAction/index.ts
+++ b/src/views/BrowserTestEditor/Actions/ClearAction/index.ts
@@ -1,0 +1,1 @@
+export * from './ClearActionBody'

--- a/src/views/BrowserTestEditor/Actions/index.ts
+++ b/src/views/BrowserTestEditor/Actions/index.ts
@@ -1,4 +1,5 @@
 export * from './CheckAction'
+export * from './ClearAction'
 export * from './ClickAction'
 export * from './FillAction'
 export * from './GoToAction'

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -90,6 +90,13 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
         >
           Fill input
         </DropdownMenu.Item>
+        <DropdownMenu.Item
+          onClick={() => {
+            onAddAction('locator.clear')
+          }}
+        >
+          Clear input
+        </DropdownMenu.Item>
         <DropdownMenu.Separator />
         <DropdownMenu.Item
           onClick={() => {

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -1,6 +1,7 @@
 import { Code } from '@radix-ui/themes'
 import {
   CircleQuestionMarkIcon,
+  EraserIcon,
   GlobeIcon,
   MousePointerClickIcon,
   RefreshCwIcon,
@@ -13,6 +14,7 @@ import { ReactElement, ReactNode } from 'react'
 
 import {
   CheckActionBody,
+  ClearActionBody,
   ClickActionBody,
   FillActionBody,
   GoToActionBody,
@@ -95,6 +97,25 @@ const actionEditors: ActionEditorRegistry = {
           role: {
             type: 'role',
             role: 'checkbox',
+          },
+        },
+      },
+    }),
+  },
+  'locator.clear': {
+    icon: <EraserIcon aria-hidden="true" />,
+    render: ({ action, onChange }) => (
+      <ClearActionBody action={action} onChange={onChange} />
+    ),
+    create: () => ({
+      id: crypto.randomUUID(),
+      method: 'locator.clear',
+      locator: {
+        current: 'role',
+        values: {
+          role: {
+            type: 'role',
+            role: 'textbox',
           },
         },
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Add Clear input action
- ⚠️ Action options are not a part of this PR

<img width="1242" height="897" alt="grafik" src="https://github.com/user-attachments/assets/1442f781-9d31-4570-9bcb-ccdfb8173a67" />


## How to Test
- Add a new Clear input action
- Configure the locator
- Verify that the action has matching code in the script 

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new UI action and codegen path for `locator.clear` without changing existing action semantics or security-sensitive logic.
> 
> **Overview**
> Adds a new **Clear input** browser action (`locator.clear`) to the Browser Test Editor, including UI/editor wiring (menu entry, icon, default locator suggestions, and a `ClearActionBody` locator form).
> 
> Extends the browser test graph/types and codegen pipeline to carry a new `ClearExpression`/`ClearNode`, connect it in the intermediate execution graph, and emit `await locator.clear()` in generated scenarios, including variable substitution and browser-scenario detection updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bd1bc2674e5882ae175fc617e1a0816e74ed09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->