### PR TITLE
feat(browser): Format select options based on type

### DIFF
--- a/src/components/Browser/SelectOptions.tsx
+++ b/src/components/Browser/SelectOptions.tsx
@@ -1,6 +1,3 @@
-import { css } from '@emotion/react'
-import { Fragment } from 'react'
-
 interface SelectOption {
   value?: string
   label?: string
@@ -15,31 +12,20 @@ function quote(str: string) {
   return `"${str}"`
 }
 
-function formatOption(option: SelectOption | string) {
+export function formatOption(option: SelectOption | string) {
   if (typeof option === 'string') {
     return quote(option)
   }
 
   if (option.label !== undefined) {
-    return option.label.length ? (
-      option.label
-    ) : (
-      <span
-        css={css`
-          opacity: 0.8;
-          font-style: italic;
-        `}
-      >
-        (empty)
-      </span>
-    )
+    return `label: ${quote(option.label)}`
   }
 
   if (option.index !== undefined) {
-    return option.index.toString()
+    return `index: ${option.index.toString()}`
   }
 
-  return quote(option.value ?? '')
+  return `value: ${quote(option.value ?? '')}`
 }
 
 export function SelectOptions({ options }: SelectOptionsProps) {
@@ -51,16 +37,5 @@ export function SelectOptions({ options }: SelectOptionsProps) {
     return <code>{formatOption(options[0]!)}</code>
   }
 
-  const last = options[options.length - 1]!
-
-  return (
-    <>
-      {options.slice(0, -1).map((option, index) => (
-        <Fragment key={index}>
-          <code>{formatOption(option)}</code>,{' '}
-        </Fragment>
-      ))}{' '}
-      and <code>{formatOption(last)}</code>
-    </>
-  )
+  return <>{options.length} options</>
 }

--- a/src/components/Browser/SelectOptions.tsx
+++ b/src/components/Browser/SelectOptions.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 import { Fragment } from 'react'
 
 interface SelectOption {
@@ -10,35 +11,56 @@ interface SelectOptionsProps {
   options: Array<SelectOption | string>
 }
 
-export function SelectOptions({ options }: SelectOptionsProps) {
-  const normalizedOptions = options.map((option) => {
-    if (typeof option === 'string') {
-      return option
-    }
+function quote(str: string) {
+  return `"${str}"`
+}
 
-    return option.value ?? option.label ?? option.index?.toString() ?? ''
-  })
-
-  if (normalizedOptions.length === 1) {
-    return <code>{normalizedOptions[0]}</code>
+function formatOption(option: SelectOption | string) {
+  if (typeof option === 'string') {
+    return quote(option)
   }
 
-  const last = normalizedOptions[options.length - 1]
+  if (option.label !== undefined) {
+    return option.label.length ? (
+      option.label
+    ) : (
+      <span
+        css={css`
+          opacity: 0.8;
+          font-style: italic;
+        `}
+      >
+        (empty)
+      </span>
+    )
+  }
 
-  if (last === undefined) {
+  if (option.index !== undefined) {
+    return option.index.toString()
+  }
+
+  return quote(option.value ?? '')
+}
+
+export function SelectOptions({ options }: SelectOptionsProps) {
+  if (options.length === 0) {
     return null
   }
 
+  if (options.length === 1) {
+    return <code>{formatOption(options[0]!)}</code>
+  }
+
+  const last = options[options.length - 1]!
+
   return (
     <>
-      {normalizedOptions.slice(0, -1).map((option, index) => {
-        return (
-          <Fragment key={index}>
-            <code>{option}</code>,{' '}
-          </Fragment>
-        )
-      })}{' '}
-      and <code>{last}</code>
+      {options.slice(0, -1).map((option, index) => (
+        <Fragment key={index}>
+          <code>{formatOption(option)}</code>,{' '}
+        </Fragment>
+      ))}{' '}
+      and <code>{formatOption(last)}</code>
     </>
   )
 }

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -1,4 +1,3 @@
-import { SelectOptions } from '@/components/Browser/SelectOptions'
 import { BrowserEvent } from '@/schemas/recording'
 import { NodeSelector } from '@/schemas/selectors'
 import { exhaustive } from '@/utils/typescript'
@@ -7,6 +6,7 @@ import { AssertDescription } from './AssertDescription'
 import { ClickDescription } from './ClickDescription'
 import { InputChangeDescription } from './InputChangeDescription'
 import { PageNavigationDescription } from './PageNavigationDescription'
+import { SelectChangeDescription } from './SelectChangeDescription'
 import { Selector } from './Selector'
 import { WaitForDescription } from './WaitForDescription'
 
@@ -58,15 +58,7 @@ export function EventDescription({
       )
 
     case 'select-change':
-      return (
-        <>
-          Selected <SelectOptions options={event.selected} /> from{' '}
-          <Selector
-            selectors={event.target.selectors}
-            onHighlight={onHighlight}
-          />
-        </>
-      )
+      return <SelectChangeDescription event={event} onHighlight={onHighlight} />
 
     case 'submit-form':
       return (

--- a/src/components/BrowserEventList/EventDescription/SelectChangeDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/SelectChangeDescription.tsx
@@ -1,0 +1,47 @@
+import { css } from '@emotion/react'
+
+import { formatOption, SelectOptions } from '@/components/Browser/SelectOptions'
+import { Tooltip } from '@/components/primitives/Tooltip'
+import { SelectChangeEvent } from '@/schemas/recording'
+import { NodeSelector } from '@/schemas/selectors'
+
+import { Selector } from './Selector'
+
+interface SelectChangeDescriptionProps {
+  event: SelectChangeEvent
+  onHighlight: (selector: NodeSelector | null) => void
+}
+
+export function SelectChangeDescription({
+  event,
+  onHighlight,
+}: SelectChangeDescriptionProps) {
+  return (
+    <>
+      Selected
+      <Tooltip
+        content={event.selected
+          .map((option) => formatOption(option))
+          .join(', ')}
+      >
+        <div
+          css={css`
+            gap: calc(var(--studio-spacing-1) * 1.5);
+            flex-shrink: 1;
+            padding: calc(var(--studio-spacing-1) * 0.5)
+              calc(var(--studio-spacing-1) * 1.5);
+            overflow: hidden;
+            background-color: var(--gray-3);
+            color: var(--gray-12);
+            border-radius: 3px;
+            font-size: var(--studio-font-size-1);
+          `}
+        >
+          <SelectOptions options={event.selected} />
+        </div>
+      </Tooltip>{' '}
+      from{' '}
+      <Selector selectors={event.target.selectors} onHighlight={onHighlight} />
+    </>
+  )
+}

--- a/src/views/BrowserTestEditor/ActionForms/forms/SelectOptionValuesForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/SelectOptionValuesForm.tsx
@@ -240,7 +240,7 @@ function toEntry(type: MatchType, input: string): SelectOptionValue {
 function validateSelectOptionEntry(
   entry: SelectOptionValue
 ): string | undefined {
-  if (entry.label !== undefined && entry.label.trim() === '') {
+  if (entry.label !== undefined && entry.label === '') {
     return 'Label cannot be empty'
   }
   if (entry.index !== undefined && !Number.isInteger(entry.index)) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Format options differently based on whether it's `value`, `label`, or `index` 
- Display `N options` when N > 1

Test editor:
<img width="460" height="233" alt="grafik" src="https://github.com/user-attachments/assets/656c0313-1f14-4b40-98f9-27346c3753a4" />

Recording:
<img width="312" height="187" alt="grafik" src="https://github.com/user-attachments/assets/51486ee9-9353-4f9a-9318-2f6592535daf" />

## How to Test
Verify that the options are rendered as expected in:
1. browser events in k6 studio
2. browser events in the in-browser UI during the recording process
3. Browser test editor (you'll need to add a new select options action)

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only formatting/refactor changes with small validation behavior tweak; main risk is unexpected display/tooltip behavior for select-change events and edge-case option values.
> 
> **Overview**
> Select option rendering is updated to be type-aware: options are now formatted as `value: "..."`, `label: "..."`, or `index: N` via new `formatOption()` in `SelectOptions`.
> 
> `select-change` event descriptions are refactored into a new `SelectChangeDescription` component that shows a compact summary (single option or count) with a tooltip containing the full formatted list. Validation in `SelectOptionValuesForm` is tightened so an empty `label` string is rejected without trimming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a263b588e64ea7ce971ea121d24ee6f99dfee1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->