### PR TITLE
chore: Upgrade rrweb to latest alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-router-dom": "^6.30.3",
         "react-select": "^5.10.2",
         "react-use": "^17.5.1",
-        "rrweb": "^2.0.0-alpha.18",
+        "rrweb": "^2.0.0-alpha.20",
         "tiny-invariant": "^1.3.3",
         "tree-kill": "^1.2.2",
         "typescript": "^5.4.5",
@@ -5805,15 +5805,15 @@
       ]
     },
     "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-RbnDgKxA/odwB1R4gF7eUUj+rdSrq6ROQJsnMw7MIsGzlbSYvJeZN8YY4XqU0G6sKJvXI6bSzk7w/G94jNwzhw==",
       "license": "MIT"
     },
     "node_modules/@rrweb/utils": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-MTQOmhPRe39C0fYaCnnVYOufQsyGzwNXpUStKiyFSfGLUJrzuwhbRoUAKR5w6W2j5XuA0bIz3ZDIBztkquOhLw==",
       "license": "MIT"
     },
     "node_modules/@sentry-internal/browser-utils": {
@@ -17337,28 +17337,28 @@
       "license": "MIT"
     },
     "node_modules/rrdom": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-hoqjS4662LtBp82qEz9GrqU36UpEmCvTA2Hns3qdF7cklLFFy3G+0Th8hLytJENleHHWxsB5nWJ3eXz5mSRxdQ==",
       "license": "MIT",
       "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrweb-snapshot": "^2.0.0-alpha.20"
       }
     },
     "node_modules/rrweb": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-CZKDlm+j1VA50Ko3gnMbpvguCAleljsTNXPnVk9aeNP8o6T6kolRbISHyDZpqZ4G+bdDLlQOignPP3jEsXs8Gg==",
       "license": "MIT",
       "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "@rrweb/utils": "^2.0.0-alpha.18",
+        "@rrweb/types": "^2.0.0-alpha.20",
+        "@rrweb/utils": "^2.0.0-alpha.20",
         "@types/css-font-loading-module": "0.0.7",
         "@xstate/fsm": "^1.4.0",
         "base64-arraybuffer": "^1.0.1",
         "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.18",
-        "rrweb-snapshot": "^2.0.0-alpha.18"
+        "rrdom": "^2.0.0-alpha.20",
+        "rrweb-snapshot": "^2.0.0-alpha.20"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -17368,9 +17368,9 @@
       "dev": true
     },
     "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
