### PR TITLE
refactor: Make TestOptions dialog controlled via props and callbacks

### DIFF
--- a/src/store/generator/selectors.ts
+++ b/src/store/generator/selectors.ts
@@ -73,7 +73,7 @@ export function selectGeneratorData(state: GeneratorStore): GeneratorFileData {
   }
 }
 
-function selectLoadProfile({
+export function selectLoadProfileExecutorOptions({
   executor,
   stages,
   vus,
@@ -94,6 +94,10 @@ function selectLoadProfile({
     default:
       return exhaustive(executor)
   }
+}
+
+function selectLoadProfile(state: GeneratorStore): TestOptions['loadProfile'] {
+  return selectLoadProfileExecutorOptions(state)
 }
 
 export function selectHasVerificationRule(state: GeneratorStore) {

--- a/src/views/Generator/GeneratorTabs/GeneratorTabs.tsx
+++ b/src/views/Generator/GeneratorTabs/GeneratorTabs.tsx
@@ -1,19 +1,28 @@
 import { css } from '@emotion/react'
 import { Box, Flex, Tabs } from '@radix-ui/themes'
 import { CircleXIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 import { useScriptPreview } from '@/hooks/useScriptPreview'
 import {
   selectFilteredRequests,
+  selectHasGroups,
   selectHasRecording,
+  selectLoadProfileExecutorOptions,
   useGeneratorStore,
 } from '@/store/generator'
 import { ProxyData } from '@/types'
+import type { TestData as GeneratorTestData } from '@/types/testData'
+import type {
+  LoadProfileExecutorOptions,
+  LoadZoneData,
+  ThinkTime,
+  Threshold,
+} from '@/types/testOptions'
 
 import { Allowlist } from '../Allowlist'
 import { TestData } from '../TestData'
-import { TestOptions } from '../TestOptions'
+import { TestOptionsDialog } from '../TestOptions'
 
 import { RequestList } from './RequestList'
 import { ScriptPreview } from './ScriptPreview'
@@ -32,6 +41,59 @@ export function GeneratorTabs({
   const { hasError } = useScriptPreview()
 
   const hasRecording = useGeneratorStore(selectHasRecording)
+
+  const loadProfile = useGeneratorStore(selectLoadProfileExecutorOptions)
+  const sleepType = useGeneratorStore((store) => store.sleepType)
+  const timing = useGeneratorStore((store) => store.timing)
+  const hasGroups = useGeneratorStore(selectHasGroups)
+  const thresholds = useGeneratorStore((store) => store.thresholds)
+  const loadZones = useGeneratorStore((store) => store.loadZones)
+  const variables = useGeneratorStore((store) => store.variables)
+  const rules = useGeneratorStore((store) => store.rules)
+
+  const handleLoadProfileChange = useCallback(
+    (data: LoadProfileExecutorOptions) => {
+      const {
+        setExecutor,
+        setStages,
+        setVus,
+        setIterations,
+      } = useGeneratorStore.getState()
+      setExecutor(data.executor)
+      if (data.executor === 'ramping-vus') {
+        setStages(data.stages)
+      }
+      if (data.executor === 'shared-iterations') {
+        setVus(data.vus)
+        setIterations(data.iterations)
+      }
+    },
+    []
+  )
+
+  const handleThinkTimeChange = useCallback(
+    (data: Pick<ThinkTime, 'sleepType' | 'timing'>) => {
+      const { setSleepType, setTiming } = useGeneratorStore.getState()
+      setSleepType(data.sleepType)
+      setTiming(data.timing)
+    },
+    []
+  )
+
+  const handleThresholdsChange = useCallback((next: Threshold[]) => {
+    useGeneratorStore.getState().setThresholds(next)
+  }, [])
+
+  const handleLoadZonesChange = useCallback((next: LoadZoneData) => {
+    useGeneratorStore.getState().setLoadZones(next)
+  }, [])
+
+  const handleVariablesChange = useCallback(
+    (next: GeneratorTestData['variables']) => {
+      useGeneratorStore.getState().setVariables(next)
+    },
+    []
+  )
 
   return (
     <Flex direction="column" height="100%" minHeight="0" asChild>
@@ -65,7 +127,20 @@ export function GeneratorTabs({
                 </Tabs.Trigger>
               </Flex>
               <Flex pr="2" pl="4" gap="4">
-                <TestOptions />
+                <TestOptionsDialog
+                  loadProfile={loadProfile}
+                  onLoadProfileChange={handleLoadProfileChange}
+                  thinkTime={{ sleepType, timing }}
+                  onThinkTimeChange={handleThinkTimeChange}
+                  hasGroups={hasGroups}
+                  thresholds={thresholds}
+                  onThresholdsChange={handleThresholdsChange}
+                  loadZones={loadZones}
+                  onLoadZonesChange={handleLoadZonesChange}
+                  variables={variables}
+                  onVariablesChange={handleVariablesChange}
+                  rules={rules}
+                />
                 <TestData />
                 <Allowlist />
               </Flex>

--- a/src/views/Generator/TestData/TestData.tsx
+++ b/src/views/Generator/TestData/TestData.tsx
@@ -4,12 +4,16 @@ import { ArchiveIcon } from 'lucide-react'
 import { useState } from 'react'
 
 import { PopoverDialog } from '@/components/PopoverDialogs'
+import { useGeneratorStore } from '@/store/generator'
 
 import { DataFiles } from './DataFiles'
 import { VariablesEditor } from './VariablesEditor'
 
 export function TestData() {
   const [selectedTab, setSelectedTab] = useState('variables')
+  const variables = useGeneratorStore((store) => store.variables)
+  const setVariables = useGeneratorStore((store) => store.setVariables)
+  const rules = useGeneratorStore((store) => store.rules)
 
   return (
     <PopoverDialog
@@ -40,7 +44,11 @@ export function TestData() {
           >
             <Box p="3" pt="0" css={{ '.rt-TabsContent': { outline: 'none' } }}>
               <Tabs.Content value="variables">
-                <VariablesEditor />
+                <VariablesEditor
+                  variables={variables}
+                  rules={rules}
+                  onVariablesChange={setVariables}
+                />
               </Tabs.Content>
               <Tabs.Content value="dataFiles">
                 <DataFiles />

--- a/src/views/Generator/TestData/VariablesEditor.tsx
+++ b/src/views/Generator/TestData/VariablesEditor.tsx
@@ -14,24 +14,36 @@ import {
 import { FieldGroup } from '@/components/Form'
 import { Table } from '@/components/Table'
 import { TestDataSchema } from '@/schemas/generator'
-import { useGeneratorStore } from '@/store/generator'
+import { TestRule } from '@/types/rules'
 import { TestData } from '@/types/testData'
 
-export function VariablesEditor() {
-  const variables = useGeneratorStore((store) => store.variables)
-  const setVariables = useGeneratorStore((store) => store.setVariables)
+interface VariablesEditorProps {
+  variables: TestData['variables']
+  rules: TestRule[]
+  onVariablesChange: (variables: TestData['variables']) => void
+}
 
+export function VariablesEditor({
+  variables,
+  rules,
+  onVariablesChange,
+}: VariablesEditorProps) {
   const {
     handleSubmit,
     register,
     control,
     watch,
+    reset,
     formState: { errors },
   } = useForm<Pick<TestData, 'variables'>>({
     resolver: zodResolver(TestDataSchema.pick({ variables: true })),
     shouldFocusError: false,
     defaultValues: { variables },
   })
+
+  useEffect(() => {
+    reset({ variables })
+  }, [variables, reset])
 
   const { fields, append, remove } = useFieldArray({
     control,
@@ -42,9 +54,9 @@ export function VariablesEditor() {
 
   const onSubmit = useCallback(
     (data: Pick<TestData, 'variables'>) => {
-      setVariables(data.variables)
+      onVariablesChange(data.variables)
     },
-    [setVariables]
+    [onVariablesChange]
   )
 
   // Submit onChange
@@ -80,6 +92,7 @@ export function VariablesEditor() {
               register={register}
               errors={errors}
               onRemove={remove}
+              rules={rules}
             />
           ))}
           <Table.Row>
@@ -101,6 +114,7 @@ interface VariableRowProps {
   register: UseFormRegister<Pick<TestData, 'variables'>>
   errors: FieldErrors<Pick<TestData, 'variables'>>
   onRemove: UseFieldArrayRemove
+  rules: TestRule[]
 }
 
 function VariableRow({
@@ -109,14 +123,13 @@ function VariableRow({
   errors,
   register,
   onRemove,
+  rules,
 }: VariableRowProps) {
-  const isVariableInUse = useGeneratorStore((state) =>
-    state.rules.some(
-      (rule) =>
-        rule.type === 'parameterization' &&
-        rule.value.type === 'variable' &&
-        rule.value.variableName === field.name
-    )
+  const isVariableInUse = rules.some(
+    (rule) =>
+      rule.type === 'parameterization' &&
+      rule.value.type === 'variable' &&
+      rule.value.variableName === field.name
   )
 
   return (

--- a/src/views/Generator/TestOptions/LoadProfile/LoadProfile.tsx
+++ b/src/views/Generator/TestOptions/LoadProfile/LoadProfile.tsx
@@ -4,53 +4,38 @@ import { useCallback, useEffect } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { LoadProfileExecutorOptionsSchema } from '@/schemas/generator'
-import { useGeneratorStore } from '@/store/generator'
 import { LoadProfileExecutorOptions } from '@/types/testOptions'
 
 import { Executor } from './components/Executor'
 import { ExecutorOptions } from './components/ExecutorOptions'
 
-export function LoadProfile() {
-  const executor = useGeneratorStore((store) => store.executor)
-  const setExecutor = useGeneratorStore((store) => store.setExecutor)
+interface LoadProfileProps {
+  loadProfile: LoadProfileExecutorOptions
+  onLoadProfileChange: (data: LoadProfileExecutorOptions) => void
+}
 
-  const stages = useGeneratorStore((store) => store.stages)
-  const setStages = useGeneratorStore((store) => store.setStages)
-
-  const vus = useGeneratorStore((store) => store.vus)
-  const setVus = useGeneratorStore((store) => store.setVus)
-
-  const iterations = useGeneratorStore((store) => store.iterations)
-  const setIterations = useGeneratorStore((store) => store.setIterations)
-
+export function LoadProfile({
+  loadProfile,
+  onLoadProfileChange,
+}: LoadProfileProps) {
   const formMethods = useForm<LoadProfileExecutorOptions>({
     resolver: zodResolver(LoadProfileExecutorOptionsSchema),
     shouldFocusError: false,
-    defaultValues: {
-      executor,
-      stages,
-      vus,
-      iterations,
-    },
+    defaultValues: loadProfile,
   })
-  const { watch, handleSubmit } = formMethods
+  const { watch, handleSubmit, reset } = formMethods
+
+  useEffect(() => {
+    reset(loadProfile)
+  }, [loadProfile, reset])
 
   const data = formMethods.watch()
 
   const onSubmit = useCallback(
     (data: LoadProfileExecutorOptions) => {
-      setExecutor(data.executor)
-
-      if (data.executor === 'ramping-vus') {
-        setStages(data.stages)
-      }
-
-      if (data.executor === 'shared-iterations') {
-        setVus(data.vus)
-        setIterations(data.iterations)
-      }
+      onLoadProfileChange(data)
     },
-    [setExecutor, setIterations, setStages, setVus]
+    [onLoadProfileChange]
   )
 
   // Submit onChange

--- a/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
+++ b/src/views/Generator/TestOptions/LoadZones/LoadZones.tsx
@@ -13,7 +13,6 @@ import { ExternalLink } from '@/components/ExternalLink'
 import { FieldGroup } from '@/components/Form'
 import { Table } from '@/components/Table'
 import { LoadZoneSchema } from '@/schemas/generator/v1/loadZone'
-import { useGeneratorStore } from '@/store/generator/useGeneratorStore'
 import { LoadZoneData } from '@/types/testOptions'
 
 import { LoadZoneRow } from './LoadZoneRow'
@@ -23,10 +22,12 @@ import {
   LOAD_ZONES_REGIONS_OPTIONS,
 } from './LoadZones.utils'
 
-export function LoadZones() {
-  const loadZones = useGeneratorStore((store) => store.loadZones)
-  const setLoadZones = useGeneratorStore((store) => store.setLoadZones)
+interface LoadZonesProps {
+  loadZones: LoadZoneData
+  onLoadZonesChange: (loadZones: LoadZoneData) => void
+}
 
+export function LoadZones({ loadZones, onLoadZonesChange }: LoadZonesProps) {
   const formMethods = useForm<LoadZoneData>({
     resolver: zodResolver(LoadZoneSchema),
     shouldFocusError: false,
@@ -38,8 +39,13 @@ export function LoadZones() {
     watch,
     control,
     setValue,
+    reset,
     formState: { errors },
   } = formMethods
+
+  useEffect(() => {
+    reset(loadZones)
+  }, [loadZones, reset])
 
   const { append, remove, fields } = useFieldArray<LoadZoneData>({
     control,
@@ -60,9 +66,9 @@ export function LoadZones() {
 
   const onSubmit = useCallback(
     (data: LoadZoneData) => {
-      setLoadZones(data)
+      onLoadZonesChange(data)
     },
-    [setLoadZones]
+    [onLoadZonesChange]
   )
 
   // Submit onChange

--- a/src/views/Generator/TestOptions/TestOptionsDialog.tsx
+++ b/src/views/Generator/TestOptions/TestOptionsDialog.tsx
@@ -4,15 +4,51 @@ import { SettingsIcon } from 'lucide-react'
 import { useState } from 'react'
 
 import { PopoverDialog } from '@/components/PopoverDialogs'
+import { TestRule } from '@/types/rules'
+import { TestData } from '@/types/testData'
+import {
+  LoadProfileExecutorOptions,
+  LoadZoneData,
+  ThinkTime,
+  Threshold,
+} from '@/types/testOptions'
 
 import { VariablesEditor } from '../TestData/VariablesEditor'
 
 import { LoadProfile } from './LoadProfile'
 import { LoadZones } from './LoadZones'
-import { ThinkTime } from './ThinkTime'
+import { ThinkTime as ThinkTimePanel } from './ThinkTime'
 import { Thresholds } from './Thresholds'
 
-export function TestOptions() {
+export interface TestOptionsDialogProps {
+  loadProfile: LoadProfileExecutorOptions
+  onLoadProfileChange: (data: LoadProfileExecutorOptions) => void
+  thinkTime: Pick<ThinkTime, 'sleepType' | 'timing'>
+  onThinkTimeChange: (data: Pick<ThinkTime, 'sleepType' | 'timing'>) => void
+  hasGroups: boolean
+  thresholds: Threshold[]
+  onThresholdsChange: (thresholds: Threshold[]) => void
+  loadZones: LoadZoneData
+  onLoadZonesChange: (loadZones: LoadZoneData) => void
+  variables: TestData['variables']
+  onVariablesChange: (variables: TestData['variables']) => void
+  rules: TestRule[]
+}
+
+export function TestOptionsDialog({
+  loadProfile,
+  onLoadProfileChange,
+  thinkTime,
+  onThinkTimeChange,
+  hasGroups,
+  thresholds,
+  onThresholdsChange,
+  loadZones,
+  onLoadZonesChange,
+  variables,
+  onVariablesChange,
+  rules,
+}: TestOptionsDialogProps) {
   const [selectedTab, setSelectedTab] = useState('loadProfile')
 
   return (
@@ -46,19 +82,36 @@ export function TestOptions() {
           >
             <Box p="3" pt="0" css={{ '.rt-TabsContent': { outline: 'none' } }}>
               <Tabs.Content value="loadProfile">
-                <LoadProfile />
+                <LoadProfile
+                  loadProfile={loadProfile}
+                  onLoadProfileChange={onLoadProfileChange}
+                />
               </Tabs.Content>
               <Tabs.Content value="thinkTime">
-                <ThinkTime />
+                <ThinkTimePanel
+                  thinkTime={thinkTime}
+                  hasGroups={hasGroups}
+                  onThinkTimeChange={onThinkTimeChange}
+                />
               </Tabs.Content>
               <Tabs.Content value="variables">
-                <VariablesEditor />
+                <VariablesEditor
+                  variables={variables}
+                  rules={rules}
+                  onVariablesChange={onVariablesChange}
+                />
               </Tabs.Content>
               <Tabs.Content value="thresholds">
-                <Thresholds />
+                <Thresholds
+                  thresholds={thresholds}
+                  onThresholdsChange={onThresholdsChange}
+                />
               </Tabs.Content>
               <Tabs.Content value="loadZones">
-                <LoadZones />
+                <LoadZones
+                  loadZones={loadZones}
+                  onLoadZonesChange={onLoadZonesChange}
+                />
               </Tabs.Content>
             </Box>
           </ScrollArea>

--- a/src/views/Generator/TestOptions/ThinkTime.tsx
+++ b/src/views/Generator/TestOptions/ThinkTime.tsx
@@ -6,7 +6,6 @@ import { useForm } from 'react-hook-form'
 import { FieldGroup } from '@/components/Form'
 import { ControlledRadioGroup } from '@/components/Form/ControllerRadioGroup'
 import { ThinkTimeSchema } from '@/schemas/generator'
-import { selectHasGroups, useGeneratorStore } from '@/store/generator'
 import type { ThinkTime } from '@/types/testOptions'
 import { stringAsNullableNumber, stringAsOptionalNumber } from '@/utils/form'
 
@@ -21,19 +20,24 @@ const SLEEP_TYPE_OPTIONS = [
   { value: 'iterations', label: 'End of iteration' },
 ]
 
-export function ThinkTime() {
-  const sleepType = useGeneratorStore((store) => store.sleepType)
-  const timing = useGeneratorStore((store) => store.timing)
-  const setSleepType = useGeneratorStore((store) => store.setSleepType)
-  const setTiming = useGeneratorStore((store) => store.setTiming)
-  const hasGroups = useGeneratorStore(selectHasGroups)
+interface ThinkTimeProps {
+  thinkTime: Pick<ThinkTime, 'sleepType' | 'timing'>
+  hasGroups: boolean
+  onThinkTimeChange: (data: Pick<ThinkTime, 'sleepType' | 'timing'>) => void
+}
 
+export function ThinkTime({
+  thinkTime: { sleepType, timing },
+  hasGroups,
+  onThinkTimeChange,
+}: ThinkTimeProps) {
   const {
     register,
     handleSubmit,
     watch,
     control,
     setValue,
+    reset,
     formState: { errors },
   } = useForm<ThinkTime>({
     resolver: zodResolver(ThinkTimeSchema),
@@ -44,14 +48,20 @@ export function ThinkTime() {
     shouldFocusError: false,
   })
 
+  useEffect(() => {
+    reset({ sleepType, timing })
+  }, [sleepType, timing, reset])
+
   const data = watch()
 
   const onSubmit = useCallback(
     (data: ThinkTime) => {
-      setSleepType(data.sleepType)
-      setTiming(data.timing)
+      onThinkTimeChange({
+        sleepType: data.sleepType,
+        timing: data.timing,
+      })
     },
-    [setSleepType, setTiming]
+    [onThinkTimeChange]
   )
 
   useEffect(() => {

--- a/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
+++ b/src/views/Generator/TestOptions/Thresholds/Thresholds.tsx
@@ -6,15 +6,19 @@ import { useForm, useFieldArray, FormProvider } from 'react-hook-form'
 import { ExternalLink } from '@/components/ExternalLink'
 import { Table } from '@/components/Table'
 import { ThresholdDataSchema } from '@/schemas/generator'
-import { useGeneratorStore } from '@/store/generator'
 import { Threshold, ThresholdData } from '@/types/testOptions'
 
 import { ThresholdRow } from './ThresholdRow'
 
-export function Thresholds() {
-  const thresholds = useGeneratorStore((store) => store.thresholds)
-  const setThresholds = useGeneratorStore((store) => store.setThresholds)
+interface ThresholdsProps {
+  thresholds: Threshold[]
+  onThresholdsChange: (thresholds: Threshold[]) => void
+}
 
+export function Thresholds({
+  thresholds,
+  onThresholdsChange,
+}: ThresholdsProps) {
   const formMethods = useForm<{ thresholds: Threshold[] }>({
     resolver: zodResolver(ThresholdDataSchema),
     shouldFocusError: false,
@@ -23,7 +27,11 @@ export function Thresholds() {
     },
   })
 
-  const { handleSubmit, control, watch } = formMethods
+  const { handleSubmit, control, watch, reset } = formMethods
+
+  useEffect(() => {
+    reset({ thresholds })
+  }, [thresholds, reset])
 
   const { append, remove, fields } = useFieldArray<ThresholdData>({
     control,
@@ -45,9 +53,9 @@ export function Thresholds() {
 
   const onSubmit = useCallback(
     (data: ThresholdData) => {
-      setThresholds(data.thresholds)
+      onThresholdsChange(data.thresholds)
     },
-    [setThresholds]
+    [onThresholdsChange]
   )
 
   // Submit onChange

--- a/src/views/Generator/TestOptions/index.ts
+++ b/src/views/Generator/TestOptions/index.ts
@@ -1,1 +1,1 @@
-export * from './TestOptions'
+export * from './TestOptionsDialog'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The generator Test options popover is now a controlled `TestOptionsDialog` component. It receives the current load profile, think time, thresholds, load zones, variables, and rules as props, and reports edits through callbacks instead of reading or writing `useGeneratorStore` internally.

Child panels (`LoadProfile`, `ThinkTime`, `Thresholds`, `LoadZones`, `VariablesEditor`) were updated to take their slice of state and update callbacks as props. Forms reset when external props change so the dialog stays in sync with the store.

`GeneratorTabs` wires the dialog to the generator store: it selects state with hooks and applies updates via `useGeneratorStore.getState()` in memoized handlers.

`VariablesEditor` is shared with the Test data dialog; `TestData` now passes store-backed props there as well.

`selectLoadProfileExecutorOptions` was exported from the generator selectors for reuse when building the load profile object passed into the dialog.

## How to Test

- Open a generator with a recording, open **Test options**, and change load profile, think time, thresholds, load zones, and variables; close and reopen the dialog and confirm values persist.
- Open **Test data** → Variables and confirm variable editing and rule-based disable/remove behavior still work.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Prepares the browser test editor to reuse the same Test options UI with a different store.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-529f48ab-f36c-452e-a633-dbcd35825ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-529f48ab-f36c-452e-a633-dbcd35825ea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

