### PR TITLE
internal(assistant): Track sign-in and autocorrelation outcome events

### DIFF
--- a/src/hooks/useAssistantAuth.ts
+++ b/src/hooks/useAssistantAuth.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { useEffect, useRef, useState } from 'react'
 
+import { UsageEventName } from '@/services/usageTracking/types'
 import { useStudioUIStore } from '@/store/ui'
 import { queryClient } from '@/utils/query'
 
@@ -48,6 +49,9 @@ export function useAssistantSignIn() {
     },
     onSuccess: (result) => {
       if (result.type === 'authenticated') {
+        window.studio.app.trackEvent({
+          event: UsageEventName.AssistantSignInSucceeded,
+        })
         return invalidateAssistantAuthStatus()
       }
     },

--- a/src/services/usageTracking/types.ts
+++ b/src/services/usageTracking/types.ts
@@ -24,11 +24,16 @@ export enum UsageEventName {
   ScriptOpenedExternal = 'script_opened_external',
   ScriptRunInCloud = 'script_run_in_cloud',
 
+  // Grafana Assistant
+  AssistantSignInSucceeded = 'assistant_sign_in_succeeded',
+
   AutocorrelationDialogOpened = 'autocorrelation_dialog_opened',
   AutocorrelationStarted = 'autocorrelation_started',
   AutocorrelationSucceeded = 'autocorrelation_succeeded',
   AutocorrelationPartiallySucceeded = 'autocorrelation_partially_succeeded',
   AutocorrelationFailed = 'autocorrelation_failed',
+  AutocorrelationAborted = 'autocorrelation_aborted',
+  AutocorrelationErrored = 'autocorrelation_errored',
 }
 
 export interface UsageEventMetadata {
@@ -108,6 +113,10 @@ interface ScriptRunInCloudEvent {
   event: UsageEventName.ScriptRunInCloud
 }
 
+interface AssistantSignInSucceededEvent {
+  event: UsageEventName.AssistantSignInSucceeded
+}
+
 interface AutocorrelationDialogOpenedEvent {
   event: UsageEventName.AutocorrelationDialogOpened
 }
@@ -128,6 +137,17 @@ interface AutocorrelationFailedEvent {
   event: UsageEventName.AutocorrelationFailed
 }
 
+interface AutocorrelationAbortedEvent {
+  event: UsageEventName.AutocorrelationAborted
+  payload: {
+    status: string
+  }
+}
+
+interface AutocorrelationErroredEvent {
+  event: UsageEventName.AutocorrelationErrored
+}
+
 export type UsageEvent =
   | AppInstalledEvent
   | UserLoggedInEvent
@@ -142,10 +162,13 @@ export type UsageEvent =
   | ScriptValidatedEvent
   | ScriptOpenedExternalEvent
   | ScriptRunInCloudEvent
+  | AssistantSignInSucceededEvent
   | AutocorrelationDialogOpenedEvent
   | AutocorrelationStartedEvent
   | AutocorrelationSucceededEvent
   | AutocorrelationPartiallySucceededEvent
   | AutocorrelationFailedEvent
+  | AutocorrelationAbortedEvent
+  | AutocorrelationErroredEvent
 
 export type UsageEventWithMetadata = UsageEvent & UsageEventMetadata

--- a/src/views/Generator/AutoCorrelation/useGenerateRules.ts
+++ b/src/views/Generator/AutoCorrelation/useGenerateRules.ts
@@ -37,6 +37,13 @@ const outcomeEvents = {
   failure: UsageEventName.AutocorrelationFailed,
 } as const
 
+const LOADING_STATES: CorrelationStatus[] = [
+  'validating',
+  'analyzing',
+  'creating-rules',
+  'finalizing',
+]
+
 export const useGenerateRules = ({
   clearValidation,
 }: {
@@ -48,6 +55,7 @@ export const useGenerateRules = ({
   const [outcomeReason, setOutcomeReason] = useState('')
   const [tokenUsage, setTokenUsage] = useState<TokenUsage>()
   const suggestedRulesRef = useRef(suggestedRules)
+  const correlationStatusRef = useRef(correlationStatus)
   const abortControllerRef = useRef<AbortController | null>(null)
   const recording = useGeneratorStore(selectFilteredRequests)
   const generator = useGeneratorStore(selectGeneratorData)
@@ -60,6 +68,7 @@ export const useGenerateRules = ({
     : 'openai'
 
   suggestedRulesRef.current = suggestedRules
+  correlationStatusRef.current = correlationStatus
 
   const {
     sendMessage,
@@ -81,6 +90,9 @@ export const useGenerateRules = ({
     sendAutomaticallyWhen: (args) => lastMessageIsToolCall(args, provider),
     onError: (error) => {
       setCorrelationStatus('error')
+      window.studio.app.trackEvent({
+        event: UsageEventName.AutocorrelationErrored,
+      })
       console.error(error)
     },
     onToolCall: async ({ toolCall }) => {
@@ -189,12 +201,7 @@ export const useGenerateRules = ({
     return result
   }
 
-  const isLoading = [
-    'validating',
-    'analyzing',
-    'creating-rules',
-    'finalizing',
-  ].includes(correlationStatus)
+  const isLoading = LOADING_STATES.includes(correlationStatus)
 
   async function start() {
     window.studio.app.trackEvent({
@@ -228,6 +235,14 @@ export const useGenerateRules = ({
   }
 
   function stop() {
+    if (!LOADING_STATES.includes(correlationStatusRef.current)) {
+      return
+    }
+
+    window.studio.app.trackEvent({
+      event: UsageEventName.AutocorrelationAborted,
+      payload: { status: correlationStatusRef.current },
+    })
     void stopGeneration()
     setCorrelationStatus('aborted')
     abortControllerRef.current?.abort()

--- a/src/views/Generator/AutoCorrelation/useGenerateRules.ts
+++ b/src/views/Generator/AutoCorrelation/useGenerateRules.ts
@@ -67,8 +67,15 @@ export const useGenerateRules = ({
     ? 'grafana-assistant'
     : 'openai'
 
-  suggestedRulesRef.current = suggestedRules
-  correlationStatusRef.current = correlationStatus
+  // Sync refs after commit (not during render) so aborted renders in
+  // concurrent mode can't leave refs pointing at uncommitted state.
+  useEffect(() => {
+    suggestedRulesRef.current = suggestedRules
+  })
+
+  useEffect(() => {
+    correlationStatusRef.current = correlationStatus
+  })
 
   const {
     sendMessage,


### PR DESCRIPTION
## Description

Adds usage tracking events for the assistant feature and autocorrelation outcomes, so we can measure adoption and success rates.

New events:

- `assistant_sign_in_succeeded`: fires from `useAssistantSignIn` when the sign-in mutation returns `authenticated`.
- `autocorrelation_aborted`: fires when the user stops an in-progress run. Payload includes the loading phase that was aborted (`validating`, `analyzing`, `creating-rules`, `finalizing`).
- `autocorrelation_errored`: fires from `useChat`'s `onError` callback when the streaming request itself fails.

`stop()` in `useGenerateRules` is guarded on the loading-state set so it only fires the aborted event for a run that's actually in progress. Without the guard the unmount cleanup in `AutoCorrelation.tsx` fires a second duplicate event every time the modal closes (accept, discard, or after a natural completion).

`LOADING_STATES` is extracted to a module const so the guard and `isLoading` share the same list.

## How to Test

1. Watch for `trackEvent` logs in terminal.
2. Sign in with the assistant: expect one `assistant_sign_in_succeeded` event.
3. Start an autocorrelation run and click Stop mid-flight: expect one `autocorrelation_aborted` event with `payload.status` matching the current phase. Close the modal afterwards, no second event fires.
4. Start a run, let it complete, then close the modal via Accept or Discard: no `autocorrelation_aborted` event.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to emitting new analytics events and a small guard/ref sync around autocorrelation stop handling, with no changes to core auth or data processing logic.
> 
> **Overview**
> Adds usage analytics for the assistant feature: emits `assistant_sign_in_succeeded` after a successful assistant authentication, and introduces `autocorrelation_aborted` (with phase payload) plus `autocorrelation_errored` for autocorrelation runs.
> 
> Updates autocorrelation generation to share a single `LOADING_STATES` list, track streaming errors via `useChat`’s `onError`, and guard `stop()` so abort events only fire for in-progress runs (using refs synced post-commit to avoid stale state in concurrent renders).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7b23626a8a889e9d6ecfbdd783ba2f42d4add54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->