+      "version": "2.0.0-alpha.20",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.20.tgz",
+      "integrity": "sha512-YTNf9YVeaGRo/jxY3FKBge2c/Ojd/KTHmuWloUSB+oyPXuY73ZeeG873qMMmhIpqEn7hn7aBF1eWEQmP7wjf8A==",
       "license": "MIT",
       "dependencies": {
         "postcss": "^8.4.38"

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-router-dom": "^6.30.3",
         "react-select": "^5.10.2",
         "react-use": "^17.5.1",
-        "rrweb": "^2.0.0-alpha.20",
+        "rrweb": "2.0.0-alpha.20",
         "tiny-invariant": "^1.3.3",
         "tree-kill": "^1.2.2",
         "typescript": "^5.4.5",
@@ -317,6 +317,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -625,6 +626,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1150,6 +1152,7 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1592,6 +1595,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2554,6 +2558,7 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2891,6 +2896,7 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3201,6 +3207,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3222,6 +3229,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3258,6 +3266,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -3788,6 +3797,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.31.0.tgz",
       "integrity": "sha512-cYJeP+6qN0UnBv1r09hXl0YorB8kXHv61BC0NUlBA8vxrylZ4/C8lnva3gd1E8n33DNYSaiGW+DuGoSt0QQ7Dw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6911,6 +6921,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
       "integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6987,6 +6998,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6997,6 +7009,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7094,6 +7107,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.16.1.tgz",
       "integrity": "sha512-SxdPak/5bO0EnGktV05+Hq8oatjAYVY3Zh2bye9pGZy6+jwyR3LG3YKkV4YatlsgqXP28BTeVm9pqwJM96vf2A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.16.1",
@@ -7962,6 +7976,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9016,6 +9031,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -10869,16 +10885,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11217,6 +11223,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11355,6 +11362,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -13068,6 +13076,7 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14988,6 +14997,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -16557,6 +16567,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16581,6 +16592,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16592,6 +16604,7 @@
       "version": "7.53.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
       "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -17511,6 +17524,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18678,6 +18692,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18932,7 +18947,8 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -19070,6 +19086,7 @@
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
       "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19602,6 +19619,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -19712,6 +19730,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20347,6 +20366,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "react-router-dom": "^6.30.3",
     "react-select": "^5.10.2",
     "react-use": "^17.5.1",
-    "rrweb": "^2.0.0-alpha.18",
+    "rrweb": "2.0.0-alpha.20",
     "tiny-invariant": "^1.3.3",
     "tree-kill": "^1.2.2",
     "typescript": "^5.4.5",

--- a/patches/rrweb+2.0.0-alpha.20.patch
+++ b/patches/rrweb+2.0.0-alpha.20.patch
@@ -1,9 +1,9 @@
 diff --git a/node_modules/rrweb/dist/rrweb.cjs b/node_modules/rrweb/dist/rrweb.cjs
-index d455aa0..86e7de1 100644
+index 7d09b21..48fd3a1 100644
 --- a/node_modules/rrweb/dist/rrweb.cjs
 +++ b/node_modules/rrweb/dist/rrweb.cjs
-@@ -14576,6 +14576,10 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
-         }, 
+@@ -14737,6 +14737,10 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
+         },
          live: {
            on: {
 +            STOP_LIVE: {
@@ -13,7 +13,7 @@ index d455aa0..86e7de1 100644
              ADD_EVENT: {
                target: "live",
                actions: ["addEvent"]
-@@ -15702,6 +15706,9 @@ class Replayer {
+@@ -15863,6 +15867,9 @@ class Replayer {
    startLive(baselineTime) {
      this.service.send({ type: "TO_LIVE", payload: { baselineTime } });
    }
@@ -23,11 +23,11 @@ index d455aa0..86e7de1 100644
    addEvent(rawEvent) {
      const event = this.config.unpackFn ? this.config.unpackFn(rawEvent) : rawEvent;
      if (indicatesTouchDevice(event)) {
-diff --git a/node_modules/rrweb/dist/rrweb.d.ts b/node_modules/rrweb/dist/rrweb.d.ts
-index 95305d6..66540cb 100644
---- a/node_modules/rrweb/dist/rrweb.d.ts
-+++ b/node_modules/rrweb/dist/rrweb.d.ts
-@@ -182,6 +182,8 @@ declare type PlayerEvent = {
+diff --git a/node_modules/rrweb/dist/rrweb.d.cts b/node_modules/rrweb/dist/rrweb.d.cts
+index 92d2c5f..b4cd061 100644
+--- a/node_modules/rrweb/dist/rrweb.d.cts
++++ b/node_modules/rrweb/dist/rrweb.d.cts
+@@ -178,6 +178,8 @@ declare type PlayerEvent = {
      };
  } | {
      type: 'PAUSE';
@@ -36,7 +36,28 @@ index 95305d6..66540cb 100644
  } | {
      type: 'TO_LIVE';
      payload: {
-@@ -299,6 +301,7 @@ export declare class Replayer {
+@@ -295,6 +297,7 @@ export declare class Replayer {
+     resume(timeOffset?: number): void;
+     destroy(): void;
+     startLive(baselineTime?: number): void;
++    stopLive(): void;
+     addEvent(rawEvent: eventWithTime | string): void;
+     enableInteract(): void;
+     disableInteract(): void;
+diff --git a/node_modules/rrweb/dist/rrweb.d.ts b/node_modules/rrweb/dist/rrweb.d.ts
+index 92d2c5f..b4cd061 100644
+--- a/node_modules/rrweb/dist/rrweb.d.ts
++++ b/node_modules/rrweb/dist/rrweb.d.ts
+@@ -178,6 +178,8 @@ declare type PlayerEvent = {
+     };
+ } | {
+     type: 'PAUSE';
++} | {
++    type: 'STOP_LIVE';
+ } | {
+     type: 'TO_LIVE';
+     payload: {
+@@ -295,6 +297,7 @@ export declare class Replayer {
      resume(timeOffset?: number): void;
      destroy(): void;
      startLive(baselineTime?: number): void;
@@ -45,21 +66,31 @@ index 95305d6..66540cb 100644
      enableInteract(): void;
      disableInteract(): void;
 diff --git a/node_modules/rrweb/dist/rrweb.js b/node_modules/rrweb/dist/rrweb.js
-index 5d38597..13a9d10 100644
+index 553c605..78f9bfc 100644
 --- a/node_modules/rrweb/dist/rrweb.js
 +++ b/node_modules/rrweb/dist/rrweb.js
-@@ -14574,6 +14574,10 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
+@@ -14735,6 +14735,10 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
          },
          live: {
            on: {
 +            STOP_LIVE: {
-+              target: 'paused',
++              target: "paused",
 +              actions: ["pause"]
-+            }, 
++            },
              ADD_EVENT: {
                target: "live",
                actions: ["addEvent"]
-@@ -15700,6 +15704,9 @@ class Replayer {
+@@ -14822,6 +14826,9 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
+             return Date.now();
+           }
+         }),
++        stopLive() {
++          this.service.send({ type: "STOP_LIVE" });
++        },
+         addEvent: o((ctx, machineEvent) => {
+           const { baselineTime, timer, events } = ctx;
+           if (machineEvent.type === "ADD_EVENT") {
+@@ -15861,6 +15868,9 @@ class Replayer {
    startLive(baselineTime) {
      this.service.send({ type: "TO_LIVE", payload: { baselineTime } });
    }

--- a/patches/rrweb+2.0.0-alpha.20.patch
+++ b/patches/rrweb+2.0.0-alpha.20.patch
@@ -66,7 +66,7 @@ index 92d2c5f..b4cd061 100644
      enableInteract(): void;
      disableInteract(): void;
 diff --git a/node_modules/rrweb/dist/rrweb.js b/node_modules/rrweb/dist/rrweb.js
-index 553c605..78f9bfc 100644
+index 553c605..bf92559 100644
 --- a/node_modules/rrweb/dist/rrweb.js
 +++ b/node_modules/rrweb/dist/rrweb.js
 @@ -14735,6 +14735,10 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
@@ -74,23 +74,13 @@ index 553c605..78f9bfc 100644
          live: {
            on: {
 +            STOP_LIVE: {
-+              target: "paused",
++              target: 'paused',
 +              actions: ["pause"]
 +            },
              ADD_EVENT: {
                target: "live",
                actions: ["addEvent"]
-@@ -14822,6 +14826,9 @@ function createPlayerService(context, { getCastFn, applyEventsSynchronously, emi
-             return Date.now();
-           }
-         }),
-+        stopLive() {
-+          this.service.send({ type: "STOP_LIVE" });
-+        },
-         addEvent: o((ctx, machineEvent) => {
-           const { baselineTime, timer, events } = ctx;
-           if (machineEvent.type === "ADD_EVENT") {
-@@ -15861,6 +15868,9 @@ class Replayer {
+@@ -15861,6 +15865,9 @@ class Replayer {
    startLive(baselineTime) {
      this.service.send({ type: "TO_LIVE", payload: { baselineTime } });
    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR upgrades the `rrweb` package to the latest alpha version (which fails the CI for the lockfile maintenance PR). I also pinned the dependency so that renovate won't upgrade it during lockfile maintenance again.

## How to Test

Test that the browser debugger is working correctly.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades and pins an alpha `rrweb` dependency and applies a local patch that changes replay state-machine behavior; this could affect session replay/streaming playback correctness.
> 
> **Overview**
> Upgrades `rrweb` from `2.0.0-alpha.18` to **pinned** `2.0.0-alpha.20` (and updates the lockfile accordingly) to avoid automated version bumps during maintenance.
> 
> Adds a `patch-package` patch for `rrweb@2.0.0-alpha.20` that introduces a `STOP_LIVE` player event and a `Replayer.stopLive()` API, wiring it to transition live playback back to `paused` and updating the published TypeScript declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7649873943b6a47986003aa9ba237efe0bde42dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->