### PR TITLE
fix: Prevent AutoCorrelation controls jumping when token usage hidden

### DIFF
--- a/src/views/Generator/AutoCorrelation/AutoCorrelation.tsx
+++ b/src/views/Generator/AutoCorrelation/AutoCorrelation.tsx
@@ -127,7 +127,9 @@ export function AutoCorrelation({
         }}
       >
         {provider === 'openai' && (
-          <TokenUsageIndicator tokenUsage={tokenUsage} />
+          <div>
+            <TokenUsageIndicator tokenUsage={tokenUsage} />
+          </div>
         )}
         <Flex gap="3">
           <Button


### PR DESCRIPTION
Wrap TokenUsageIndicator in a div so the footer keeps two flex children and the Stop/Discard/Accept buttons stay on the right while token usage has not yet loaded.

Before:

![Autocorrelation controls on the left while validating](https://raw.githubusercontent.com/grafana/k6-studio/pr-1185-screenshots/pr-1185/autocorrelation-buttons-left.png)