### PR TITLE
feat: Add Grafana Cloud k6 workspace PoC with Monaco editor

### DIFF
--- a/src/AppRoutes.tsx
+++ b/src/AppRoutes.tsx
@@ -39,6 +39,16 @@ const Validator = lazy(() =>
 const DataFile = lazy(() =>
   import('@/views/DataFile').then((module) => ({ default: module.DataFile }))
 )
+const CloudWorkspaceHome = lazy(() =>
+  import('@/views/CloudWorkspace/CloudWorkspaceHome').then((module) => ({
+    default: module.CloudWorkspaceHome,
+  }))
+)
+const CloudWorkspaceTestEditor = lazy(() =>
+  import('@/views/CloudWorkspace/CloudWorkspaceTestEditor').then((module) => ({
+    default: module.CloudWorkspaceTestEditor,
+  }))
+)
 
 const router = createHashRouter(
   createRoutesFromChildren(
@@ -60,6 +70,11 @@ const router = createHashRouter(
       />
       <Route path={routeMap.validator} element={<Validator />} />
       <Route path={routeMap.dataFilePreviewer} element={<DataFile />} />
+      <Route path={routeMap.cloudWorkspace} element={<CloudWorkspaceHome />} />
+      <Route
+        path={routeMap.cloudWorkspaceTest}
+        element={<CloudWorkspaceTestEditor />}
+      />
       <Route path="*" element={<NoRouteFound />} />
     </Route>
   )

--- a/src/components/Layout/ActivityBar/ActivityBar.tsx
+++ b/src/components/Layout/ActivityBar/ActivityBar.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react'
 import { Flex, Grid, Separator } from '@radix-ui/themes'
+import { CloudIcon } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import k6LogoDark from '@/assets/logo-dark.svg'
@@ -48,6 +49,11 @@ export function ActivityBar() {
           to={getRoutePath('home')}
           icon={<HomeIcon />}
           tooltip="Home"
+        />
+        <NavIconButton
+          to={getRoutePath('cloudWorkspace')}
+          icon={<CloudIcon />}
+          tooltip="Cloud workspace"
         />
       </Grid>
 

--- a/src/components/Layout/ActivityBar/ActivityBar.tsx
+++ b/src/components/Layout/ActivityBar/ActivityBar.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { Flex, Grid, Separator } from '@radix-ui/themes'
-import { CloudIcon } from 'lucide-react'
+import { Cloud } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
 import k6LogoDark from '@/assets/logo-dark.svg'
@@ -47,12 +47,26 @@ export function ActivityBar() {
       <Grid gap="5" mt="4">
         <NavIconButton
           to={getRoutePath('home')}
-          icon={<HomeIcon />}
+          icon={
+            <HomeIcon
+              css={css`
+                min-height: 32px;
+              `}
+            />
+          }
           tooltip="Home"
         />
         <NavIconButton
           to={getRoutePath('cloudWorkspace')}
-          icon={<CloudIcon />}
+          icon={
+            <Cloud
+              css={css`
+                width: 24px !important;
+                height: 24px !important;
+                padding: 8px;
+              `}
+            />
+          }
           tooltip="Cloud workspace"
         />
       </Grid>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, IconButton, Spinner } from '@radix-ui/themes'
 import { Allotment } from 'allotment'
 import { PanelLeftOpenIcon } from 'lucide-react'
 import { Suspense, useEffect } from 'react'
-import { Outlet, useLocation } from 'react-router-dom'
+import { Outlet, useLocation, useMatch } from 'react-router-dom'
 import { useLocalStorage } from 'react-use'
 
 import { useDelayedVisibility } from '@/hooks/useDelayedVisibility'
@@ -35,6 +35,9 @@ export function Layout() {
     true
   )
   const location = useLocation()
+  const isCloudWorkspaceRoute = Boolean(
+    useMatch({ path: '/cloud-workspace', end: false })
+  )
   useListenDeepLinks()
 
   const handleVisibleChange = (index: number, visible: boolean) => {
@@ -92,6 +95,7 @@ export function Layout() {
           <Sidebar
             isExpanded={isSidebarExpanded}
             onCollapseSidebar={() => setIsSidebarExpanded(false)}
+            variant={isCloudWorkspaceRoute ? 'cloud-workspace' : 'local'}
           />
         </Allotment.Pane>
 

--- a/src/components/Layout/Sidebar/CloudWorkspaceSidebar.tsx
+++ b/src/components/Layout/Sidebar/CloudWorkspaceSidebar.tsx
@@ -6,18 +6,43 @@ import {
   IconButton,
   Reset,
   ScrollArea,
+  Spinner,
   Text,
   Tooltip,
 } from '@radix-ui/themes'
-import { ChevronDownIcon, ChevronRight, PanelLeftCloseIcon } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { ChevronRight, PanelLeftCloseIcon } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 
 import {
+  type CloudWorkspaceTestEntry,
   type CloudWorkspaceTree,
   formatCloudTestRef,
 } from '@/handlers/cloudWorkspace/types'
 import { getRoutePath } from '@/routeMap'
+
+const testLinkCss = css`
+  display: block;
+  padding: var(--space-1) var(--space-2) var(--space-1) var(--space-5);
+  font-size: 12px;
+  line-height: 22px;
+  color: var(--gray-11);
+  border-radius: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-decoration: none;
+
+  &:hover {
+    background-color: var(--gray-4);
+  }
+
+  &.active {
+    color: var(--accent-9);
+    font-weight: 700;
+  }
+`
+
 interface CloudWorkspaceSidebarProps {
   isExpanded?: boolean
   onCollapseSidebar: () => void
@@ -29,7 +54,21 @@ export function CloudWorkspaceSidebar({
 }: CloudWorkspaceSidebarProps) {
   const [tree, setTree] = useState<CloudWorkspaceTree | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [open, setOpen] = useState(true)
+  const [openByProject, setOpenByProject] = useState<Record<number, boolean>>(
+    {}
+  )
+  const [testsByProject, setTestsByProject] = useState<
+    Record<number, CloudWorkspaceTestEntry[]>
+  >({})
+  const [testsErrorByProject, setTestsErrorByProject] = useState<
+    Record<number, string | undefined>
+  >({})
+  const [loadingByProject, setLoadingByProject] = useState<
+    Record<number, boolean>
+  >({})
+
+  const loadedProjectIdsRef = useRef<Set<number>>(new Set())
+  const fetchInFlightRef = useRef<Set<number>>(new Set())
 
   const loadTree = useCallback(() => {
     window.studio.cloudWorkspace
@@ -37,16 +76,86 @@ export function CloudWorkspaceSidebar({
       .then((data) => {
         setError(null)
         setTree(data)
+        setTestsByProject({})
+        setTestsErrorByProject({})
+        setOpenByProject({})
+        setLoadingByProject({})
+        loadedProjectIdsRef.current = new Set()
+        fetchInFlightRef.current = new Set()
       })
       .catch((err: unknown) => {
         setTree(null)
-        setError(err instanceof Error ? err.message : 'Failed to load cloud tests.')
+        setError(
+          err instanceof Error ? err.message : 'Failed to load cloud tests.'
+        )
       })
   }, [])
 
   useEffect(() => {
     loadTree()
   }, [loadTree])
+
+  const loadTestsForProject = useCallback(async (projectId: number) => {
+    if (loadedProjectIdsRef.current.has(projectId)) {
+      return
+    }
+
+    if (fetchInFlightRef.current.has(projectId)) {
+      return
+    }
+
+    fetchInFlightRef.current.add(projectId)
+    setLoadingByProject((prev) => ({ ...prev, [projectId]: true }))
+    setTestsErrorByProject((prev) => {
+      const next = { ...prev }
+      delete next[projectId]
+
+      return next
+    })
+
+    try {
+      const tests =
+        await window.studio.cloudWorkspace.listProjectTests(projectId)
+      loadedProjectIdsRef.current.add(projectId)
+      setTestsByProject((prev) => ({ ...prev, [projectId]: tests }))
+    } catch (err: unknown) {
+      setTestsErrorByProject((prev) => ({
+        ...prev,
+        [projectId]:
+          err instanceof Error ? err.message : 'Failed to load tests.',
+      }))
+    } finally {
+      fetchInFlightRef.current.delete(projectId)
+      setLoadingByProject((prev) => {
+        const next = { ...prev }
+        delete next[projectId]
+
+        return next
+      })
+    }
+  }, [])
+
+  const handleProjectOpenChange = useCallback(
+    (projectId: number, open: boolean) => {
+      setOpenByProject((prev) => ({ ...prev, [projectId]: open }))
+      if (open) {
+        void loadTestsForProject(projectId)
+      }
+    },
+    [loadTestsForProject]
+  )
+
+  const projectCount = tree?.projects.length ?? 0
+
+  const stackSubtitle = useMemo(() => {
+    if (tree === null) {
+      return null
+    }
+
+    return `${tree.stackName} (${projectCount} ${
+      projectCount === 1 ? 'project' : 'projects'
+    })`
+  }, [tree, projectCount])
 
   return (
     <Box
@@ -79,89 +188,142 @@ export function CloudWorkspaceSidebar({
           </Text>
         )}
         <ScrollArea scrollbars="vertical">
-          <Collapsible.Root open={open} onOpenChange={setOpen}>
-            <Flex align="center" gap="2" width="100%" px="1" pt="1">
-              <Collapsible.Trigger asChild>
-                <Reset>
-                  <button type="button">
-                    <Flex align="center" gap="1">
-                      {open ? <ChevronDownIcon /> : <ChevronRight />}
-                      <Text
-                        size="2"
-                        css={css`
-                          flex-grow: 1;
-                          font-weight: 600;
-                          font-size: 12px;
-                          text-transform: uppercase;
-                        `}
-                      >
-                        {tree?.stackName ?? 'Grafana Cloud'} (
-                        {tree?.tests.length ?? 0})
-                      </Text>
-                    </Flex>
-                  </button>
-                </Reset>
-              </Collapsible.Trigger>
-            </Flex>
-            <Collapsible.Content>
-              <ul
-                css={css`
-                  list-style: none;
-                  padding: 0;
-                  margin: var(--space-1) 0 var(--space-2);
-                `}
-              >
-                {tree &&
-                  tree.tests.map((t) => {
-                    const ref = formatCloudTestRef(t.projectId, t.testId)
-                    const to = getRoutePath('cloudWorkspaceTest', {
-                      ref: encodeURIComponent(ref),
-                    })
+          {stackSubtitle && (
+            <Text size="1" color="gray" mx="2" mb="1">
+              {stackSubtitle}
+            </Text>
+          )}
+          <Flex direction="column" gap="1" px="1" pb="2">
+            {tree &&
+              tree.projects.map((project) => {
+                const open = openByProject[project.projectId] ?? false
+                const loaded = project.projectId in testsByProject
+                const tests = testsByProject[project.projectId]
+                const testsError = testsErrorByProject[project.projectId]
+                const isLoading = loadingByProject[project.projectId] === true
 
-                    return (
-                      <li key={ref}>
-                        <Tooltip content={t.name} side="right" sideOffset={12}>
-                          <NavLink
-                            to={to}
-                            css={css`
-                              display: block;
-                              padding: var(--space-1) var(--space-2) var(--space-1)
-                                var(--space-5);
-                              font-size: 12px;
-                              line-height: 22px;
-                              color: var(--gray-11);
-                              border-radius: 4px;
-                              overflow: hidden;
-                              text-overflow: ellipsis;
-                              white-space: nowrap;
-                              text-decoration: none;
+                return (
+                  <Collapsible.Root
+                    key={project.projectId}
+                    open={open}
+                    onOpenChange={(next) =>
+                      handleProjectOpenChange(project.projectId, next)
+                    }
+                    asChild
+                  >
+                    <Box
+                      css={css`
+                        &[data-state='open'] .cloud-project-chevron {
+                          transform: rotate(90deg);
+                        }
+                      `}
+                    >
+                      <Flex align="center" gap="2" width="100%" pl="1" pt="1">
+                        <Collapsible.Trigger asChild>
+                          <Reset>
+                            <button type="button">
+                              <Flex align="center" gap="1" minWidth="0">
+                                <Box flexShrink="0">
+                                  <ChevronRight
+                                    className="cloud-project-chevron"
+                                    css={css`
+                                      flex-shrink: 0;
+                                      transition: transform 0.15s ease;
+                                    `}
+                                  />
+                                </Box>
+                                <Text
+                                  size="2"
+                                  css={css`
+                                    flex-grow: 1;
+                                    font-weight: 600;
+                                    font-size: 12px;
+                                    text-align: left;
+                                    overflow: hidden;
+                                    text-overflow: ellipsis;
+                                    white-space: nowrap;
+                                  `}
+                                  title={project.name}
+                                >
+                                  {project.name}
+                                  {loaded && tests !== undefined
+                                    ? ` (${tests.length})`
+                                    : ''}
+                                </Text>
+                              </Flex>
+                            </button>
+                          </Reset>
+                        </Collapsible.Trigger>
+                      </Flex>
+                      <Collapsible.Content>
+                        {isLoading && (
+                          <Flex align="center" justify="center" py="3">
+                            <Spinner />
+                          </Flex>
+                        )}
+                        {!isLoading && testsError !== undefined && (
+                          <Box px="2" py="2">
+                            <Text size="1" color="red">
+                              {testsError}
+                            </Text>
+                          </Box>
+                        )}
+                        {!isLoading &&
+                          loaded &&
+                          tests !== undefined &&
+                          testsError === undefined && (
+                            <ul
+                              css={css`
+                                list-style: none;
+                                padding: 0;
+                                margin: var(--space-1) 0 0;
+                              `}
+                            >
+                              {tests.map((t) => {
+                                const ref = formatCloudTestRef(
+                                  t.projectId,
+                                  t.testId
+                                )
+                                const to = getRoutePath('cloudWorkspaceTest', {
+                                  ref: encodeURIComponent(ref),
+                                })
 
-                              &:hover {
-                                background-color: var(--gray-4);
-                              }
-
-                              &.active {
-                                color: var(--accent-9);
-                                font-weight: 700;
-                              }
-                            `}
-                          >
-                            {t.name}.js
-                          </NavLink>
-                        </Tooltip>
-                      </li>
-                    )
-                  })}
-                {tree && tree.tests.length === 0 && (
-                  <Box px="2" py="1">
-                    <Text size="1" color="gray">
-                      No tests in this stack.
-                    </Text>
-                  </Box>
-                )}
-              </ul>
-            </Collapsible.Content>
-          </Collapsible.Root>
+                                return (
+                                  <li key={ref}>
+                                    <Tooltip
+                                      content={t.name}
+                                      side="right"
+                                      sideOffset={12}
+                                    >
+                                      <NavLink to={to} css={testLinkCss}>
+                                        {t.name}.js
+                                      </NavLink>
+                                    </Tooltip>
+                                  </li>
+                                )
+                              })}
+                              {tests.length === 0 && (
+                                <Box px="2" py="1">
+                                  <Text size="1" color="gray">
+                                    No tests in this project.
+                                  </Text>
+                                </Box>
+                              )}
+                            </ul>
+                          )}
+                      </Collapsible.Content>
+                    </Box>
+                  </Collapsible.Root>
+                )
+              })}
+            {tree && tree.projects.length === 0 && (
+              <Box px="2" py="1">
+                <Text size="1" color="gray">
+                  No projects in this stack.
+                </Text>
+              </Box>
+            )}
+          </Flex>
         </ScrollArea>
       </Flex>
     </Box>

--- a/src/components/Layout/Sidebar/CloudWorkspaceSidebar.tsx
+++ b/src/components/Layout/Sidebar/CloudWorkspaceSidebar.tsx
@@ -1,0 +1,169 @@
+import { css } from '@emotion/react'
+import * as Collapsible from '@radix-ui/react-collapsible'
+import {
+  Box,
+  Flex,
+  IconButton,
+  Reset,
+  ScrollArea,
+  Text,
+  Tooltip,
+} from '@radix-ui/themes'
+import { ChevronDownIcon, ChevronRight, PanelLeftCloseIcon } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { NavLink } from 'react-router-dom'
+
+import {
+  type CloudWorkspaceTree,
+  formatCloudTestRef,
+} from '@/handlers/cloudWorkspace/types'
+import { getRoutePath } from '@/routeMap'
+interface CloudWorkspaceSidebarProps {
+  isExpanded?: boolean
+  onCollapseSidebar: () => void
+}
+
+export function CloudWorkspaceSidebar({
+  isExpanded,
+  onCollapseSidebar,
+}: CloudWorkspaceSidebarProps) {
+  const [tree, setTree] = useState<CloudWorkspaceTree | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState(true)
+
+  const loadTree = useCallback(() => {
+    window.studio.cloudWorkspace
+      .getTree()
+      .then((data) => {
+        setError(null)
+        setTree(data)
+      })
+      .catch((err: unknown) => {
+        setTree(null)
+        setError(err instanceof Error ? err.message : 'Failed to load cloud tests.')
+      })
+  }, [])
+
+  useEffect(() => {
+    loadTree()
+  }, [loadTree])
+
+  return (
+    <Box
+      height="100%"
+      maxHeight="100%"
+      maxWidth="100%"
+      overflow="hidden"
+      position="relative"
+      asChild
+    >
+      <Flex direction="column">
+        <Flex align="center" m="2" gap="2" justify="between">
+          <Text size="1" weight="bold" color="gray" highContrast>
+            Cloud workspace
+          </Text>
+          {isExpanded && (
+            <IconButton
+              size="1"
+              variant="ghost"
+              color="gray"
+              onClick={onCollapseSidebar}
+            >
+              <PanelLeftCloseIcon />
+            </IconButton>
+          )}
+        </Flex>
+        {error && (
+          <Text size="1" color="red" mx="2" mb="2">
+            {error}
+          </Text>
+        )}
+        <ScrollArea scrollbars="vertical">
+          <Collapsible.Root open={open} onOpenChange={setOpen}>
+            <Flex align="center" gap="2" width="100%" px="1" pt="1">
+              <Collapsible.Trigger asChild>
+                <Reset>
+                  <button type="button">
+                    <Flex align="center" gap="1">
+                      {open ? <ChevronDownIcon /> : <ChevronRight />}
+                      <Text
+                        size="2"
+                        css={css`
+                          flex-grow: 1;
+                          font-weight: 600;
+                          font-size: 12px;
+                          text-transform: uppercase;
+                        `}
+                      >
+                        {tree?.stackName ?? 'Grafana Cloud'} (
+                        {tree?.tests.length ?? 0})
+                      </Text>
+                    </Flex>
+                  </button>
+                </Reset>
+              </Collapsible.Trigger>
+            </Flex>
+            <Collapsible.Content>
+              <ul
+                css={css`
+                  list-style: none;
+                  padding: 0;
+                  margin: var(--space-1) 0 var(--space-2);
+                `}
+              >
+                {tree &&
+                  tree.tests.map((t) => {
+                    const ref = formatCloudTestRef(t.projectId, t.testId)
+                    const to = getRoutePath('cloudWorkspaceTest', {
+                      ref: encodeURIComponent(ref),
+                    })
+
+                    return (
+                      <li key={ref}>
+                        <Tooltip content={t.name} side="right" sideOffset={12}>
+                          <NavLink
+                            to={to}
+                            css={css`
+                              display: block;
+                              padding: var(--space-1) var(--space-2) var(--space-1)
+                                var(--space-5);
+                              font-size: 12px;
+                              line-height: 22px;
+                              color: var(--gray-11);
+                              border-radius: 4px;
+                              overflow: hidden;
+                              text-overflow: ellipsis;
+                              white-space: nowrap;
+                              text-decoration: none;
+
+                              &:hover {
+                                background-color: var(--gray-4);
+                              }
+
+                              &.active {
+                                color: var(--accent-9);
+                                font-weight: 700;
+                              }
+                            `}
+                          >
+                            {t.name}.js
+                          </NavLink>
+                        </Tooltip>
+                      </li>
+                    )
+                  })}
+                {tree && tree.tests.length === 0 && (
+                  <Box px="2" py="1">
+                    <Text size="1" color="gray">
+                      No tests in this stack.
+                    </Text>
+                  </Box>
+                )}
+              </ul>
+            </Collapsible.Content>
+          </Collapsible.Root>
+        </ScrollArea>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/components/Layout/Sidebar/Sidebar.tsx
+++ b/src/components/Layout/Sidebar/Sidebar.tsx
@@ -11,20 +11,35 @@ import { useImportDataFile } from '@/hooks/useImportDataFile'
 import { getRoutePath } from '@/routeMap'
 import { useFeaturesStore } from '@/store/features'
 
+import { CloudWorkspaceSidebar } from './CloudWorkspaceSidebar'
 import { useFiles } from './Sidebar.hooks'
 
 interface SidebarProps {
   isExpanded?: boolean
   onCollapseSidebar: () => void
+  variant?: 'local' | 'cloud-workspace'
 }
 
-export function Sidebar({ isExpanded, onCollapseSidebar }: SidebarProps) {
+export function Sidebar({
+  isExpanded,
+  onCollapseSidebar,
+  variant = 'local',
+}: SidebarProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const { recordings, tests, scripts, dataFiles } = useFiles(searchTerm)
   const handleImportDataFile = useImportDataFile()
   const isBrowserEditorEnabled = useFeaturesStore(
     (state) => state.features['browser-test-editor']
   )
+
+  if (variant === 'cloud-workspace') {
+    return (
+      <CloudWorkspaceSidebar
+        isExpanded={isExpanded}
+        onCollapseSidebar={onCollapseSidebar}
+      />
+    )
+  }
 
   return (
     <Box

--- a/src/handlers/cloud/states.ts
+++ b/src/handlers/cloud/states.ts
@@ -238,7 +238,7 @@ export class RunInCloudStateMachine extends EventEmitter<RunInCloudEventMap> {
       type: 'done',
       result: {
         type: 'started',
-        testRunUrl: `${state.stack.url}/a/k6-app/runs/${run.id}`,
+        testRunUrl: run.test_run_details_page_url,
       },
     }
   }

--- a/src/handlers/cloudWorkspace/index.ts
+++ b/src/handlers/cloudWorkspace/index.ts
@@ -1,0 +1,128 @@
+import { ipcMain, shell } from 'electron'
+
+import { getProfileData } from '@/handlers/auth/fs'
+import { ProjectClient } from '@/services/k6/projects'
+import { TestClient } from '@/services/k6/tests'
+import { CloudCredentials } from '@/services/k6/types'
+
+import {
+  CloudWorkspaceHandlers,
+  CloudWorkspaceTree,
+  parseCloudTestRef,
+} from './types'
+
+async function getCredentials(): Promise<{
+  credentials: CloudCredentials
+  stackName: string
+}> {
+  const profiles = await getProfileData()
+  const stack = profiles.profiles.stacks[profiles.profiles.currentStack]
+
+  if (stack === undefined) {
+    throw new Error('Sign in to Grafana Cloud to use the cloud workspace.')
+  }
+
+  const token = profiles.tokens[stack.id]
+
+  if (token === undefined) {
+    throw new Error('Could not find token for the current stack.')
+  }
+
+  return {
+    credentials: {
+      stackId: stack.id,
+      token,
+    },
+    stackName: stack.name,
+  }
+}
+
+export function initialize() {
+  ipcMain.handle(
+    CloudWorkspaceHandlers.GetTree,
+    async (): Promise<CloudWorkspaceTree> => {
+      const { credentials, stackName } = await getCredentials()
+      const projects = new ProjectClient(credentials)
+      const tests = new TestClient(credentials)
+
+      const list = await projects.listAll({})
+      const entries: CloudWorkspaceTree['tests'] = []
+
+      for (const project of list.value) {
+        const projectTests = await tests.listInProject({
+          projectId: project.id,
+        })
+
+        for (const t of projectTests) {
+          entries.push({
+            projectId: t.project_id ?? project.id,
+            testId: t.id,
+            name: t.name,
+          })
+        }
+      }
+
+      entries.sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+      )
+
+      return { stackName, tests: entries }
+    }
+  )
+
+  ipcMain.handle(
+    CloudWorkspaceHandlers.GetScript,
+    async (_event, ref: string): Promise<string> => {
+      const parsed = parseCloudTestRef(ref)
+      if (parsed === null) {
+        throw new Error('Invalid cloud test reference.')
+      }
+
+      const { credentials } = await getCredentials()
+      const tests = new TestClient(credentials)
+
+      return tests.getScriptSource({
+        testId: parsed.testId,
+      })
+    }
+  )
+
+  ipcMain.handle(
+    CloudWorkspaceHandlers.SaveScript,
+    async (_event, ref: string, source: string): Promise<void> => {
+      const parsed = parseCloudTestRef(ref)
+      if (parsed === null) {
+        throw new Error('Invalid cloud test reference.')
+      }
+
+      const { credentials } = await getCredentials()
+      const tests = new TestClient(credentials)
+
+      await tests.putScriptSource({
+        testId: parsed.testId,
+        source,
+      })
+    }
+  )
+
+  ipcMain.handle(
+    CloudWorkspaceHandlers.RunTest,
+    async (_event, ref: string): Promise<string> => {
+      const parsed = parseCloudTestRef(ref)
+      if (parsed === null) {
+        throw new Error('Invalid cloud test reference.')
+      }
+
+      const { credentials } = await getCredentials()
+      const tests = new TestClient(credentials)
+
+      const run = await tests.run({
+        testId: parsed.testId,
+      })
+
+      await shell.openExternal(run.test_run_details_page_url)
+
+      return run.test_run_details_page_url
+    }
+  )
+}

--- a/src/handlers/cloudWorkspace/index.ts
+++ b/src/handlers/cloudWorkspace/index.ts
@@ -2,14 +2,33 @@ import { ipcMain, shell } from 'electron'
 
 import { getProfileData } from '@/handlers/auth/fs'
 import { ProjectClient } from '@/services/k6/projects'
+import type { CloudTest } from '@/services/k6/schemas'
 import { TestClient } from '@/services/k6/tests'
 import { CloudCredentials } from '@/services/k6/types'
 
 import {
   CloudWorkspaceHandlers,
+  CloudWorkspaceTestEntry,
   CloudWorkspaceTree,
   parseCloudTestRef,
 } from './types'
+
+function mapTestsForProject(
+  projectId: number,
+  projectTests: CloudTest[]
+): CloudWorkspaceTestEntry[] {
+  const entries: CloudWorkspaceTestEntry[] = projectTests.map((t) => ({
+    projectId: t.project_id ?? projectId,
+    testId: t.id,
+    name: t.name,
+  }))
+
+  entries.sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+  )
+
+  return entries
+}
 
 async function getCredentials(): Promise<{
   credentials: CloudCredentials
@@ -43,30 +62,31 @@ export function initialize() {
     async (): Promise<CloudWorkspaceTree> => {
       const { credentials, stackName } = await getCredentials()
       const projects = new ProjectClient(credentials)
-      const tests = new TestClient(credentials)
 
       const list = await projects.listAll({})
-      const entries: CloudWorkspaceTree['tests'] = []
-
-      for (const project of list.value) {
-        const projectTests = await tests.listInProject({
+      const projectFolders: CloudWorkspaceTree['projects'] = list.value.map(
+        (project) => ({
           projectId: project.id,
+          name: project.name,
         })
+      )
 
-        for (const t of projectTests) {
-          entries.push({
-            projectId: t.project_id ?? project.id,
-            testId: t.id,
-            name: t.name,
-          })
-        }
-      }
-
-      entries.sort((a, b) =>
+      projectFolders.sort((a, b) =>
         a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
       )
 
-      return { stackName, tests: entries }
+      return { stackName, projects: projectFolders }
+    }
+  )
+
+  ipcMain.handle(
+    CloudWorkspaceHandlers.ListProjectTests,
+    async (_event, projectId: number): Promise<CloudWorkspaceTestEntry[]> => {
+      const { credentials } = await getCredentials()
+      const tests = new TestClient(credentials)
+      const projectTests = await tests.listInProject({ projectId })
+
+      return mapTestsForProject(projectId, projectTests)
     }
   )
 

--- a/src/handlers/cloudWorkspace/preload.ts
+++ b/src/handlers/cloudWorkspace/preload.ts
@@ -2,12 +2,24 @@ import { ipcRenderer } from 'electron'
 
 import {
   CloudWorkspaceHandlers,
+  CloudWorkspaceTestEntry,
   CloudWorkspaceTree,
   CloudTestRefString,
 } from './types'
 
 export function getTree(): Promise<CloudWorkspaceTree> {
-  return ipcRenderer.invoke(CloudWorkspaceHandlers.GetTree) as Promise<CloudWorkspaceTree>
+  return ipcRenderer.invoke(
+    CloudWorkspaceHandlers.GetTree
+  ) as Promise<CloudWorkspaceTree>
+}
+
+export function listProjectTests(
+  projectId: number
+): Promise<CloudWorkspaceTestEntry[]> {
+  return ipcRenderer.invoke(
+    CloudWorkspaceHandlers.ListProjectTests,
+    projectId
+  ) as Promise<CloudWorkspaceTestEntry[]>
 }
 
 export function getScript(ref: CloudTestRefString): Promise<string> {

--- a/src/handlers/cloudWorkspace/preload.ts
+++ b/src/handlers/cloudWorkspace/preload.ts
@@ -1,0 +1,36 @@
+import { ipcRenderer } from 'electron'
+
+import {
+  CloudWorkspaceHandlers,
+  CloudWorkspaceTree,
+  CloudTestRefString,
+} from './types'
+
+export function getTree(): Promise<CloudWorkspaceTree> {
+  return ipcRenderer.invoke(CloudWorkspaceHandlers.GetTree) as Promise<CloudWorkspaceTree>
+}
+
+export function getScript(ref: CloudTestRefString): Promise<string> {
+  return ipcRenderer.invoke(
+    CloudWorkspaceHandlers.GetScript,
+    ref
+  ) as Promise<string>
+}
+
+export function saveScript(
+  ref: CloudTestRefString,
+  source: string
+): Promise<void> {
+  return ipcRenderer.invoke(
+    CloudWorkspaceHandlers.SaveScript,
+    ref,
+    source
+  ) as Promise<void>
+}
+
+export function runTest(ref: CloudTestRefString): Promise<string> {
+  return ipcRenderer.invoke(
+    CloudWorkspaceHandlers.RunTest,
+    ref
+  ) as Promise<string>
+}

--- a/src/handlers/cloudWorkspace/types.ts
+++ b/src/handlers/cloudWorkspace/types.ts
@@ -1,0 +1,42 @@
+export enum CloudWorkspaceHandlers {
+  GetTree = 'cloud-workspace:get-tree',
+  GetScript = 'cloud-workspace:get-script',
+  SaveScript = 'cloud-workspace:save-script',
+  RunTest = 'cloud-workspace:run-test',
+}
+
+/** Serialized test reference for routes and IPC (`projectId:testId`). */
+export type CloudTestRefString = `${number}:${number}`
+
+export interface CloudWorkspaceTestEntry {
+  projectId: number
+  testId: number
+  name: string
+}
+
+export interface CloudWorkspaceTree {
+  stackName: string
+  tests: CloudWorkspaceTestEntry[]
+}
+
+export function parseCloudTestRef(ref: string): {
+  projectId: number
+  testId: number
+} | null {
+  const match = /^(\d+):(\d+)$/.exec(ref.trim())
+  if (!match) {
+    return null
+  }
+
+  return {
+    projectId: Number(match[1]),
+    testId: Number(match[2]),
+  }
+}
+
+export function formatCloudTestRef(
+  projectId: number,
+  testId: number
+): CloudTestRefString {
+  return `${projectId}:${testId}`
+}

--- a/src/handlers/cloudWorkspace/types.ts
+++ b/src/handlers/cloudWorkspace/types.ts
@@ -1,5 +1,6 @@
 export enum CloudWorkspaceHandlers {
   GetTree = 'cloud-workspace:get-tree',
+  ListProjectTests = 'cloud-workspace:list-project-tests',
   GetScript = 'cloud-workspace:get-script',
   SaveScript = 'cloud-workspace:save-script',
   RunTest = 'cloud-workspace:run-test',
@@ -14,9 +15,15 @@ export interface CloudWorkspaceTestEntry {
   name: string
 }
 
+export interface CloudWorkspaceProjectSummary {
+  projectId: number
+  name: string
+}
+
 export interface CloudWorkspaceTree {
   stackName: string
-  tests: CloudWorkspaceTestEntry[]
+  /** Projects in the stack (tests are loaded when a folder is expanded). */
+  projects: CloudWorkspaceProjectSummary[]
 }
 
 export function parseCloudTestRef(ref: string): {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -5,6 +5,7 @@ import * as browser from './browser'
 import * as browserRemote from './browserRemote'
 import * as browserTest from './browserTest'
 import * as cloud from './cloud'
+import * as cloudWorkspace from './cloudWorkspace'
 import * as dataFiles from './dataFiles'
 import * as generator from './generator'
 import * as har from './har'
@@ -18,6 +19,7 @@ export function initialize() {
   browserRemote.initialize()
   auth.initialize()
   cloud.initialize()
+  cloudWorkspace.initialize()
   har.initialize()
   browser.initialize()
   script.initialize()

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -1,9 +1,14 @@
+import { randomUUID } from 'crypto'
 import { ipcMain } from 'electron'
 import log from 'electron-log/main'
 import { readFile, writeFile, unlink } from 'fs/promises'
 import path from 'path'
 
-import { SCRIPTS_PATH, TEMP_GENERATOR_SCRIPT_PATH } from '@/constants/workspace'
+import {
+  SCRIPTS_PATH,
+  TEMP_GENERATOR_SCRIPT_PATH,
+  TEMP_PATH,
+} from '@/constants/workspace'
 import { waitForProxy } from '@/main/proxy'
 import { showScriptSelectDialog, runScript } from '@/main/script'
 import { trackEvent } from '@/services/usageTracking'
@@ -54,6 +59,24 @@ export function initialize() {
       script,
       options: options ?? {},
       isExternal: isExternalScript(resolvedScriptPath),
+    }
+  })
+
+  ipcMain.handle(ScriptHandler.Inspect, async (_, script: string) => {
+    const tempPath = path.join(TEMP_PATH, `inspect-${randomUUID()}.js`)
+
+    await writeFile(tempPath, script, 'utf-8')
+
+    try {
+      const options = await new K6Client()
+        .inspect({ scriptPath: tempPath })
+        .catch(() => null)
+
+      return options ?? {}
+    } finally {
+      await unlink(tempPath).catch(() => {
+        /* temp may already be gone */
+      })
     }
   })
 

--- a/src/handlers/script/preload.ts
+++ b/src/handlers/script/preload.ts
@@ -2,6 +2,7 @@ import { ipcRenderer } from 'electron'
 
 import { BrowserActionEvent, BrowserReplayEvent } from '@/main/runner/schema'
 import { Check, LogEntry } from '@/schemas/k6'
+import { K6TestOptions } from '@/utils/k6/schema'
 
 import { createListener } from '../utils'
 
@@ -16,6 +17,13 @@ export function openScript(scriptPath: string) {
     ScriptHandler.Open,
     scriptPath
   ) as Promise<OpenScriptResult>
+}
+
+export function inspectScript(script: string) {
+  return ipcRenderer.invoke(
+    ScriptHandler.Inspect,
+    script
+  ) as Promise<K6TestOptions>
 }
 
 export function runScriptFromGenerator(script: string, shouldTrack = true) {

--- a/src/handlers/script/types.ts
+++ b/src/handlers/script/types.ts
@@ -3,6 +3,7 @@ import { K6TestOptions } from '@/utils/k6/schema'
 export enum ScriptHandler {
   Select = 'script:select',
   Open = 'script:open',
+  Inspect = 'script:inspect',
   Run = 'script:run',
   Stop = 'script:stop',
   Save = 'script:save',

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,6 +7,7 @@ import * as browser from './handlers/browser/preload'
 import * as browserRemote from './handlers/browserRemote/preload'
 import * as browserTest from './handlers/browserTest/preload'
 import * as cloud from './handlers/cloud/preload'
+import * as cloudWorkspace from './handlers/cloudWorkspace/preload'
 import * as data from './handlers/dataFiles/preload'
 import * as generator from './handlers/generator/preload'
 import * as har from './handlers/har/preload'
@@ -32,6 +33,7 @@ const studio = {
   settings,
   browserRemote,
   cloud,
+  cloudWorkspace,
   ai,
 } as const
 

--- a/src/routeMap.ts
+++ b/src/routeMap.ts
@@ -8,6 +8,8 @@ const routes = {
   generator: '/generator/:fileName',
   browserTestEditor: '/editor/:fileName',
   dataFilePreviewer: '/data-file/:fileName',
+  cloudWorkspace: '/cloud-workspace',
+  cloudWorkspaceTest: '/cloud-workspace/test/:ref',
 }
 
 export type RouteName = keyof typeof routes
@@ -31,4 +33,6 @@ export const routeMap = {
   browserTestEditor: getRoutePath('browserTestEditor'),
   validator: getRoutePath('validator'),
   dataFilePreviewer: getRoutePath('dataFilePreviewer'),
+  cloudWorkspace: getRoutePath('cloudWorkspace'),
+  cloudWorkspaceTest: getRoutePath('cloudWorkspaceTest'),
 }

--- a/src/services/k6/projects.ts
+++ b/src/services/k6/projects.ts
@@ -11,6 +11,19 @@ export class ProjectClient {
     this.#credentials = credentials
   }
 
+  async listAll({ signal }: CloudRequest) {
+    const response = await fetch(url(`/projects?$top=1000`), {
+      headers: getHeaders(this.#credentials),
+      signal,
+    })
+
+    if (!response.ok) {
+      throw new HttpError('Failed to fetch projects.', response)
+    }
+
+    return parse(response, ListCloudProjectsSchema)
+  }
+
   async findDefault({ signal }: CloudRequest) {
     const response = await fetch(url(`/projects`), {
       headers: getHeaders(this.#credentials),

--- a/src/services/k6/schemas.ts
+++ b/src/services/k6/schemas.ts
@@ -13,12 +13,25 @@ export function CloudList<
 export const CloudTestSchema = z.object({
   id: z.number(),
   name: z.string(),
+  project_id: z.number().optional(),
 })
 
 export const ListCloudTestsSchema = CloudList(CloudTestSchema)
 
+/** Single page of load tests (optional `@nextLink` for pagination). */
+export const ListCloudTestsPageSchema = z.object({
+  value: z.array(CloudTestSchema),
+  '@nextLink': z.string().optional(),
+})
+
 export const CloudTestRunSchema = z.object({
   id: z.number(),
+})
+
+/** Response from POST /load_tests/{id}/start (OpenAPI StartLoadTestResponse). */
+export const StartCloudTestRunSchema = z.object({
+  id: z.number(),
+  test_run_details_page_url: z.string(),
 })
 
 export const CloudProjectSchema = z.object({
@@ -31,4 +44,6 @@ export const ListCloudProjectsSchema = CloudList(CloudProjectSchema)
 
 export type CloudProject = z.infer<typeof CloudProjectSchema>
 export type CloudTest = z.infer<typeof CloudTestSchema>
+export type ListCloudTestsPage = z.infer<typeof ListCloudTestsPageSchema>
 export type CloudTestRun = z.infer<typeof CloudTestRunSchema>
+export type StartCloudTestRun = z.infer<typeof StartCloudTestRunSchema>

--- a/src/services/k6/tests.ts
+++ b/src/services/k6/tests.ts
@@ -1,10 +1,13 @@
 import { readFile } from 'fs/promises'
 
 import {
-  CloudTestRun,
-  CloudTestRunSchema,
+  CloudTest,
   CloudTestSchema,
+  ListCloudTestsPage,
+  ListCloudTestsPageSchema,
   ListCloudTestsSchema,
+  StartCloudTestRun,
+  StartCloudTestRunSchema,
 } from './schemas'
 import { CloudCredentials, CloudRequest } from './types'
 import { getHeaders, parse, url } from './utils'
@@ -18,6 +21,10 @@ interface RunTestArgs extends CloudRequest {
   testId: number
 }
 
+interface ListTestsInProjectArgs extends CloudRequest {
+  projectId: number
+}
+
 interface UploadArchiveArgs extends CloudRequest {
   projectId: number
   name: string
@@ -29,6 +36,36 @@ export class TestClient {
 
   constructor(credentials: CloudCredentials) {
     this.#credentials = credentials
+  }
+
+  async listInProject({
+    projectId,
+    signal,
+  }: ListTestsInProjectArgs): Promise<CloudTest[]> {
+    const collected: CloudTest[] = []
+    let nextUrl: string | null = url(
+      `/projects/${projectId}/load_tests?$top=1000`
+    )
+
+    while (nextUrl !== null) {
+      const response: Response = await fetch(nextUrl, {
+        headers: getHeaders(this.#credentials),
+        signal,
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch tests.')
+      }
+
+      const page: ListCloudTestsPage = await parse(
+        response,
+        ListCloudTestsPageSchema
+      )
+      collected.push(...page.value)
+      nextUrl = page['@nextLink'] ?? null
+    }
+
+    return collected
   }
 
   async findByName({ projectId, name, signal }: GetByTestNameArgs) {
@@ -92,7 +129,7 @@ export class TestClient {
     return test
   }
 
-  async run({ testId, signal }: RunTestArgs): Promise<CloudTestRun> {
+  async run({ testId, signal }: RunTestArgs): Promise<StartCloudTestRun> {
     const response = await fetch(url(`/load_tests/${testId}/start`), {
       method: 'POST',
       headers: getHeaders(this.#credentials),
@@ -103,6 +140,42 @@ export class TestClient {
       throw new Error('Failed to run the test.')
     }
 
-    return parse(response, CloudTestRunSchema)
+    return parse(response, StartCloudTestRunSchema)
+  }
+
+  async getScriptSource({ testId, signal }: RunTestArgs): Promise<string> {
+    const response = await fetch(url(`/load_tests/${testId}/script`), {
+      headers: {
+        ...getHeaders(this.#credentials),
+        Accept: 'text/javascript',
+      },
+      signal,
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to download the test script.')
+    }
+
+    return response.text()
+  }
+
+  async putScriptSource({
+    testId,
+    source,
+    signal,
+  }: RunTestArgs & { source: string }): Promise<void> {
+    const response = await fetch(url(`/load_tests/${testId}/script`), {
+      method: 'PUT',
+      headers: {
+        ...getHeaders(this.#credentials),
+        'Content-Type': 'application/octet-stream',
+      },
+      body: new TextEncoder().encode(source),
+      signal,
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to upload the test script.')
+    }
   }
 }

--- a/src/views/CloudWorkspace/CloudWorkspaceHome.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceHome.tsx
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react'
+import { Box, Text } from '@radix-ui/themes'
+
+export function CloudWorkspaceHome() {
+  return (
+    <Box p="6" height="100%">
+      <Text
+        size="3"
+        color="gray"
+        css={css`
+          max-width: 32rem;
+        `}
+      >
+        Select a test from the cloud workspace tree in the sidebar to open the
+        script editor.
+      </Text>
+    </Box>
+  )
+}

--- a/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react'
 import { Box, Button, Flex, Spinner, Text } from '@radix-ui/themes'
-import { PlayIcon, SaveIcon } from 'lucide-react'
+import { SaveIcon } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
 import { ReactMonacoEditor } from '@/components/Monaco/ReactMonacoEditor'
+import { GrafanaIcon } from '@/components/icons/GrafanaIcon'
 import {
   type CloudTestRefString,
   parseCloudTestRef,
@@ -146,19 +147,14 @@ export function CloudWorkspaceTestEditor() {
             </Text>
           )}
           <Button
-            size="1"
-            variant="soft"
+            variant="surface"
             disabled={status !== 'idle' || !isDirty}
             onClick={() => void handleSave()}
           >
-            <SaveIcon size={14} /> Save
+            <SaveIcon size={16} /> Save
           </Button>
-          <Button
-            size="1"
-            disabled={status !== 'idle'}
-            onClick={() => void handleRun()}
-          >
-            <PlayIcon size={14} /> Run in cloud
+          <Button disabled={status !== 'idle'} onClick={() => void handleRun()}>
+            <GrafanaIcon /> Run in Grafana Cloud
           </Button>
         </Flex>
       </Flex>

--- a/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
@@ -1,19 +1,45 @@
 import { css } from '@emotion/react'
-import { Box, Button, Flex, Spinner, Text } from '@radix-ui/themes'
-import { SaveIcon } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import {
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Spinner,
+  Text,
+  Tooltip,
+} from '@radix-ui/themes'
+import { CircleCheckBigIcon, SaveIcon } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 
+import { FileNameHeader } from '@/components/FileNameHeader'
+import { View } from '@/components/Layout/View'
 import { ReactMonacoEditor } from '@/components/Monaco/ReactMonacoEditor'
+import TextSpinner from '@/components/TextSpinner/TextSpinner'
 import { GrafanaIcon } from '@/components/icons/GrafanaIcon'
+import type { Script } from '@/handlers/cloud/types'
 import {
   type CloudTestRefString,
   parseCloudTestRef,
 } from '@/handlers/cloudWorkspace/types'
+import { useProxyStatus } from '@/hooks/useProxyStatus'
+import { useToast } from '@/store/ui/useToast'
+import { StudioFile } from '@/types'
+
+import { Debugger } from '../Validator/Debugger'
+import { useDebugSession } from '../Validator/Validator.hooks'
+
+import { useInspectScriptOptions } from './useInspectScriptOptions'
 
 export function CloudWorkspaceTestEditor() {
   const { ref: refParam } = useParams<{ ref: string }>()
   const ref = refParam ? decodeURIComponent(refParam) : ''
+
+  return <CloudWorkspaceTestEditorInner key={ref} urlRef={ref} />
+}
+
+function CloudWorkspaceTestEditorInner({ urlRef }: { urlRef: string }) {
+  const ref = urlRef
   const parsed = parseCloudTestRef(ref)
 
   const [source, setSource] = useState('')
@@ -22,8 +48,32 @@ export function CloudWorkspaceTestEditor() {
   const [status, setStatus] = useState<
     'idle' | 'loading' | 'saving' | 'running'
   >('idle')
-
   const isDirty = source !== savedSource
+
+  const script: Script = useMemo(
+    () => ({
+      type: 'raw',
+      content: source,
+      name: ref || 'cloud-test',
+    }),
+    [ref, source]
+  )
+
+  const { session, startDebugging, stopDebugging } = useDebugSession(script)
+  const { options, optionsReady } = useInspectScriptOptions(source, ref)
+  const proxyStatus = useProxyStatus()
+  const showToast = useToast()
+
+  const isRunning = session.state === 'running'
+
+  const cloudFile: StudioFile = useMemo(
+    () => ({
+      type: 'script',
+      fileName: `cloud-workspace/${ref}`,
+      displayName: ref,
+    }),
+    [ref]
+  )
 
   useEffect(() => {
     if (parsed?.testId === undefined || parsed?.projectId === undefined) {
@@ -58,6 +108,25 @@ export function CloudWorkspaceTestEditor() {
     }
   }, [parsed?.testId, parsed?.projectId, ref])
 
+  useEffect(() => {
+    return window.studio.script.onScriptFinished(() => {
+      showToast({
+        title: 'Script execution finished',
+        status: 'success',
+      })
+    })
+  }, [showToast])
+
+  useEffect(() => {
+    return window.studio.script.onScriptFailed(() => {
+      showToast({
+        title: 'Script execution finished',
+        description: 'The script finished running with errors',
+        status: 'error',
+      })
+    })
+  }, [showToast])
+
   const handleSave = useCallback(async () => {
     if (parsed === null) return
 
@@ -77,7 +146,7 @@ export function CloudWorkspaceTestEditor() {
     }
   }, [parsed, ref, source])
 
-  const handleRun = useCallback(async () => {
+  const handleRunInCloud = useCallback(async () => {
     if (parsed === null) return
 
     if (isDirty) {
@@ -95,6 +164,19 @@ export function CloudWorkspaceTestEditor() {
       setStatus('idle')
     }
   }, [handleSave, isDirty, parsed, ref])
+
+  const handleValidate = useCallback(async () => {
+    await startDebugging()
+  }, [startDebugging])
+
+  const handleStop = useCallback(async () => {
+    await stopDebugging()
+
+    showToast({
+      title: 'Script execution stopped',
+      description: 'The script execution was stopped by the user',
+    })
+  }, [showToast, stopDebugging])
 
   if (parsed === null) {
     return (
@@ -121,53 +203,95 @@ export function CloudWorkspaceTestEditor() {
   }
 
   return (
-    <Flex direction="column" height="100%" overflow="hidden">
-      <Flex
-        align="center"
-        justify="between"
-        px="3"
-        py="2"
-        gap="3"
-        css={css`
-          border-bottom: 1px solid var(--gray-5);
-          flex-shrink: 0;
-        `}
-      >
-        <Text
-          size="2"
-          weight="medium"
-          css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-        >
-          Cloud test · {ref}
-        </Text>
-        <Flex gap="2" align="center">
+    <View
+      title="Cloud test"
+      subTitle={
+        <FileNameHeader file={cloudFile} canRename={false} isDirty={isDirty} />
+      }
+      actions={
+        <>
+          {isRunning && (
+            <>
+              <TextSpinner text="Running" />
+              <Button variant="outline" onClick={() => void handleStop()}>
+                Stop run
+              </Button>
+            </>
+          )}
+          {!isRunning && (
+            <>
+              <Tooltip content={isDirty ? 'Save changes' : 'Changes saved'}>
+                <IconButton
+                  onClick={() => void handleSave()}
+                  disabled={status !== 'idle' || !isDirty}
+                  variant="ghost"
+                  color="gray"
+                >
+                  <SaveIcon />
+                </IconButton>
+              </Tooltip>
+              <Tooltip
+                content={`Proxy is ${proxyStatus}`}
+                hidden={proxyStatus === 'online'}
+              >
+                <Button
+                  variant="ghost"
+                  onClick={() => void handleValidate()}
+                  disabled={proxyStatus !== 'online' || status !== 'idle'}
+                >
+                  <CircleCheckBigIcon /> Validate
+                </Button>
+              </Tooltip>
+              <Button
+                disabled={status !== 'idle'}
+                loading={status === 'running'}
+                onClick={() => void handleRunInCloud()}
+              >
+                <GrafanaIcon /> Run in Grafana Cloud
+              </Button>
+            </>
+          )}
           {loadError && (
-            <Text size="1" color="red">
+            <Text
+              size="1"
+              color="red"
+              css={css`
+                max-width: 200px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              `}
+            >
               {loadError}
             </Text>
           )}
-          <Button
-            variant="surface"
-            disabled={status !== 'idle' || !isDirty}
-            onClick={() => void handleSave()}
-          >
-            <SaveIcon size={16} /> Save
-          </Button>
-          <Button disabled={status !== 'idle'} onClick={() => void handleRun()}>
-            <GrafanaIcon /> Run in Grafana Cloud
-          </Button>
-        </Flex>
+        </>
+      }
+    >
+      <Flex flexGrow="1" direction="column" minHeight="0" align="stretch">
+        {!optionsReady || options === null ? (
+          <Flex flexGrow="1" align="center" justify="center">
+            <Spinner />
+          </Flex>
+        ) : (
+          <Debugger
+            script={source}
+            options={options}
+            session={session}
+            onDebugScript={handleValidate}
+            scriptSlot={
+              <ReactMonacoEditor
+                height="100%"
+                language="javascript"
+                value={source}
+                onChange={(value) => setSource(value ?? '')}
+                path={`cloud-workspace/${ref}.js`}
+                showToolbar
+              />
+            }
+          />
+        )}
       </Flex>
-      <Box flexGrow="1" minHeight="0">
-        <ReactMonacoEditor
-          height="100%"
-          language="javascript"
-          value={source}
-          onChange={(value) => setSource(value ?? '')}
-          path={`cloud-workspace/${ref}.js`}
-          showToolbar
-        />
-      </Box>
-    </Flex>
+    </View>
   )
 }

--- a/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
@@ -209,63 +209,65 @@ function CloudWorkspaceTestEditorInner({ urlRef }: { urlRef: string }) {
         <FileNameHeader file={cloudFile} canRename={false} isDirty={isDirty} />
       }
       actions={
-        <>
-          {isRunning && (
-            <>
-              <TextSpinner text="Running" />
-              <Button variant="outline" onClick={() => void handleStop()}>
-                Stop run
-              </Button>
-            </>
-          )}
-          {!isRunning && (
-            <>
-              <Tooltip content={isDirty ? 'Save changes' : 'Changes saved'}>
-                <IconButton
-                  onClick={() => void handleSave()}
-                  disabled={status !== 'idle' || !isDirty}
-                  variant="ghost"
-                  color="gray"
-                >
-                  <SaveIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip
-                content={`Proxy is ${proxyStatus}`}
-                hidden={proxyStatus === 'online'}
-              >
-                <Button
-                  variant="ghost"
-                  onClick={() => void handleValidate()}
-                  disabled={proxyStatus !== 'online' || status !== 'idle'}
-                >
-                  <CircleCheckBigIcon /> Validate
+        <Flex align="center" gap="2" ml="2">
+          <Flex gap="4" align="center">
+            {isRunning && (
+              <>
+                <TextSpinner text="Running" />
+                <Button variant="outline" onClick={() => void handleStop()}>
+                  Stop run
                 </Button>
-              </Tooltip>
-              <Button
-                disabled={status !== 'idle'}
-                loading={status === 'running'}
-                onClick={() => void handleRunInCloud()}
+              </>
+            )}
+            {!isRunning && (
+              <>
+                <Tooltip content={isDirty ? 'Save changes' : 'Changes saved'}>
+                  <IconButton
+                    onClick={() => void handleSave()}
+                    disabled={status !== 'idle' || !isDirty}
+                    variant="ghost"
+                    color="gray"
+                  >
+                    <SaveIcon />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip
+                  content={`Proxy is ${proxyStatus}`}
+                  hidden={proxyStatus === 'online'}
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => void handleValidate()}
+                    disabled={proxyStatus !== 'online' || status !== 'idle'}
+                  >
+                    <CircleCheckBigIcon /> Validate
+                  </Button>
+                </Tooltip>
+                <Button
+                  disabled={status !== 'idle'}
+                  loading={status === 'running'}
+                  onClick={() => void handleRunInCloud()}
+                >
+                  <GrafanaIcon /> Run in Grafana Cloud
+                </Button>
+              </>
+            )}
+            {loadError && (
+              <Text
+                size="1"
+                color="red"
+                css={css`
+                  max-width: 200px;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                `}
               >
-                <GrafanaIcon /> Run in Grafana Cloud
-              </Button>
-            </>
-          )}
-          {loadError && (
-            <Text
-              size="1"
-              color="red"
-              css={css`
-                max-width: 200px;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-              `}
-            >
-              {loadError}
-            </Text>
-          )}
-        </>
+                {loadError}
+              </Text>
+            )}
+          </Flex>
+        </Flex>
       }
     >
       <Flex flexGrow="1" direction="column" minHeight="0" align="stretch">

--- a/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
@@ -18,19 +18,21 @@ export function CloudWorkspaceTestEditor() {
   const [source, setSource] = useState('')
   const [savedSource, setSavedSource] = useState('')
   const [loadError, setLoadError] = useState<string | null>(null)
-  const [status, setStatus] = useState<'idle' | 'loading' | 'saving' | 'running'>(
-    'idle'
-  )
+  const [status, setStatus] = useState<
+    'idle' | 'loading' | 'saving' | 'running'
+  >('idle')
 
   const isDirty = source !== savedSource
 
   useEffect(() => {
-    if (parsed === null) {
+    if (parsed?.testId === undefined || parsed?.projectId === undefined) {
       setLoadError('Invalid test link.')
+
       return
     }
 
     let cancelled = false
+
     setStatus('loading')
     setLoadError(null)
 
@@ -44,14 +46,16 @@ export function CloudWorkspaceTestEditor() {
       })
       .catch((err: unknown) => {
         if (cancelled) return
-        setLoadError(err instanceof Error ? err.message : 'Failed to load script.')
+        setLoadError(
+          err instanceof Error ? err.message : 'Failed to load script.'
+        )
         setStatus('idle')
       })
 
     return () => {
       cancelled = true
     }
-  }, [parsed, ref])
+  }, [parsed?.testId, parsed?.projectId, ref])
 
   const handleSave = useCallback(async () => {
     if (parsed === null) return
@@ -64,7 +68,9 @@ export function CloudWorkspaceTestEditor() {
       )
       setSavedSource(source)
     } catch (err: unknown) {
-      setLoadError(err instanceof Error ? err.message : 'Failed to save script.')
+      setLoadError(
+        err instanceof Error ? err.message : 'Failed to save script.'
+      )
     } finally {
       setStatus('idle')
     }
@@ -81,7 +87,9 @@ export function CloudWorkspaceTestEditor() {
     try {
       await window.studio.cloudWorkspace.runTest(ref as CloudTestRefString)
     } catch (err: unknown) {
-      setLoadError(err instanceof Error ? err.message : 'Failed to start test run.')
+      setLoadError(
+        err instanceof Error ? err.message : 'Failed to start test run.'
+      )
     } finally {
       setStatus('idle')
     }
@@ -124,7 +132,11 @@ export function CloudWorkspaceTestEditor() {
           flex-shrink: 0;
         `}
       >
-        <Text size="2" weight="medium" css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+        <Text
+          size="2"
+          weight="medium"
+          css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+        >
           Cloud test · {ref}
         </Text>
         <Flex gap="2" align="center">

--- a/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
+++ b/src/views/CloudWorkspace/CloudWorkspaceTestEditor.tsx
@@ -1,0 +1,165 @@
+import { css } from '@emotion/react'
+import { Box, Button, Flex, Spinner, Text } from '@radix-ui/themes'
+import { PlayIcon, SaveIcon } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+import { ReactMonacoEditor } from '@/components/Monaco/ReactMonacoEditor'
+import {
+  type CloudTestRefString,
+  parseCloudTestRef,
+} from '@/handlers/cloudWorkspace/types'
+
+export function CloudWorkspaceTestEditor() {
+  const { ref: refParam } = useParams<{ ref: string }>()
+  const ref = refParam ? decodeURIComponent(refParam) : ''
+  const parsed = parseCloudTestRef(ref)
+
+  const [source, setSource] = useState('')
+  const [savedSource, setSavedSource] = useState('')
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [status, setStatus] = useState<'idle' | 'loading' | 'saving' | 'running'>(
+    'idle'
+  )
+
+  const isDirty = source !== savedSource
+
+  useEffect(() => {
+    if (parsed === null) {
+      setLoadError('Invalid test link.')
+      return
+    }
+
+    let cancelled = false
+    setStatus('loading')
+    setLoadError(null)
+
+    window.studio.cloudWorkspace
+      .getScript(ref as CloudTestRefString)
+      .then((text) => {
+        if (cancelled) return
+        setSource(text)
+        setSavedSource(text)
+        setStatus('idle')
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : 'Failed to load script.')
+        setStatus('idle')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [parsed, ref])
+
+  const handleSave = useCallback(async () => {
+    if (parsed === null) return
+
+    setStatus('saving')
+    try {
+      await window.studio.cloudWorkspace.saveScript(
+        ref as CloudTestRefString,
+        source
+      )
+      setSavedSource(source)
+    } catch (err: unknown) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to save script.')
+    } finally {
+      setStatus('idle')
+    }
+  }, [parsed, ref, source])
+
+  const handleRun = useCallback(async () => {
+    if (parsed === null) return
+
+    if (isDirty) {
+      await handleSave()
+    }
+
+    setStatus('running')
+    try {
+      await window.studio.cloudWorkspace.runTest(ref as CloudTestRefString)
+    } catch (err: unknown) {
+      setLoadError(err instanceof Error ? err.message : 'Failed to start test run.')
+    } finally {
+      setStatus('idle')
+    }
+  }, [handleSave, isDirty, parsed, ref])
+
+  if (parsed === null) {
+    return (
+      <Box p="6">
+        <Text color="red">{loadError ?? 'Invalid test reference.'}</Text>
+      </Box>
+    )
+  }
+
+  if (status === 'loading') {
+    return (
+      <Flex align="center" justify="center" height="100%">
+        <Spinner />
+      </Flex>
+    )
+  }
+
+  if (loadError && savedSource === '' && source === '') {
+    return (
+      <Box p="6">
+        <Text color="red">{loadError}</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Flex direction="column" height="100%" overflow="hidden">
+      <Flex
+        align="center"
+        justify="between"
+        px="3"
+        py="2"
+        gap="3"
+        css={css`
+          border-bottom: 1px solid var(--gray-5);
+          flex-shrink: 0;
+        `}
+      >
+        <Text size="2" weight="medium" css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          Cloud test · {ref}
+        </Text>
+        <Flex gap="2" align="center">
+          {loadError && (
+            <Text size="1" color="red">
+              {loadError}
+            </Text>
+          )}
+          <Button
+            size="1"
+            variant="soft"
+            disabled={status !== 'idle' || !isDirty}
+            onClick={() => void handleSave()}
+          >
+            <SaveIcon size={14} /> Save
+          </Button>
+          <Button
+            size="1"
+            disabled={status !== 'idle'}
+            onClick={() => void handleRun()}
+          >
+            <PlayIcon size={14} /> Run in cloud
+          </Button>
+        </Flex>
+      </Flex>
+      <Box flexGrow="1" minHeight="0">
+        <ReactMonacoEditor
+          height="100%"
+          language="javascript"
+          value={source}
+          onChange={(value) => setSource(value ?? '')}
+          path={`cloud-workspace/${ref}.js`}
+          showToolbar
+        />
+      </Box>
+    </Flex>
+  )
+}

--- a/src/views/CloudWorkspace/useInspectScriptOptions.ts
+++ b/src/views/CloudWorkspace/useInspectScriptOptions.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { K6TestOptions } from '@/utils/k6/schema'
+
+const DEBOUNCE_MS = 400
+
+/**
+ * Runs `k6 inspect` on script text (debounced after edits) so the debugger can
+ * choose browser vs protocol layout.
+ */
+export function useInspectScriptOptions(source: string, resetKey: string) {
+  const [inspectedOptions, setInspectedOptions] =
+    useState<K6TestOptions | null>(null)
+  const isFirstRun = useRef(true)
+
+  useEffect(() => {
+    isFirstRun.current = true
+    setInspectedOptions(null)
+  }, [resetKey])
+
+  useEffect(() => {
+    let cancelled = false
+    const delay = isFirstRun.current ? 0 : DEBOUNCE_MS
+    isFirstRun.current = false
+
+    const t = window.setTimeout(() => {
+      void window.studio.script.inspectScript(source).then(
+        (o) => {
+          if (!cancelled) {
+            setInspectedOptions(o)
+          }
+        },
+        () => {
+          if (!cancelled) {
+            setInspectedOptions({})
+          }
+        }
+      )
+    }, delay)
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(t)
+    }
+  }, [source])
+
+  return {
+    options: inspectedOptions,
+    optionsReady: inspectedOptions !== null,
+  }
+}

--- a/src/views/Validator/Browser/BrowserDebugger.tsx
+++ b/src/views/Validator/Browser/BrowserDebugger.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { Flex, Tabs } from '@radix-ui/themes'
-import { useState } from 'react'
+import { ReactNode, useState } from 'react'
 
 import {
   LogsSection,
@@ -25,12 +25,14 @@ interface BrowserDebuggerProps {
   script: string
   session: DebugSession
   onDebugScript: () => void
+  scriptSlot?: ReactNode
 }
 
 export function BrowserDebugger({
   script,
   session,
   onDebugScript,
+  scriptSlot,
 }: BrowserDebuggerProps) {
   const [highlightedSelector, setHighlightedSelector] =
     useState<NodeSelector | null>(null)
@@ -84,6 +86,7 @@ export function BrowserDebugger({
                   script={script}
                   session={session}
                   highlightedSelector={highlightedSelector}
+                  scriptSlot={scriptSlot}
                 />
               </Panel>
               <Separator />

--- a/src/views/Validator/Browser/BrowserOverviewPanel.tsx
+++ b/src/views/Validator/Browser/BrowserOverviewPanel.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 import { Box, Flex, Tabs } from '@radix-ui/themes'
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
 import { ReadOnlyEditor } from '@/components/Monaco/ReadOnlyEditor'
 import { NodeSelector } from '@/schemas/selectors'
@@ -13,12 +13,14 @@ interface BrowserOverviewPanelProps {
   script: string
   session: DebugSession
   highlightedSelector: NodeSelector | null
+  scriptSlot?: ReactNode
 }
 
 export function BrowserOverviewPanel({
   script,
   session,
   highlightedSelector,
+  scriptSlot,
 }: BrowserOverviewPanelProps) {
   const [tab, setTab] = useState('script')
 
@@ -52,11 +54,13 @@ export function BrowserOverviewPanel({
           value="script"
           forceMount
         >
-          <ReadOnlyEditor
-            value={script}
-            showToolbar={false}
-            language="typescript"
-          />
+          {scriptSlot ?? (
+            <ReadOnlyEditor
+              value={script}
+              showToolbar={false}
+              language="typescript"
+            />
+          )}
         </Tabs.Content>
         <Tabs.Content
           css={css`

--- a/src/views/Validator/Debugger.tsx
+++ b/src/views/Validator/Debugger.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react'
+
 import { K6TestOptions } from '@/utils/k6/schema'
 
 import { BrowserDebugger } from './Browser/BrowserDebugger'
@@ -15,6 +17,8 @@ interface DebuggerProps {
   options: K6TestOptions
   session: DebugSession
   onDebugScript: () => void
+  /** When set, replaces the read-only script editor (e.g. editable Monaco). */
+  scriptSlot?: ReactNode
 }
 
 export function Debugger({
@@ -22,6 +26,7 @@ export function Debugger({
   options,
   session,
   onDebugScript,
+  scriptSlot,
 }: DebuggerProps) {
   if (isBrowserTest(options)) {
     return (
@@ -29,6 +34,7 @@ export function Debugger({
         script={script}
         session={session}
         onDebugScript={onDebugScript}
+        scriptSlot={scriptSlot}
       />
     )
   }
@@ -38,6 +44,7 @@ export function Debugger({
       script={script}
       session={session}
       onDebugScript={onDebugScript}
+      scriptSlot={scriptSlot}
     />
   )
 }

--- a/src/views/Validator/HTTP/HttpDebugger.tsx
+++ b/src/views/Validator/HTTP/HttpDebugger.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Box, Flex, Tabs } from '@radix-ui/themes'
 import { Allotment } from 'allotment'
-import { useEffect, useState } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
 import { ReadOnlyEditor } from '@/components/Monaco/ReadOnlyEditor'
 import { ExecutionDetails } from '@/components/Validator/ExecutionDetails'
@@ -23,12 +23,14 @@ interface HttpDebuggerProps {
   script: string
   session: DebugSession
   onDebugScript: () => void
+  scriptSlot?: ReactNode
 }
 
 export function HttpDebugger({
   script,
   session,
   onDebugScript,
+  scriptSlot,
 }: HttpDebuggerProps) {
   const [tab, setTab] = useState('script')
 
@@ -61,11 +63,13 @@ export function HttpDebugger({
                   <Tabs.Trigger value="requests">Requests</Tabs.Trigger>
                 </Tabs.List>
                 <TabsContent value="script">
-                  <ReadOnlyEditor
-                    value={script}
-                    showToolbar={false}
-                    language="typescript"
-                  />
+                  {scriptSlot ?? (
+                    <ReadOnlyEditor
+                      value={script}
+                      showToolbar={false}
+                      language="typescript"
+                    />
+                  )}
                 </TabsContent>
                 <TabsContent value="requests">
                   {session.state === 'pending' && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This proof of concept adds a **Cloud workspace** entry in the activity bar. When you open it, the sidebar switches to a collapsible tree whose root is the current Grafana Cloud stack name and whose leaves are **flat** entries for every load test in every project (displayed as `name.js`). Selecting a test opens a **Monaco** editor for the script (`GET/PUT /cloud/v6/load_tests/{id}/script` with `Accept: text/javascript` for download). **Run in cloud** starts the test via the REST API and opens the run URL returned by the API.

Main process IPC (`window.studio.cloudWorkspace`) wraps the existing k6 cloud credentials (stack token from the signed-in profile). Run-in-cloud from the validator now uses `test_run_details_page_url` from the start response instead of constructing the Grafana URL manually.

Toolbar actions in the cloud script editor use the same Radix **Button** variants and labeling as the validator (**Save** = `variant="surface"` like Debug script; primary run = default solid with **GrafanaIcon** and **Run in Grafana Cloud**).

**Limitations (PoC):** tests stored only as `.tar` archives in Grafana Cloud cannot be edited as plain text in this flow (the API returns non-JavaScript content). Pagination for projects/tests is handled for `@nextLink` on test lists.

## How to Test

1. Sign in to Grafana Cloud in the app (profile).
2. Click the cloud icon in the activity bar (`#/cloud-workspace`).
3. Confirm the sidebar shows the stack name and a list of tests; open one and edit in Monaco.
4. Save, then Run in Grafana Cloud; confirm the browser opens the test run page.
5. From Validator, use Run in Grafana Cloud and confirm the opened URL still works.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

PoC for cloud workspace / Grafana Cloud k6 REST API integration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8cec561-37c4-48b9-86bf-69008b73a119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8cec561-37c4-48b9-86bf-69008b73a119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

