### PR TITLE
refactor(browser): Use same selector library as k6 browser for greater accuracy

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     browser: true,
     es6: true,
@@ -23,6 +24,7 @@ module.exports = {
     'install-k6.js',
     '.eslintrc.cjs',
     '**/__snapshots__/',
+    'src/browser/injectedScript.js',
   ],
   plugins: [
     'import',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@sentry/vite-plugin": "^2.23.0",
         "@tabler/icons-react": "^3.31.0",
         "@tanstack/react-query": "^5.55.4",
-        "@testing-library/dom": "^10.4.1",
         "@types/plist": "^3.0.5",
         "@typescript-eslint/typescript-estree": "^8.21.0",
         "@vitejs/plugin-react": "^4.7.0",
@@ -281,7 +280,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -662,7 +660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -686,7 +683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -708,7 +704,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1236,7 +1231,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1721,7 +1715,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2553,7 +2546,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2915,7 +2907,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3226,7 +3217,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3248,7 +3238,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3285,7 +3274,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -3816,7 +3804,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6517,7 +6504,9 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6536,7 +6525,9 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6545,7 +6536,9 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -6645,7 +6638,9 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6931,7 +6926,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -7011,7 +7005,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7022,7 +7015,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8456,7 +8448,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9347,7 +9338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -11253,6 +11243,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -11632,7 +11645,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11811,7 +11823,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13632,7 +13643,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14467,7 +14477,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -15472,7 +15481,9 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15948,7 +15959,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -17222,7 +17232,9 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17236,7 +17248,9 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17248,7 +17262,9 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proc-log": {
       "version": "2.0.1",
@@ -17590,7 +17606,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17612,7 +17627,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17625,7 +17639,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
       "integrity": "sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -18538,7 +18551,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19836,7 +19848,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20129,8 +20140,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -20280,7 +20290,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20705,7 +20714,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -20817,7 +20825,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21510,7 +21517,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@sentry/vite-plugin": "^2.23.0",
     "@tabler/icons-react": "^3.31.0",
     "@tanstack/react-query": "^5.55.4",
-    "@testing-library/dom": "^10.4.1",
     "@types/plist": "^3.0.5",
     "@typescript-eslint/typescript-estree": "^8.21.0",
     "@vitejs/plugin-react": "^4.7.0",

--- a/src/browser/injectedScript.d.ts
+++ b/src/browser/injectedScript.d.ts
@@ -1,0 +1,18 @@
+interface SelectorPart {
+  name: string
+  body: string
+}
+
+interface ParsedSelector {
+  parts: SelectorPart[]
+  capture?: number
+}
+
+declare class InjectedScript {
+  querySelectorAll(
+    selector: ParsedSelector,
+    root: Document | Element | ShadowRoot
+  ): Element[] | string
+}
+
+export { InjectedScript }

--- a/src/browser/injectedScript.js
+++ b/src/browser/injectedScript.js
@@ -1,0 +1,3067 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// k6BrowserNative allows accessing native browser objects
+// even if the page under test has overridden them.
+const k6BrowserNative = (() => {
+  const iframe = document.createElement('iframe')
+  // hide it offscreen with zero size
+  iframe.style.position = 'absolute'
+  iframe.style.width = '0'
+  iframe.style.height = '0'
+  iframe.style.border = '0'
+  iframe.style.top = '-9999px'
+  iframe.style.left = '-9999px'
+  iframe.style.display = 'none'
+
+  // grab the native browser object
+  document.documentElement.appendChild(iframe)
+  const win = iframe.contentWindow
+  document.documentElement.removeChild(iframe)
+
+  return {
+    Set: win.Set,
+    Map: win.Map,
+    // Add other native browser objects as needed.
+  }
+})()
+
+// packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+var normalizedWhitespaceCache
+function normalizeWhiteSpace(text) {
+  normalizedWhitespaceCache =
+    normalizedWhitespaceCache || new k6BrowserNative.Map()
+  let result =
+    normalizedWhitespaceCache == null
+      ? void 0
+      : normalizedWhitespaceCache.get(text)
+  if (result === void 0) {
+    result = text
+      .replace(/[\u200b\u00ad]/g, '')
+      .trim()
+      .replace(/\s+/g, ' ')
+    normalizedWhitespaceCache == null
+      ? void 0
+      : normalizedWhitespaceCache.set(text, result)
+  }
+  return result
+}
+
+// packages/injected/src/domUtils.ts
+var globalOptions = {}
+function getGlobalOptions() {
+  return globalOptions
+}
+function parentElementOrShadowHost(element) {
+  if (element.parentElement) return element.parentElement
+  if (!element.parentNode) return
+  if (element.parentNode.nodeType === 11 && element.parentNode.host)
+    return element.parentNode.host
+}
+function enclosingShadowRootOrDocument(element) {
+  let node = element
+  while (node.parentNode) node = node.parentNode
+  if (node.nodeType === 11 || node.nodeType === 9) return node
+}
+function enclosingShadowHost(element) {
+  while (element.parentElement) element = element.parentElement
+  return parentElementOrShadowHost(element)
+}
+function closestCrossShadow(element, css, scope) {
+  while (element) {
+    const closest = element.closest(css)
+    if (
+      scope &&
+      closest !== scope &&
+      (closest == null ? void 0 : closest.contains(scope))
+    )
+      return
+    if (closest) return closest
+    element = enclosingShadowHost(element)
+  }
+}
+function getElementComputedStyle(element, pseudo) {
+  return element.ownerDocument && element.ownerDocument.defaultView
+    ? element.ownerDocument.defaultView.getComputedStyle(element, pseudo)
+    : void 0
+}
+function isElementStyleVisibilityVisible(element, style) {
+  style = style != null ? style : getElementComputedStyle(element)
+  if (!style) return true
+  if (
+    Element.prototype.checkVisibility &&
+    globalOptions.browserNameForWorkarounds !== 'webkit'
+  ) {
+    if (!element.checkVisibility()) return false
+  } else {
+    const detailsOrSummary = element.closest('details,summary')
+    if (
+      detailsOrSummary !== element &&
+      (detailsOrSummary == null ? void 0 : detailsOrSummary.nodeName) ===
+        'DETAILS' &&
+      !detailsOrSummary.open
+    )
+      return false
+  }
+  if (style.visibility !== 'visible') return false
+  return true
+}
+function isVisibleTextNode(node) {
+  const range = node.ownerDocument.createRange()
+  range.selectNode(node)
+  const rect = range.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+function elementSafeTagName(element) {
+  if (element instanceof HTMLFormElement) return 'FORM'
+  return element.tagName.toUpperCase()
+}
+
+// packages/injected/src/roleUtils.ts
+function hasExplicitAccessibleName(e) {
+  return e.hasAttribute('aria-label') || e.hasAttribute('aria-labelledby')
+}
+var kAncestorPreventingLandmark =
+  'article:not([role]), aside:not([role]), main:not([role]), nav:not([role]), section:not([role]), [role=article], [role=complementary], [role=main], [role=navigation], [role=region]'
+var kGlobalAriaAttributes = [
+  ['aria-atomic', void 0],
+  ['aria-busy', void 0],
+  ['aria-controls', void 0],
+  ['aria-current', void 0],
+  ['aria-describedby', void 0],
+  ['aria-details', void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-disabled', undefined],
+  ['aria-dropeffect', void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-errormessage', undefined],
+  ['aria-flowto', void 0],
+  ['aria-grabbed', void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-haspopup', undefined],
+  ['aria-hidden', void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-invalid', undefined],
+  ['aria-keyshortcuts', void 0],
+  [
+    'aria-label',
+    [
+      'caption',
+      'code',
+      'deletion',
+      'emphasis',
+      'generic',
+      'insertion',
+      'paragraph',
+      'presentation',
+      'strong',
+      'subscript',
+      'superscript',
+    ],
+  ],
+  [
+    'aria-labelledby',
+    [
+      'caption',
+      'code',
+      'deletion',
+      'emphasis',
+      'generic',
+      'insertion',
+      'paragraph',
+      'presentation',
+      'strong',
+      'subscript',
+      'superscript',
+    ],
+  ],
+  ['aria-live', void 0],
+  ['aria-owns', void 0],
+  ['aria-relevant', void 0],
+  ['aria-roledescription', ['generic']],
+]
+function hasGlobalAriaAttribute(element, forRole) {
+  return kGlobalAriaAttributes.some(([attr, prohibited]) => {
+    return (
+      !(prohibited == null ? void 0 : prohibited.includes(forRole || '')) &&
+      element.hasAttribute(attr)
+    )
+  })
+}
+function hasTabIndex(element) {
+  return !Number.isNaN(Number(String(element.getAttribute('tabindex'))))
+}
+function isFocusable(element) {
+  return (
+    !isNativelyDisabled(element) &&
+    (isNativelyFocusable(element) || hasTabIndex(element))
+  )
+}
+function isNativelyFocusable(element) {
+  const tagName = elementSafeTagName(element)
+  if (['BUTTON', 'DETAILS', 'SELECT', 'TEXTAREA'].includes(tagName)) return true
+  if (tagName === 'A' || tagName === 'AREA') return element.hasAttribute('href')
+  if (tagName === 'INPUT') return !element.hidden
+  return false
+}
+var kImplicitRoleByTagName = {
+  A: (e) => {
+    return e.hasAttribute('href') ? 'link' : null
+  },
+  AREA: (e) => {
+    return e.hasAttribute('href') ? 'link' : null
+  },
+  ARTICLE: () => 'article',
+  ASIDE: () => 'complementary',
+  BLOCKQUOTE: () => 'blockquote',
+  BUTTON: () => 'button',
+  CAPTION: () => 'caption',
+  CODE: () => 'code',
+  DATALIST: () => 'listbox',
+  DD: () => 'definition',
+  DEL: () => 'deletion',
+  DETAILS: () => 'group',
+  DFN: () => 'term',
+  DIALOG: () => 'dialog',
+  DT: () => 'term',
+  EM: () => 'emphasis',
+  FIELDSET: () => 'group',
+  FIGURE: () => 'figure',
+  FOOTER: (e) =>
+    closestCrossShadow(e, kAncestorPreventingLandmark) ? null : 'contentinfo',
+  FORM: (e) => (hasExplicitAccessibleName(e) ? 'form' : null),
+  H1: () => 'heading',
+  H2: () => 'heading',
+  H3: () => 'heading',
+  H4: () => 'heading',
+  H5: () => 'heading',
+  H6: () => 'heading',
+  HEADER: (e) =>
+    closestCrossShadow(e, kAncestorPreventingLandmark) ? null : 'banner',
+  HR: () => 'separator',
+  HTML: () => 'document',
+  IMG: (e) =>
+    e.getAttribute('alt') === '' &&
+    !e.getAttribute('title') &&
+    !hasGlobalAriaAttribute(e) &&
+    !hasTabIndex(e)
+      ? 'presentation'
+      : 'img',
+  INPUT: (e) => {
+    const type = e.type.toLowerCase()
+    if (type === 'search')
+      return e.hasAttribute('list') ? 'combobox' : 'searchbox'
+    if (['email', 'tel', 'text', 'url', ''].includes(type)) {
+      const list = getIdRefs(e, e.getAttribute('list'))[0]
+      return list && elementSafeTagName(list) === 'DATALIST'
+        ? 'combobox'
+        : 'textbox'
+    }
+    if (type === 'hidden') return null
+    if (type === 'file' && !getGlobalOptions().inputFileRoleTextbox)
+      return 'button'
+    return inputTypeToRole[type] || 'textbox'
+  },
+  INS: () => 'insertion',
+  LI: () => 'listitem',
+  MAIN: () => 'main',
+  MARK: () => 'mark',
+  MATH: () => 'math',
+  MENU: () => 'list',
+  METER: () => 'meter',
+  NAV: () => 'navigation',
+  OL: () => 'list',
+  OPTGROUP: () => 'group',
+  OPTION: () => 'option',
+  OUTPUT: () => 'status',
+  P: () => 'paragraph',
+  PROGRESS: () => 'progressbar',
+  SECTION: (e) => (hasExplicitAccessibleName(e) ? 'region' : null),
+  SELECT: (e) =>
+    e.hasAttribute('multiple') || e.size > 1 ? 'listbox' : 'combobox',
+  STRONG: () => 'strong',
+  SUB: () => 'subscript',
+  SUP: () => 'superscript',
+  // For <svg> we default to Chrome behavior:
+  // - Chrome reports 'img'.
+  // - Firefox reports 'diagram' that is not in official ARIA spec yet.
+  // - Safari reports 'no role', but still computes accessible name.
+  SVG: () => 'img',
+  TABLE: () => 'table',
+  TBODY: () => 'rowgroup',
+  TD: (e) => {
+    const table = closestCrossShadow(e, 'table')
+    const role = table ? getExplicitAriaRole(table) : ''
+    return role === 'grid' || role === 'treegrid' ? 'gridcell' : 'cell'
+  },
+  TEXTAREA: () => 'textbox',
+  TFOOT: () => 'rowgroup',
+  TH: (e) => {
+    if (e.getAttribute('scope') === 'col') return 'columnheader'
+    if (e.getAttribute('scope') === 'row') return 'rowheader'
+    const table = closestCrossShadow(e, 'table')
+    const role = table ? getExplicitAriaRole(table) : ''
+    return role === 'grid' || role === 'treegrid' ? 'gridcell' : 'cell'
+  },
+  THEAD: () => 'rowgroup',
+  TIME: () => 'time',
+  TR: () => 'row',
+  UL: () => 'list',
+}
+var kPresentationInheritanceParents = {
+  DD: ['DL', 'DIV'],
+  DIV: ['DL'],
+  DT: ['DL', 'DIV'],
+  LI: ['OL', 'UL'],
+  TBODY: ['TABLE'],
+  TD: ['TR'],
+  TFOOT: ['TABLE'],
+  TH: ['TR'],
+  THEAD: ['TABLE'],
+  TR: ['THEAD', 'TBODY', 'TFOOT', 'TABLE'],
+}
+function getImplicitAriaRole(element) {
+  var _a
+  const implicitRole =
+    ((_a = kImplicitRoleByTagName[elementSafeTagName(element)]) == null
+      ? void 0
+      : _a.call(kImplicitRoleByTagName, element)) || ''
+  if (!implicitRole) return null
+  let ancestor = element
+  while (ancestor) {
+    const parent = parentElementOrShadowHost(ancestor)
+    const parents =
+      kPresentationInheritanceParents[elementSafeTagName(ancestor)]
+    if (!parents || !parent || !parents.includes(elementSafeTagName(parent)))
+      break
+    const parentExplicitRole = getExplicitAriaRole(parent)
+    if (
+      (parentExplicitRole === 'none' ||
+        parentExplicitRole === 'presentation') &&
+      !hasPresentationConflictResolution(parent, parentExplicitRole)
+    )
+      return parentExplicitRole
+    ancestor = parent
+  }
+  return implicitRole
+}
+var validRoles = [
+  'alert',
+  'alertdialog',
+  'application',
+  'article',
+  'banner',
+  'blockquote',
+  'button',
+  'caption',
+  'cell',
+  'checkbox',
+  'code',
+  'columnheader',
+  'combobox',
+  'complementary',
+  'contentinfo',
+  'definition',
+  'deletion',
+  'dialog',
+  'directory',
+  'document',
+  'emphasis',
+  'feed',
+  'figure',
+  'form',
+  'generic',
+  'grid',
+  'gridcell',
+  'group',
+  'heading',
+  'img',
+  'insertion',
+  'link',
+  'list',
+  'listbox',
+  'listitem',
+  'log',
+  'main',
+  'mark',
+  'marquee',
+  'math',
+  'meter',
+  'menu',
+  'menubar',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'navigation',
+  'none',
+  'note',
+  'option',
+  'paragraph',
+  'presentation',
+  'progressbar',
+  'radio',
+  'radiogroup',
+  'region',
+  'row',
+  'rowgroup',
+  'rowheader',
+  'scrollbar',
+  'search',
+  'searchbox',
+  'separator',
+  'slider',
+  'spinbutton',
+  'status',
+  'strong',
+  'subscript',
+  'superscript',
+  'switch',
+  'tab',
+  'table',
+  'tablist',
+  'tabpanel',
+  'term',
+  'textbox',
+  'time',
+  'timer',
+  'toolbar',
+  'tooltip',
+  'tree',
+  'treegrid',
+  'treeitem',
+]
+function getExplicitAriaRole(element) {
+  const roles = (element.getAttribute('role') || '')
+    .split(' ')
+    .map((role) => role.trim())
+  return roles.find((role) => validRoles.includes(role)) || null
+}
+function hasPresentationConflictResolution(element, role) {
+  return hasGlobalAriaAttribute(element, role) || isFocusable(element)
+}
+function getAriaRole(element) {
+  const explicitRole = getExplicitAriaRole(element)
+  if (!explicitRole) return getImplicitAriaRole(element)
+  if (explicitRole === 'none' || explicitRole === 'presentation') {
+    const implicitRole = getImplicitAriaRole(element)
+    if (hasPresentationConflictResolution(element, implicitRole))
+      return implicitRole
+  }
+  return explicitRole
+}
+function getAriaBoolean(attr) {
+  return attr === null ? void 0 : attr.toLowerCase() === 'true'
+}
+function isElementIgnoredForAria(element) {
+  return ['STYLE', 'SCRIPT', 'NOSCRIPT', 'TEMPLATE'].includes(
+    elementSafeTagName(element)
+  )
+}
+function isElementHiddenForAria(element) {
+  if (isElementIgnoredForAria(element)) return true
+  const style = getElementComputedStyle(element)
+  const isSlot = element.nodeName === 'SLOT'
+  if ((style == null ? void 0 : style.display) === 'contents' && !isSlot) {
+    for (let child = element.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1 && !isElementHiddenForAria(child)) return false
+      if (child.nodeType === 3 && isVisibleTextNode(child)) return false
+    }
+    return true
+  }
+  const isOptionInsideSelect =
+    element.nodeName === 'OPTION' && !!element.closest('select')
+  if (
+    !isOptionInsideSelect &&
+    !isSlot &&
+    !isElementStyleVisibilityVisible(element, style)
+  )
+    return true
+  return belongsToDisplayNoneOrAriaHiddenOrNonSlotted(element)
+}
+function belongsToDisplayNoneOrAriaHiddenOrNonSlotted(element) {
+  let hidden = cacheIsHidden == null ? void 0 : cacheIsHidden.get(element)
+  if (hidden === void 0) {
+    hidden = false
+    if (
+      element.parentElement &&
+      element.parentElement.shadowRoot &&
+      !element.assignedSlot
+    )
+      hidden = true
+    if (!hidden) {
+      const style = getElementComputedStyle(element)
+      hidden =
+        !style ||
+        style.display === 'none' ||
+        getAriaBoolean(element.getAttribute('aria-hidden')) === true
+    }
+    if (!hidden) {
+      const parent = parentElementOrShadowHost(element)
+      if (parent) hidden = belongsToDisplayNoneOrAriaHiddenOrNonSlotted(parent)
+    }
+    cacheIsHidden == null ? void 0 : cacheIsHidden.set(element, hidden)
+  }
+  return hidden
+}
+function getIdRefs(element, ref) {
+  if (!ref) return []
+  const root = enclosingShadowRootOrDocument(element)
+  if (!root) return []
+  try {
+    const ids = ref.split(' ').filter((id) => !!id)
+    const result = []
+    for (const id of ids) {
+      const firstElement = root.querySelector('#' + CSS.escape(id))
+      if (firstElement && !result.includes(firstElement))
+        result.push(firstElement)
+    }
+    return result
+  } catch (e) {
+    return []
+  }
+}
+function trimFlatString(s) {
+  return s.trim()
+}
+function asFlatString(s) {
+  return s
+    .split('\xA0')
+    .map((chunk) =>
+      chunk
+        .replace(
+          /\r\n/g,
+          '\
+'
+        )
+        .replace(/[\u200b\u00ad]/g, '')
+        .replace(/\s\s*/g, ' ')
+    )
+    .join('\xA0')
+    .trim()
+}
+function queryInAriaOwned(element, selector) {
+  const result = [...element.querySelectorAll(selector)]
+  for (const owned of getIdRefs(element, element.getAttribute('aria-owns'))) {
+    if (owned.matches(selector)) result.push(owned)
+    result.push(...owned.querySelectorAll(selector))
+  }
+  return result
+}
+function getPseudoContent(element, pseudo) {
+  const cache =
+    pseudo === '::before' ? cachePseudoContentBefore : cachePseudoContentAfter
+  if (cache == null ? void 0 : cache.has(element))
+    return (cache == null ? void 0 : cache.get(element)) || ''
+  const pseudoStyle = getElementComputedStyle(element, pseudo)
+  const content = getPseudoContentImpl(element, pseudoStyle)
+  if (cache) cache.set(element, content)
+  return content
+}
+function getPseudoContentImpl(element, pseudoStyle) {
+  if (
+    !pseudoStyle ||
+    pseudoStyle.display === 'none' ||
+    pseudoStyle.visibility === 'hidden'
+  )
+    return ''
+  const content = pseudoStyle.content
+  let resolvedContent
+  if (
+    (content[0] === "'" && content[content.length - 1] === "'") ||
+    (content[0] === '"' && content[content.length - 1] === '"')
+  ) {
+    resolvedContent = content.substring(1, content.length - 1)
+  } else if (content.startsWith('attr(') && content.endsWith(')')) {
+    const attrName = content
+      .substring('attr('.length, content.length - 1)
+      .trim()
+    resolvedContent = element.getAttribute(attrName) || ''
+  }
+  if (resolvedContent !== void 0) {
+    const display = pseudoStyle.display || 'inline'
+    if (display !== 'inline') return ' ' + resolvedContent + ' '
+    return resolvedContent
+  }
+  return ''
+}
+function getAriaLabelledByElements(element) {
+  const ref = element.getAttribute('aria-labelledby')
+  if (ref === null) return null
+  const refs = getIdRefs(element, ref)
+  return refs.length ? refs : null
+}
+function allowsNameFromContent(role, targetDescendant) {
+  const alwaysAllowsNameFromContent = [
+    'button',
+    'cell',
+    'checkbox',
+    'columnheader',
+    'gridcell',
+    'heading',
+    'link',
+    'menuitem',
+    'menuitemcheckbox',
+    'menuitemradio',
+    'option',
+    'radio',
+    'row',
+    'rowheader',
+    'switch',
+    'tab',
+    'tooltip',
+    'treeitem',
+  ].includes(role)
+  const descendantAllowsNameFromContent =
+    targetDescendant &&
+    [
+      '',
+      'caption',
+      'code',
+      'contentinfo',
+      'definition',
+      'deletion',
+      'emphasis',
+      'insertion',
+      'list',
+      'listitem',
+      'mark',
+      'none',
+      'paragraph',
+      'presentation',
+      'region',
+      'row',
+      'rowgroup',
+      'section',
+      'strong',
+      'subscript',
+      'superscript',
+      'table',
+      'term',
+      'time',
+    ].includes(role)
+  return alwaysAllowsNameFromContent || descendantAllowsNameFromContent
+}
+function getElementAccessibleName(element, includeHidden) {
+  const cache = includeHidden ? cacheAccessibleNameHidden : cacheAccessibleName
+  let accessibleName = cache == null ? void 0 : cache.get(element)
+  if (accessibleName === void 0) {
+    accessibleName = ''
+    const elementProhibitsNaming = [
+      'caption',
+      'code',
+      'definition',
+      'deletion',
+      'emphasis',
+      'generic',
+      'insertion',
+      'mark',
+      'paragraph',
+      'presentation',
+      'strong',
+      'subscript',
+      'suggestion',
+      'superscript',
+      'term',
+      'time',
+    ].includes(getAriaRole(element) || '')
+    if (!elementProhibitsNaming) {
+      accessibleName = asFlatString(
+        getTextAlternativeInternal(element, {
+          includeHidden,
+          visitedElements: new k6BrowserNative.Set(),
+          embeddedInTargetElement: 'self',
+        })
+      )
+    }
+    cache == null ? void 0 : cache.set(element, accessibleName)
+  }
+  return accessibleName
+}
+function getTextAlternativeInternal(element, options) {
+  var _a, _b, _c, _d
+  if (options.visitedElements.has(element)) return ''
+  const childOptions = {
+    ...options,
+    embeddedInTargetElement:
+      options.embeddedInTargetElement === 'self'
+        ? 'descendant'
+        : options.embeddedInTargetElement,
+  }
+  if (!options.includeHidden) {
+    const isEmbeddedInHiddenReferenceTraversal =
+      !!((_a = options.embeddedInLabelledBy) == null ? void 0 : _a.hidden) ||
+      !!((_b = options.embeddedInDescribedBy) == null ? void 0 : _b.hidden) ||
+      !!((_c = options.embeddedInNativeTextAlternative) == null
+        ? void 0
+        : _c.hidden) ||
+      !!((_d = options.embeddedInLabel) == null ? void 0 : _d.hidden)
+    if (
+      isElementIgnoredForAria(element) ||
+      (!isEmbeddedInHiddenReferenceTraversal && isElementHiddenForAria(element))
+    ) {
+      options.visitedElements.add(element)
+      return ''
+    }
+  }
+  const labelledBy = getAriaLabelledByElements(element)
+  if (!options.embeddedInLabelledBy) {
+    const accessibleName = (labelledBy || [])
+      .map((ref) =>
+        getTextAlternativeInternal(ref, {
+          ...options,
+          embeddedInLabelledBy: {
+            element: ref,
+            hidden: isElementHiddenForAria(ref),
+          },
+          embeddedInDescribedBy: void 0,
+          embeddedInTargetElement: void 0,
+          embeddedInLabel: void 0,
+          embeddedInNativeTextAlternative: void 0,
+        })
+      )
+      .join(' ')
+    if (accessibleName) return accessibleName
+  }
+  const role = getAriaRole(element) || ''
+  const tagName = elementSafeTagName(element)
+  if (
+    !!options.embeddedInLabel ||
+    !!options.embeddedInLabelledBy ||
+    options.embeddedInTargetElement === 'descendant'
+  ) {
+    const isOwnLabel = [...(element.labels || [])].includes(element)
+    const isOwnLabelledBy = (labelledBy || []).includes(element)
+    if (!isOwnLabel && !isOwnLabelledBy) {
+      if (role === 'textbox') {
+        options.visitedElements.add(element)
+        if (tagName === 'INPUT' || tagName === 'TEXTAREA') return element.value
+        return element.textContent || ''
+      }
+      if (['combobox', 'listbox'].includes(role)) {
+        options.visitedElements.add(element)
+        let selectedOptions
+        if (tagName === 'SELECT') {
+          selectedOptions = [...element.selectedOptions]
+          if (!selectedOptions.length && element.options.length)
+            selectedOptions.push(element.options[0])
+        } else {
+          const listbox =
+            role === 'combobox'
+              ? queryInAriaOwned(element, '*').find(
+                  (e) => getAriaRole(e) === 'listbox'
+                )
+              : element
+          selectedOptions = listbox
+            ? queryInAriaOwned(listbox, '[aria-selected="true"]').filter(
+                (e) => getAriaRole(e) === 'option'
+              )
+            : []
+        }
+        if (!selectedOptions.length && tagName === 'INPUT') {
+          return element.value
+        }
+        return selectedOptions
+          .map((option) => getTextAlternativeInternal(option, childOptions))
+          .join(' ')
+      }
+      if (
+        ['progressbar', 'scrollbar', 'slider', 'spinbutton', 'meter'].includes(
+          role
+        )
+      ) {
+        options.visitedElements.add(element)
+        if (element.hasAttribute('aria-valuetext'))
+          return element.getAttribute('aria-valuetext') || ''
+        if (element.hasAttribute('aria-valuenow'))
+          return element.getAttribute('aria-valuenow') || ''
+        return element.getAttribute('value') || ''
+      }
+      if (['menu'].includes(role)) {
+        options.visitedElements.add(element)
+        return ''
+      }
+    }
+  }
+  const ariaLabel = element.getAttribute('aria-label') || ''
+  if (trimFlatString(ariaLabel)) {
+    options.visitedElements.add(element)
+    return ariaLabel
+  }
+  if (!['presentation', 'none'].includes(role)) {
+    if (
+      tagName === 'INPUT' &&
+      ['button', 'submit', 'reset'].includes(element.type)
+    ) {
+      options.visitedElements.add(element)
+      const value = element.value || ''
+      if (trimFlatString(value)) return value
+      if (element.type === 'submit') return 'Submit'
+      if (element.type === 'reset') return 'Reset'
+      const title = element.getAttribute('title') || ''
+      return title
+    }
+    if (
+      !getGlobalOptions().inputFileRoleTextbox &&
+      tagName === 'INPUT' &&
+      element.type === 'file'
+    ) {
+      options.visitedElements.add(element)
+      const labels = element.labels || []
+      if (labels.length && !options.embeddedInLabelledBy)
+        return getAccessibleNameFromAssociatedLabels(labels, options)
+      return 'Choose File'
+    }
+    if (tagName === 'INPUT' && element.type === 'image') {
+      options.visitedElements.add(element)
+      const labels = element.labels || []
+      if (labels.length && !options.embeddedInLabelledBy)
+        return getAccessibleNameFromAssociatedLabels(labels, options)
+      const alt = element.getAttribute('alt') || ''
+      if (trimFlatString(alt)) return alt
+      const title = element.getAttribute('title') || ''
+      if (trimFlatString(title)) return title
+      return 'Submit'
+    }
+    if (!labelledBy && tagName === 'BUTTON') {
+      options.visitedElements.add(element)
+      const labels = element.labels || []
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options)
+    }
+    if (!labelledBy && tagName === 'OUTPUT') {
+      options.visitedElements.add(element)
+      const labels = element.labels || []
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options)
+      return element.getAttribute('title') || ''
+    }
+    if (
+      !labelledBy &&
+      (tagName === 'TEXTAREA' || tagName === 'SELECT' || tagName === 'INPUT')
+    ) {
+      options.visitedElements.add(element)
+      const labels = element.labels || []
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options)
+      const usePlaceholder =
+        (tagName === 'INPUT' &&
+          ['text', 'password', 'search', 'tel', 'email', 'url'].includes(
+            element.type
+          )) ||
+        tagName === 'TEXTAREA'
+      const placeholder = element.getAttribute('placeholder') || ''
+      const title = element.getAttribute('title') || ''
+      if (!usePlaceholder || title) return title
+      return placeholder
+    }
+    if (!labelledBy && tagName === 'FIELDSET') {
+      options.visitedElements.add(element)
+      for (
+        let child = element.firstElementChild;
+        child;
+        child = child.nextElementSibling
+      ) {
+        if (elementSafeTagName(child) === 'LEGEND') {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: {
+              element: child,
+              hidden: isElementHiddenForAria(child),
+            },
+          })
+        }
+      }
+      const title = element.getAttribute('title') || ''
+      return title
+    }
+    if (!labelledBy && tagName === 'FIGURE') {
+      options.visitedElements.add(element)
+      for (
+        let child = element.firstElementChild;
+        child;
+        child = child.nextElementSibling
+      ) {
+        if (elementSafeTagName(child) === 'FIGCAPTION') {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: {
+              element: child,
+              hidden: isElementHiddenForAria(child),
+            },
+          })
+        }
+      }
+      const title = element.getAttribute('title') || ''
+      return title
+    }
+    if (tagName === 'IMG') {
+      options.visitedElements.add(element)
+      const alt = element.getAttribute('alt') || ''
+      if (trimFlatString(alt)) return alt
+      const title = element.getAttribute('title') || ''
+      return title
+    }
+    if (tagName === 'TABLE') {
+      options.visitedElements.add(element)
+      for (
+        let child = element.firstElementChild;
+        child;
+        child = child.nextElementSibling
+      ) {
+        if (elementSafeTagName(child) === 'CAPTION') {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: {
+              element: child,
+              hidden: isElementHiddenForAria(child),
+            },
+          })
+        }
+      }
+      const summary = element.getAttribute('summary') || ''
+      if (summary) return summary
+    }
+    if (tagName === 'AREA') {
+      options.visitedElements.add(element)
+      const alt = element.getAttribute('alt') || ''
+      if (trimFlatString(alt)) return alt
+      const title = element.getAttribute('title') || ''
+      return title
+    }
+    if (tagName === 'SVG' || element.ownerSVGElement) {
+      options.visitedElements.add(element)
+      for (
+        let child = element.firstElementChild;
+        child;
+        child = child.nextElementSibling
+      ) {
+        if (elementSafeTagName(child) === 'TITLE' && child.ownerSVGElement) {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInLabelledBy: {
+              element: child,
+              hidden: isElementHiddenForAria(child),
+            },
+          })
+        }
+      }
+    }
+    if (element.ownerSVGElement && tagName === 'A') {
+      const title = element.getAttribute('xlink:title') || ''
+      if (trimFlatString(title)) {
+        options.visitedElements.add(element)
+        return title
+      }
+    }
+  }
+  const shouldNameFromContentForSummary =
+    tagName === 'SUMMARY' && !['presentation', 'none'].includes(role)
+  if (
+    allowsNameFromContent(
+      role,
+      options.embeddedInTargetElement === 'descendant'
+    ) ||
+    shouldNameFromContentForSummary ||
+    !!options.embeddedInLabelledBy ||
+    !!options.embeddedInDescribedBy ||
+    !!options.embeddedInLabel ||
+    !!options.embeddedInNativeTextAlternative
+  ) {
+    options.visitedElements.add(element)
+    const accessibleName = innerAccumulatedElementText(element, childOptions)
+    const maybeTrimmedAccessibleName =
+      options.embeddedInTargetElement === 'self'
+        ? trimFlatString(accessibleName)
+        : accessibleName
+    if (maybeTrimmedAccessibleName) return accessibleName
+  }
+  if (!['presentation', 'none'].includes(role) || tagName === 'IFRAME') {
+    options.visitedElements.add(element)
+    const title = element.getAttribute('title') || ''
+    if (trimFlatString(title)) return title
+  }
+  options.visitedElements.add(element)
+  return ''
+}
+function innerAccumulatedElementText(element, options) {
+  const tokens = []
+  const visit = (node, skipSlotted) => {
+    var _a
+    if (skipSlotted && node.assignedSlot) return
+    if (node.nodeType === 1) {
+      const display =
+        ((_a = getElementComputedStyle(node)) == null ? void 0 : _a.display) ||
+        'inline'
+      let token = getTextAlternativeInternal(node, options)
+      if (display !== 'inline' || node.nodeName === 'BR')
+        token = ' ' + token + ' '
+      tokens.push(token)
+    } else if (node.nodeType === 3) {
+      tokens.push(node.textContent || '')
+    }
+  }
+  tokens.push(getPseudoContent(element, '::before'))
+  const assignedNodes =
+    element.nodeName === 'SLOT' ? element.assignedNodes() : []
+  if (assignedNodes.length) {
+    for (const child of assignedNodes) visit(child, false)
+  } else {
+    for (let child = element.firstChild; child; child = child.nextSibling)
+      visit(child, true)
+    if (element.shadowRoot) {
+      for (
+        let child = element.shadowRoot.firstChild;
+        child;
+        child = child.nextSibling
+      )
+        visit(child, true)
+    }
+    for (const owned of getIdRefs(element, element.getAttribute('aria-owns')))
+      visit(owned, true)
+  }
+  tokens.push(getPseudoContent(element, '::after'))
+  return tokens.join('')
+}
+var kAriaSelectedRoles = [
+  'gridcell',
+  'option',
+  'row',
+  'tab',
+  'rowheader',
+  'columnheader',
+  'treeitem',
+]
+function getAriaSelected(element) {
+  if (elementSafeTagName(element) === 'OPTION') return element.selected
+  if (kAriaSelectedRoles.includes(getAriaRole(element) || ''))
+    return getAriaBoolean(element.getAttribute('aria-selected')) === true
+  return false
+}
+var kAriaCheckedRoles = [
+  'checkbox',
+  'menuitemcheckbox',
+  'option',
+  'radio',
+  'switch',
+  'menuitemradio',
+  'treeitem',
+]
+function getAriaChecked(element) {
+  const result = getChecked(element, true)
+  return result === 'error' ? false : result
+}
+function getChecked(element, allowMixed) {
+  const tagName = elementSafeTagName(element)
+  if (allowMixed && tagName === 'INPUT' && element.indeterminate) return 'mixed'
+  if (tagName === 'INPUT' && ['checkbox', 'radio'].includes(element.type))
+    return element.checked
+  if (kAriaCheckedRoles.includes(getAriaRole(element) || '')) {
+    const checked = element.getAttribute('aria-checked')
+    if (checked === 'true') return true
+    if (allowMixed && checked === 'mixed') return 'mixed'
+    return false
+  }
+  return 'error'
+}
+var kAriaPressedRoles = ['button']
+function getAriaPressed(element) {
+  if (kAriaPressedRoles.includes(getAriaRole(element) || '')) {
+    const pressed = element.getAttribute('aria-pressed')
+    if (pressed === 'true') return true
+    if (pressed === 'mixed') return 'mixed'
+  }
+  return false
+}
+var kAriaExpandedRoles = [
+  'application',
+  'button',
+  'checkbox',
+  'combobox',
+  'gridcell',
+  'link',
+  'listbox',
+  'menuitem',
+  'row',
+  'tab',
+  'treeitem',
+  'columnheader',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'rowheader',
+  'switch',
+]
+function getAriaExpanded(element) {
+  if (elementSafeTagName(element) === 'DETAILS') return element.open
+  if (kAriaExpandedRoles.includes(getAriaRole(element) || '')) {
+    const expanded = element.getAttribute('aria-expanded')
+    if (expanded === null) return void 0
+    if (expanded === 'true') return true
+    return false
+  }
+  return void 0
+}
+var kAriaLevelRoles = ['heading', 'listitem', 'row', 'treeitem']
+function getAriaLevel(element) {
+  const native = { H1: 1, H2: 2, H3: 3, H4: 4, H5: 5, H6: 6 }[
+    elementSafeTagName(element)
+  ]
+  if (native) return native
+  if (kAriaLevelRoles.includes(getAriaRole(element) || '')) {
+    const attr = element.getAttribute('aria-level')
+    const value = attr === null ? Number.NaN : Number(attr)
+    if (Number.isInteger(value) && value >= 1) return value
+  }
+  return 0
+}
+var kAriaDisabledRoles = [
+  'application',
+  'button',
+  'composite',
+  'gridcell',
+  'group',
+  'input',
+  'link',
+  'menuitem',
+  'scrollbar',
+  'separator',
+  'tab',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'grid',
+  'listbox',
+  'menu',
+  'menubar',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'radiogroup',
+  'row',
+  'rowheader',
+  'searchbox',
+  'select',
+  'slider',
+  'spinbutton',
+  'switch',
+  'tablist',
+  'textbox',
+  'toolbar',
+  'tree',
+  'treegrid',
+  'treeitem',
+]
+function getAriaDisabled(element) {
+  return isNativelyDisabled(element) || hasExplicitAriaDisabled(element)
+}
+function isNativelyDisabled(element) {
+  const isNativeFormControl = [
+    'BUTTON',
+    'INPUT',
+    'SELECT',
+    'TEXTAREA',
+    'OPTION',
+    'OPTGROUP',
+  ].includes(element.tagName)
+  return (
+    isNativeFormControl &&
+    (element.hasAttribute('disabled') || belongsToDisabledFieldSet(element))
+  )
+}
+function belongsToDisabledFieldSet(element) {
+  const fieldSetElement =
+    element == null ? void 0 : element.closest('FIELDSET[DISABLED]')
+  if (!fieldSetElement) return false
+  const legendElement = fieldSetElement.querySelector(':scope > LEGEND')
+  return !legendElement || !legendElement.contains(element)
+}
+function hasExplicitAriaDisabled(element, isAncestor = false) {
+  if (!element) return false
+  if (isAncestor || kAriaDisabledRoles.includes(getAriaRole(element) || '')) {
+    const attribute = (
+      element.getAttribute('aria-disabled') || ''
+    ).toLowerCase()
+    if (attribute === 'true') return true
+    if (attribute === 'false') return false
+    return hasExplicitAriaDisabled(parentElementOrShadowHost(element), true)
+  }
+  return false
+}
+function getAccessibleNameFromAssociatedLabels(labels, options) {
+  return [...labels]
+    .map((label) =>
+      getTextAlternativeInternal(label, {
+        ...options,
+        embeddedInLabel: {
+          element: label,
+          hidden: isElementHiddenForAria(label),
+        },
+        embeddedInNativeTextAlternative: void 0,
+        embeddedInLabelledBy: void 0,
+        embeddedInDescribedBy: void 0,
+        embeddedInTargetElement: void 0,
+      })
+    )
+    .filter((accessibleName) => !!accessibleName)
+    .join(' ')
+}
+var cacheAccessibleName
+var cacheAccessibleNameHidden
+var cacheAccessibleDescription
+var cacheAccessibleDescriptionHidden
+var cacheAccessibleErrorMessage
+var cacheIsHidden
+var cachePseudoContentBefore
+var cachePseudoContentAfter
+var cachesCounter = 0
+function beginAriaCaches() {
+  ++cachesCounter
+  cacheAccessibleName != null
+    ? cacheAccessibleName
+    : (cacheAccessibleName = new k6BrowserNative.Map())
+  cacheAccessibleNameHidden != null
+    ? cacheAccessibleNameHidden
+    : (cacheAccessibleNameHidden = new k6BrowserNative.Map())
+  cacheAccessibleDescription != null
+    ? cacheAccessibleDescription
+    : (cacheAccessibleDescription = new k6BrowserNative.Map())
+  cacheAccessibleDescriptionHidden != null
+    ? cacheAccessibleDescriptionHidden
+    : (cacheAccessibleDescriptionHidden = new k6BrowserNative.Map())
+  cacheAccessibleErrorMessage != null
+    ? cacheAccessibleErrorMessage
+    : (cacheAccessibleErrorMessage = new k6BrowserNative.Map())
+  cacheIsHidden != null
+    ? cacheIsHidden
+    : (cacheIsHidden = new k6BrowserNative.Map())
+  cachePseudoContentBefore != null
+    ? cachePseudoContentBefore
+    : (cachePseudoContentBefore = new k6BrowserNative.Map())
+  cachePseudoContentAfter != null
+    ? cachePseudoContentAfter
+    : (cachePseudoContentAfter = new k6BrowserNative.Map())
+}
+function endAriaCaches() {
+  if (!--cachesCounter) {
+    cacheAccessibleName = void 0
+    cacheAccessibleNameHidden = void 0
+    cacheAccessibleDescription = void 0
+    cacheAccessibleDescriptionHidden = void 0
+    cacheAccessibleErrorMessage = void 0
+    cacheIsHidden = void 0
+    cachePseudoContentBefore = void 0
+    cachePseudoContentAfter = void 0
+  }
+}
+var inputTypeToRole = {
+  button: 'button',
+  checkbox: 'checkbox',
+  image: 'button',
+  number: 'spinbutton',
+  radio: 'radio',
+  range: 'slider',
+  reset: 'button',
+  submit: 'button',
+}
+
+// packages/injected/src/selectorUtils.ts
+function matchesAttributePart(value, attr) {
+  const objValue =
+    typeof value === 'string' && !attr.caseSensitive
+      ? value.toUpperCase()
+      : value
+  const attrValue =
+    typeof attr.value === 'string' && !attr.caseSensitive
+      ? attr.value.toUpperCase()
+      : attr.value
+  if (attr.op === '<truthy>') return !!objValue
+  if (attr.op === '=') {
+    if (attrValue instanceof RegExp)
+      return typeof objValue === 'string' && !!objValue.match(attrValue)
+    return objValue === attrValue
+  }
+  if (typeof objValue !== 'string' || typeof attrValue !== 'string')
+    return false
+  if (attr.op === '*=') return objValue.includes(attrValue)
+  if (attr.op === '^=') return objValue.startsWith(attrValue)
+  if (attr.op === '$=') return objValue.endsWith(attrValue)
+  if (attr.op === '|=')
+    return objValue === attrValue || objValue.startsWith(attrValue + '-')
+  if (attr.op === '~=') return objValue.split(' ').includes(attrValue)
+  return false
+}
+
+// packages/playwright-core/src/utils/isomorphic/cssParser.ts
+var InvalidSelectorError = class extends Error {}
+
+// packages/playwright-core/src/utils/isomorphic/selectorParser.ts
+function parseAttributeSelector(selector, allowUnquotedStrings) {
+  let wp = 0
+  let EOL = selector.length === 0
+  const next = () => selector[wp] || ''
+  const eat1 = () => {
+    const result2 = next()
+    ++wp
+    EOL = wp >= selector.length
+    return result2
+  }
+  const syntaxError = (stage) => {
+    if (EOL)
+      throw new InvalidSelectorError(
+        `Unexpected end of selector while parsing selector \`${selector}\``
+      )
+    throw new InvalidSelectorError(
+      `Error while parsing selector \`${selector}\` - unexpected symbol "${next()}" at position ${wp}` +
+        (stage ? ' during ' + stage : '')
+    )
+  }
+  function skipSpaces() {
+    while (!EOL && /\s/.test(next())) eat1()
+  }
+  function isCSSNameChar(char) {
+    return (
+      char >= '\x80' ||
+      (char >= '0' && char <= '9') ||
+      (char >= 'A' && char <= 'Z') ||
+      (char >= 'a' && char <= 'z') ||
+      (char >= '0' && char <= '9') ||
+      char === '_' ||
+      char === '-'
+    )
+  }
+  function readIdentifier() {
+    let result2 = ''
+    skipSpaces()
+    while (!EOL && isCSSNameChar(next())) result2 += eat1()
+    return result2
+  }
+  function readQuotedString(quote) {
+    let result2 = eat1()
+    if (result2 !== quote) syntaxError('parsing quoted string')
+    while (!EOL && next() !== quote) {
+      if (next() === '\\') eat1()
+      result2 += eat1()
+    }
+    if (next() !== quote) syntaxError('parsing quoted string')
+    result2 += eat1()
+    return result2
+  }
+  function readRegularExpression() {
+    if (eat1() !== '/') syntaxError('parsing regular expression')
+    let source = ''
+    let inClass = false
+    while (!EOL) {
+      if (next() === '\\') {
+        source += eat1()
+        if (EOL) syntaxError('parsing regular expression')
+      } else if (inClass && next() === ']') {
+        inClass = false
+      } else if (!inClass && next() === '[') {
+        inClass = true
+      } else if (!inClass && next() === '/') {
+        break
+      }
+      source += eat1()
+    }
+    if (eat1() !== '/') syntaxError('parsing regular expression')
+    let flags = ''
+    while (!EOL && next().match(/[dgimsuy]/)) flags += eat1()
+    try {
+      return new RegExp(source, flags)
+    } catch (e) {
+      throw new InvalidSelectorError(
+        `Error while parsing selector \`${selector}\`: ${e.message}`
+      )
+    }
+  }
+  function readAttributeToken() {
+    let token = ''
+    skipSpaces()
+    if (next() === `'` || next() === `"`)
+      token = readQuotedString(next()).slice(1, -1)
+    else token = readIdentifier()
+    if (!token) syntaxError('parsing property path')
+    return token
+  }
+  function readOperator() {
+    skipSpaces()
+    let op = ''
+    if (!EOL) op += eat1()
+    if (!EOL && op !== '=') op += eat1()
+    if (!['=', '*=', '^=', '$=', '|=', '~='].includes(op))
+      syntaxError('parsing operator')
+    return op
+  }
+  function readAttribute() {
+    eat1()
+    const jsonPath = []
+    jsonPath.push(readAttributeToken())
+    skipSpaces()
+    while (next() === '.') {
+      eat1()
+      jsonPath.push(readAttributeToken())
+      skipSpaces()
+    }
+    if (next() === ']') {
+      eat1()
+      return {
+        name: jsonPath.join('.'),
+        jsonPath,
+        op: '<truthy>',
+        value: null,
+        caseSensitive: false,
+      }
+    }
+    const operator = readOperator()
+    let value = void 0
+    let caseSensitive = true
+    skipSpaces()
+    if (next() === '/') {
+      if (operator !== '=')
+        throw new InvalidSelectorError(
+          `Error while parsing selector \`${selector}\` - cannot use ${operator} in attribute with regular expression`
+        )
+      value = readRegularExpression()
+    } else if (next() === `'` || next() === `"`) {
+      value = readQuotedString(next()).slice(1, -1)
+      skipSpaces()
+      if (next() === 'i' || next() === 'I') {
+        caseSensitive = false
+        eat1()
+      } else if (next() === 's' || next() === 'S') {
+        caseSensitive = true
+        eat1()
+      }
+    } else {
+      value = ''
+      while (
+        !EOL &&
+        (isCSSNameChar(next()) || next() === '+' || next() === '.')
+      )
+        value += eat1()
+      if (value === 'true') {
+        value = true
+      } else if (value === 'false') {
+        value = false
+      } else {
+        if (!allowUnquotedStrings) {
+          value = +value
+          if (Number.isNaN(value)) syntaxError('parsing attribute value')
+        }
+      }
+    }
+    skipSpaces()
+    if (next() !== ']') syntaxError('parsing attribute value')
+    eat1()
+    if (operator !== '=' && typeof value !== 'string')
+      throw new InvalidSelectorError(
+        `Error while parsing selector \`${selector}\` - cannot use ${operator} in attribute with non-string matching value - ${value}`
+      )
+    return {
+      name: jsonPath.join('.'),
+      jsonPath,
+      op: operator,
+      value,
+      caseSensitive,
+    }
+  }
+  const result = {
+    name: '',
+    attributes: [],
+  }
+  result.name = readIdentifier()
+  skipSpaces()
+  while (next() === '[') {
+    result.attributes.push(readAttribute())
+    skipSpaces()
+  }
+  if (!EOL) syntaxError(void 0)
+  if (!result.name && !result.attributes.length)
+    throw new InvalidSelectorError(
+      `Error while parsing selector \`${selector}\` - selector cannot be empty`
+    )
+  return result
+}
+
+// packages/injected/src/roleSelectorEngine.ts
+var kSupportedAttributes = [
+  'selected',
+  'checked',
+  'pressed',
+  'expanded',
+  'level',
+  'disabled',
+  'name',
+  'include-hidden',
+]
+kSupportedAttributes.sort()
+function validateSupportedRole(attr, roles, role) {
+  if (!roles.includes(role))
+    throw new Error(
+      `"${attr}" attribute is only supported for roles: ${roles
+        .slice()
+        .sort()
+        .map((role2) => `"${role2}"`)
+        .join(', ')}`
+    )
+}
+function validateSupportedValues(attr, values) {
+  if (attr.op !== '<truthy>' && !values.includes(attr.value))
+    throw new Error(
+      `"${attr.name}" must be one of ${values.map((v) => JSON.stringify(v)).join(', ')}`
+    )
+}
+function validateSupportedOp(attr, ops) {
+  if (!ops.includes(attr.op))
+    throw new Error(`"${attr.name}" does not support "${attr.op}" matcher`)
+}
+function validateAttributes(attrs, role) {
+  const options = { role }
+  for (const attr of attrs) {
+    switch (attr.name) {
+      case 'checked': {
+        validateSupportedRole(attr.name, kAriaCheckedRoles, role)
+        validateSupportedValues(attr, [true, false, 'mixed'])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.checked = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      case 'pressed': {
+        validateSupportedRole(attr.name, kAriaPressedRoles, role)
+        validateSupportedValues(attr, [true, false, 'mixed'])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.pressed = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      case 'selected': {
+        validateSupportedRole(attr.name, kAriaSelectedRoles, role)
+        validateSupportedValues(attr, [true, false])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.selected = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      case 'expanded': {
+        validateSupportedRole(attr.name, kAriaExpandedRoles, role)
+        validateSupportedValues(attr, [true, false])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.expanded = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      case 'level': {
+        validateSupportedRole(attr.name, kAriaLevelRoles, role)
+        if (typeof attr.value === 'string') attr.value = +attr.value
+        if (
+          attr.op !== '=' ||
+          typeof attr.value !== 'number' ||
+          Number.isNaN(attr.value)
+        )
+          throw new Error(`"level" attribute must be compared to a number`)
+        options.level = attr.value
+        break
+      }
+      case 'disabled': {
+        validateSupportedValues(attr, [true, false])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.disabled = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      case 'name': {
+        if (attr.op === '<truthy>')
+          throw new Error(`"name" attribute must have a value`)
+        if (typeof attr.value !== 'string' && !(attr.value instanceof RegExp))
+          throw new Error(
+            `"name" attribute must be a string or a regular expression`
+          )
+        options.name = attr.value
+        options.nameOp = attr.op
+        options.exact = attr.caseSensitive
+        break
+      }
+      case 'include-hidden': {
+        validateSupportedValues(attr, [true, false])
+        validateSupportedOp(attr, ['<truthy>', '='])
+        options.includeHidden = attr.op === '<truthy>' ? true : attr.value
+        break
+      }
+      default: {
+        throw new Error(
+          `Unknown attribute "${attr.name}", must be one of ${kSupportedAttributes.map((a) => `"${a}"`).join(', ')}.`
+        )
+      }
+    }
+  }
+  return options
+}
+function queryRole(scope, options, internal) {
+  const result = []
+  const match = (element) => {
+    if (getAriaRole(element) !== options.role) return
+    if (
+      options.selected !== void 0 &&
+      getAriaSelected(element) !== options.selected
+    )
+      return
+    if (
+      options.checked !== void 0 &&
+      getAriaChecked(element) !== options.checked
+    )
+      return
+    if (
+      options.pressed !== void 0 &&
+      getAriaPressed(element) !== options.pressed
+    )
+      return
+    if (
+      options.expanded !== void 0 &&
+      getAriaExpanded(element) !== options.expanded
+    )
+      return
+    if (options.level !== void 0 && getAriaLevel(element) !== options.level)
+      return
+    if (
+      options.disabled !== void 0 &&
+      getAriaDisabled(element) !== options.disabled
+    )
+      return
+    if (!options.includeHidden) {
+      const isHidden = isElementHiddenForAria(element)
+      if (isHidden) return
+    }
+    if (options.name !== void 0) {
+      const accessibleName = normalizeWhiteSpace(
+        getElementAccessibleName(element, !!options.includeHidden)
+      )
+      if (typeof options.name === 'string')
+        options.name = normalizeWhiteSpace(options.name)
+      if (internal && !options.exact && options.nameOp === '=')
+        options.nameOp = '*='
+      if (
+        !matchesAttributePart(accessibleName, {
+          name: '',
+          jsonPath: [],
+          op: options.nameOp || '=',
+          value: options.name,
+          caseSensitive: !!options.exact,
+        })
+      )
+        return
+    }
+    result.push(element)
+  }
+  const query = (root) => {
+    const shadows = []
+    if (root.shadowRoot) shadows.push(root.shadowRoot)
+    for (const element of root.querySelectorAll('*')) {
+      match(element)
+      if (element.shadowRoot) shadows.push(element.shadowRoot)
+    }
+    shadows.forEach(query)
+  }
+  query(scope)
+  return result
+}
+
+function createRoleEngine(internal) {
+  return {
+    queryAll: (scope, selector) => {
+      const parsed = parseAttributeSelector(selector, true)
+      const role = parsed.name.toLowerCase()
+      if (!role) throw new Error(`Role must not be empty`)
+      const options = validateAttributes(parsed.attributes, role)
+      beginAriaCaches()
+      try {
+        return queryRole(scope, options, internal)
+      } finally {
+        endAriaCaches()
+      }
+    },
+  }
+}
+
+// packages/injected/src/selectorEvaluator.ts
+var SelectorEvaluatorImpl = class {
+  constructor() {
+    this._retainCacheCounter = 0
+    this._cacheText = new k6BrowserNative.Map()
+    this._cacheQueryCSS = new k6BrowserNative.Map()
+  }
+  begin() {
+    ++this._retainCacheCounter
+  }
+  end() {
+    --this._retainCacheCounter
+    if (!this._retainCacheCounter) {
+      this._cacheQueryCSS.clear()
+      this._cacheText.clear()
+    }
+  }
+  _cached(cache, main, rest, cb) {
+    if (!cache.has(main)) cache.set(main, [])
+    const entries = cache.get(main)
+    const entry = entries.find((e) =>
+      rest.every((value, index) => e.rest[index] === value)
+    )
+    if (entry) return entry.result
+    const result = cb()
+    entries.push({ rest, result })
+    return result
+  }
+  _queryCSS(context, css) {
+    return this._cached(
+      this._cacheQueryCSS,
+      css,
+      [context.scope, context.pierceShadow, context.originalScope],
+      () => {
+        let result = []
+        function query(root) {
+          result = result.concat([...root.querySelectorAll(css)])
+          if (!context.pierceShadow) return
+          if (root.shadowRoot) query(root.shadowRoot)
+          for (const element of root.querySelectorAll('*')) {
+            if (element.shadowRoot) query(element.shadowRoot)
+          }
+        }
+        query(context.scope)
+        return result
+      }
+    )
+  }
+}
+
+// packages/injected/src/selectorUtils.ts
+function shouldSkipForTextMatching(element) {
+  const document = element.ownerDocument
+  return (
+    element.nodeName === 'SCRIPT' ||
+    element.nodeName === 'NOSCRIPT' ||
+    element.nodeName === 'STYLE' ||
+    (document.head && document.head.contains(element))
+  )
+}
+function elementText(cache, root) {
+  let value = cache.get(root)
+  if (value === void 0) {
+    value = { full: '', normalized: '', immediate: [] }
+    if (!shouldSkipForTextMatching(root)) {
+      let currentImmediate = ''
+      if (
+        root instanceof HTMLInputElement &&
+        (root.type === 'submit' || root.type === 'button')
+      ) {
+        value = {
+          full: root.value,
+          normalized: normalizeWhiteSpace(root.value),
+          immediate: [root.value],
+        }
+      } else {
+        for (let child = root.firstChild; child; child = child.nextSibling) {
+          if (child.nodeType === Node.TEXT_NODE) {
+            value.full += child.nodeValue || ''
+            currentImmediate += child.nodeValue || ''
+          } else if (child.nodeType === Node.COMMENT_NODE) {
+            continue
+          } else {
+            if (currentImmediate) value.immediate.push(currentImmediate)
+            currentImmediate = ''
+            if (child.nodeType === Node.ELEMENT_NODE)
+              value.full += elementText(cache, child).full
+          }
+        }
+        if (currentImmediate) value.immediate.push(currentImmediate)
+        if (root.shadowRoot)
+          value.full += elementText(cache, root.shadowRoot).full
+        if (value.full) value.normalized = normalizeWhiteSpace(value.full)
+      }
+    }
+    cache.set(root, value)
+  }
+  return value
+}
+function getElementLabels(textCache, element) {
+  const labels = getAriaLabelledByElements(element)
+  if (labels) return labels.map((label) => elementText(textCache, label))
+  const ariaLabel = element.getAttribute('aria-label')
+  if (ariaLabel !== null && !!ariaLabel.trim())
+    return [
+      {
+        full: ariaLabel,
+        normalized: normalizeWhiteSpace(ariaLabel),
+        immediate: [ariaLabel],
+      },
+    ]
+  const isNonHiddenInput =
+    element.nodeName === 'INPUT' && element.type !== 'hidden'
+  if (
+    ['BUTTON', 'METER', 'OUTPUT', 'PROGRESS', 'SELECT', 'TEXTAREA'].includes(
+      element.nodeName
+    ) ||
+    isNonHiddenInput
+  ) {
+    const labels2 = element.labels
+    if (labels2)
+      return [...labels2].map((label) => elementText(textCache, label))
+  }
+  return []
+}
+function elementMatchesText(cache, element, matcher) {
+  if (shouldSkipForTextMatching(element)) return 'none'
+  if (!matcher(elementText(cache, element))) return 'none'
+  for (let child = element.firstChild; child; child = child.nextSibling) {
+    if (
+      child.nodeType === Node.ELEMENT_NODE &&
+      matcher(elementText(cache, child))
+    )
+      return 'selfAndChildren'
+  }
+  if (element.shadowRoot && matcher(elementText(cache, element.shadowRoot)))
+    return 'selfAndChildren'
+  return 'self'
+}
+
+// packages/injected/src/injectedScript.ts
+function cssUnquote(s) {
+  s = s.substring(1, s.length - 1)
+  if (!s.includes('\\')) return s
+  const r = []
+  let i = 0
+  while (i < s.length) {
+    if (s[i] === '\\' && i + 1 < s.length) i++
+    r.push(s[i++])
+  }
+  return r.join('')
+}
+function createTextMatcher(selector, internal) {
+  if (selector[0] === '/' && selector.lastIndexOf('/') > 0) {
+    const lastSlash = selector.lastIndexOf('/')
+    const re = new RegExp(
+      selector.substring(1, lastSlash),
+      selector.substring(lastSlash + 1)
+    )
+    return {
+      matcher: (elementText2) => re.test(elementText2.full),
+      kind: 'regex',
+    }
+  }
+  const unquote = internal ? JSON.parse.bind(JSON) : cssUnquote
+  let strict = false
+  if (
+    selector.length > 1 &&
+    selector[0] === '"' &&
+    selector[selector.length - 1] === '"'
+  ) {
+    selector = unquote(selector)
+    strict = true
+  } else if (
+    internal &&
+    selector.length > 1 &&
+    selector[0] === '"' &&
+    selector[selector.length - 2] === '"' &&
+    selector[selector.length - 1] === 'i'
+  ) {
+    selector = unquote(selector.substring(0, selector.length - 1))
+    strict = false
+  } else if (
+    internal &&
+    selector.length > 1 &&
+    selector[0] === '"' &&
+    selector[selector.length - 2] === '"' &&
+    selector[selector.length - 1] === 's'
+  ) {
+    selector = unquote(selector.substring(0, selector.length - 1))
+    strict = true
+  } else if (
+    selector.length > 1 &&
+    selector[0] === "'" &&
+    selector[selector.length - 1] === "'"
+  ) {
+    selector = unquote(selector)
+    strict = true
+  }
+  selector = normalizeWhiteSpace(selector)
+  if (strict) {
+    if (internal)
+      return {
+        kind: 'strict',
+        matcher: (elementText2) => elementText2.normalized === selector,
+      }
+    const strictTextNodeMatcher = (elementText2) => {
+      if (!selector && !elementText2.immediate.length) return true
+      return elementText2.immediate.some(
+        (s) => normalizeWhiteSpace(s) === selector
+      )
+    }
+    return { matcher: strictTextNodeMatcher, kind: 'strict' }
+  }
+  selector = selector.toLowerCase()
+  return {
+    kind: 'lax',
+    matcher: (elementText2) =>
+      elementText2.normalized.toLowerCase().includes(selector),
+  }
+}
+
+const autoClosingTags = new k6BrowserNative.Set([
+  'AREA',
+  'BASE',
+  'BR',
+  'COL',
+  'COMMAND',
+  'EMBED',
+  'HR',
+  'IMG',
+  'INPUT',
+  'KEYGEN',
+  'LINK',
+  'MENUITEM',
+  'META',
+  'PARAM',
+  'SOURCE',
+  'TRACK',
+  'WBR',
+])
+const booleanAttributes = new k6BrowserNative.Set([
+  'checked',
+  'selected',
+  'disabled',
+  'readonly',
+  'multiple',
+])
+const eventType = new k6BrowserNative.Map([
+  ['auxclick', 'mouse'],
+  ['click', 'mouse'],
+  ['dblclick', 'mouse'],
+  ['mousedown', 'mouse'],
+  ['mouseenter', 'mouse'],
+  ['mouseleave', 'mouse'],
+  ['mousemove', 'mouse'],
+  ['mouseout', 'mouse'],
+  ['mouseover', 'mouse'],
+  ['mouseup', 'mouse'],
+  ['mousewheel', 'mouse'],
+
+  ['keydown', 'keyboard'],
+  ['keyup', 'keyboard'],
+  ['keypress', 'keyboard'],
+  ['textInput', 'keyboard'],
+
+  ['touchstart', 'touch'],
+  ['touchmove', 'touch'],
+  ['touchend', 'touch'],
+  ['touchcancel', 'touch'],
+
+  ['pointerover', 'pointer'],
+  ['pointerout', 'pointer'],
+  ['pointerenter', 'pointer'],
+  ['pointerleave', 'pointer'],
+  ['pointerdown', 'pointer'],
+  ['pointerup', 'pointer'],
+  ['pointermove', 'pointer'],
+  ['pointercancel', 'pointer'],
+  ['gotpointercapture', 'pointer'],
+  ['lostpointercapture', 'pointer'],
+
+  ['focus', 'focus'],
+  ['blur', 'focus'],
+
+  ['drag', 'drag'],
+  ['dragstart', 'drag'],
+  ['dragend', 'drag'],
+  ['dragover', 'drag'],
+  ['dragenter', 'drag'],
+  ['dragleave', 'drag'],
+  ['dragexit', 'drag'],
+  ['drop', 'drag'],
+])
+
+const continuePolling = Symbol('continuePolling')
+
+function isVisible(element) {
+  if (!element.ownerDocument || !element.ownerDocument.defaultView) {
+    return true
+  }
+  const style = element.ownerDocument.defaultView.getComputedStyle(element)
+  if (!style || style.visibility === 'hidden') {
+    return false
+  }
+  const rect = element.getBoundingClientRect()
+  return rect.width > 0 && rect.height > 0
+}
+
+function oneLine(s) {
+  return s.replace(/\n/g, '↵').replace(/\t/g, '⇆')
+}
+
+class CSSQueryEngine {
+  queryAll(root, selector) {
+    return root.querySelectorAll(selector)
+  }
+}
+
+class TextQueryEngine {
+  queryAll(root, selector) {
+    return root.queryAll(selector)
+  }
+}
+
+class XPathQueryEngine {
+  queryAll(root, selector) {
+    if (selector.startsWith('/')) {
+      selector = '.' + selector
+    }
+    const result = []
+
+    // DocumentFragments cannot be queried with XPath and they do not implement
+    // evaluate. It first needs to be converted to a Document before being able
+    // to run the evaluate against it.
+    //
+    // This avoids the following error:
+    // - Failed to execute 'evaluate' on 'Document': The node provided is
+    //   '#document-fragment', which is not a valid context node type.
+    if (root instanceof DocumentFragment) {
+      root = convertToDocument(root)
+    }
+
+    const document = root instanceof Document ? root : root.ownerDocument
+    if (!document) {
+      return result
+    }
+    const it = document.evaluate(
+      selector,
+      root,
+      null,
+      XPathResult.ORDERED_NODE_ITERATOR_TYPE
+    )
+    for (let node = it.iterateNext(); node; node = it.iterateNext()) {
+      if (node.nodeType === 1 /*Node.ELEMENT_NODE*/) {
+        result.push(node)
+      }
+    }
+    return result
+  }
+}
+
+class AttributeEngine {
+  constructor() {
+    this._evaluator = new SelectorEvaluatorImpl()
+  }
+  queryAll(root, selector) {
+    try {
+      this._evaluator.begin()
+
+      const parsed = parseAttributeSelector(selector, true)
+      if (parsed.name || parsed.attributes.length !== 1)
+        throw new Error('Malformed attribute selector: ' + selector)
+      const { name, value, caseSensitive } = parsed.attributes[0]
+      const lowerCaseValue = caseSensitive ? null : value.toLowerCase()
+      let matcher
+      if (value instanceof RegExp) matcher = (s) => !!s.match(value)
+      else if (caseSensitive) matcher = (s) => s === value
+      else matcher = (s) => s.toLowerCase().includes(lowerCaseValue)
+      const elements = this._evaluator._queryCSS(
+        { scope: root, pierceShadow: true },
+        `[${name}]`
+      )
+      return elements.filter((e) => matcher(e.getAttribute(name)))
+    } finally {
+      this._evaluator.end()
+    }
+  }
+}
+
+class LabelEngine {
+  constructor() {
+    this._evaluator = new SelectorEvaluatorImpl()
+  }
+  queryAll(root, selector) {
+    try {
+      this._evaluator.begin()
+
+      const { matcher } = createTextMatcher(selector, true)
+      const allElements = this._evaluator._queryCSS(
+        { scope: root, pierceShadow: true },
+        '*'
+      )
+      return allElements.filter((element) => {
+        return getElementLabels(this._evaluator._cacheText, element).some(
+          (label) => matcher(label)
+        )
+      })
+    } finally {
+      this._evaluator.end()
+    }
+  }
+}
+
+class TextEngine {
+  constructor(shadow, internal) {
+    this._evaluator = new SelectorEvaluatorImpl()
+    this._shadow = shadow
+    this._internal = internal
+  }
+  queryAll(root, selector) {
+    try {
+      this._evaluator.begin()
+
+      const { matcher, kind } = createTextMatcher(selector, this._internal)
+      const result = []
+      let lastDidNotMatchSelf = null
+      const appendElement = (element) => {
+        if (
+          kind === 'lax' &&
+          lastDidNotMatchSelf &&
+          lastDidNotMatchSelf.contains(element)
+        )
+          return false
+        const matches = elementMatchesText(
+          this._evaluator._cacheText,
+          element,
+          matcher
+        )
+        if (matches === 'none') lastDidNotMatchSelf = element
+        if (
+          matches === 'self' ||
+          (matches === 'selfAndChildren' &&
+            kind === 'strict' &&
+            !this._internal)
+        )
+          result.push(element)
+      }
+      if (root.nodeType === Node.ELEMENT_NODE) appendElement(root)
+      const elements = this._evaluator._queryCSS(
+        { scope: root, pierceShadow: this._shadow },
+        '*'
+      )
+      for (const element of elements) appendElement(element)
+      return result
+    } finally {
+      this._evaluator.end()
+    }
+  }
+}
+
+// convertToDocument will convert a DocumentFragment into a Document. It does
+// this by creating a new Document and copying the elements from the
+// DocumentFragment to the Document.
+function convertToDocument(fragment) {
+  var newDoc = document.implementation.createHTMLDocument('Temporary Document')
+
+  copyNodesToDocument(fragment, newDoc.body)
+
+  return newDoc
+}
+
+// copyNodesToDocument manually copies nodes to a new document, excluding
+// ShadowRoot nodes -- ShadowRoot are not cloneable so we need to manually
+// clone them one element at a time.
+function copyNodesToDocument(sourceNode, targetNode) {
+  sourceNode.childNodes.forEach((child) => {
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      // Clone the child node without its descendants
+      let clonedChild = child.cloneNode(false)
+      targetNode.appendChild(clonedChild)
+
+      // If the child has a shadow root, recursively copy its children
+      // instead of the shadow root itself.
+      if (child.shadowRoot) {
+        copyNodesToDocument(child.shadowRoot, clonedChild)
+      } else {
+        // Recursively copy normal child nodes
+        copyNodesToDocument(child, clonedChild)
+      }
+    } else {
+      // For non-element nodes (like text nodes), clone them directly.
+      let clonedChild = child.cloneNode(true)
+      targetNode.appendChild(clonedChild)
+    }
+  })
+}
+
+class InjectedScript {
+  constructor() {
+    this._replaceRafWithTimeout = false
+    this._stableRafCount = 10
+    this._evaluator = new SelectorEvaluatorImpl()
+    this._queryEngines = {
+      css: new CSSQueryEngine(),
+      text: new TextQueryEngine(),
+      xpath: new XPathQueryEngine(),
+      'internal:role': createRoleEngine(true),
+      'internal:attr': new AttributeEngine(),
+      'internal:label': new LabelEngine(),
+      'internal:text': new TextEngine(true, true),
+      'internal:has-text': this._createInternalHasTextEngine(),
+      'internal:has-not-text': this._createInternalHasNotTextEngine(),
+    }
+  }
+
+  _queryEngineAll(part, root) {
+    return this._queryEngines[part.name].queryAll(root, part.body)
+  }
+
+  _createInternalHasTextEngine() {
+    return {
+      queryAll: (root, selector) => {
+        if (root.nodeType !== 1 /* Node.ELEMENT_NODE */) return []
+        const element = root
+        const text = elementText(this._evaluator._cacheText, element)
+        const { matcher } = createTextMatcher(selector, true)
+        return matcher(text) ? [element] : []
+      },
+    }
+  }
+
+  _createInternalHasNotTextEngine() {
+    return {
+      queryAll: (root, selector) => {
+        if (root.nodeType !== 1 /* Node.ELEMENT_NODE */) return []
+        const element = root
+        const text = elementText(this._evaluator._cacheText, element)
+        const { matcher } = createTextMatcher(selector, true)
+        return matcher(text) ? [] : [element]
+      },
+    }
+  }
+
+  _querySelectorRecursively(roots, selector, index, queryCache) {
+    if (index === selector.parts.length) {
+      return roots
+    }
+
+    const part = selector.parts[index]
+    if (part.name === 'nth') {
+      let filtered = []
+      if (part.body === '0') {
+        filtered = roots.slice(0, 1)
+      } else if (part.body === '-1') {
+        if (roots.length) {
+          filtered = roots.slice(roots.length - 1)
+        }
+      } else {
+        if (typeof selector.capture === 'number') {
+          return 'error:nthnocapture'
+        }
+        const nth = parseInt(part.body, 10)
+        const set = new k6BrowserNative.Set()
+        for (const root of roots) {
+          set.add(root.element)
+          if (nth + 1 === set.size) {
+            filtered = [root]
+          }
+        }
+      }
+      return this._querySelectorRecursively(
+        filtered,
+        selector,
+        index + 1,
+        queryCache
+      )
+    }
+
+    if (part.name === 'visible') {
+      const visible = Boolean(part.body)
+      return roots.filter((match) => visible === isVisible(match.element))
+    }
+
+    const result = []
+    for (const root of roots) {
+      const capture =
+        index - 1 === selector.capture ? root.element : root.capture
+
+      // Do not query engine twice for the same element.
+      let queryResults = queryCache.get(root.element)
+      if (!queryResults) {
+        queryResults = []
+        queryCache.set(root.element, queryResults)
+      }
+      let all = queryResults[index]
+      if (!all) {
+        all = this._queryEngineAll(selector.parts[index], root.element)
+        queryResults[index] = all
+      }
+
+      for (const element of all) {
+        if (!('nodeName' in element)) {
+          return `error:expectednode:${Object.prototype.toString.call(element)}`
+        }
+        result.push({ element, capture })
+      }
+
+      // Explore the Shadow DOM recursively.
+      const shadowResults = this._exploreShadowDOM(
+        root.element,
+        selector,
+        index,
+        queryCache,
+        capture
+      )
+      result.push(...shadowResults)
+    }
+
+    return this._querySelectorRecursively(
+      result,
+      selector,
+      index + 1,
+      queryCache
+    )
+  }
+
+  _exploreShadowDOM(root, selector, index, queryCache, capture) {
+    let result = []
+    if (root.shadowRoot) {
+      const shadowRootResults = this._querySelectorRecursively(
+        [{ element: root.shadowRoot, capture }],
+        selector,
+        index,
+        queryCache
+      )
+      result = result.concat(shadowRootResults)
+    }
+
+    if (!root.hasChildNodes()) return result
+
+    for (let i = 0; i < root.children.length; i++) {
+      const childElement = root.children[i]
+      result = result.concat(
+        this._exploreShadowDOM(
+          childElement,
+          selector,
+          index,
+          queryCache,
+          capture
+        )
+      )
+    }
+
+    return result
+  }
+
+  // Make sure we target an appropriate node in the DOM before performing an action.
+  _retarget(node, behavior) {
+    let element =
+      node.nodeType === 1 /*Node.ELEMENT_NODE*/ ? node : node.parentElement
+    if (!element) {
+      return null
+    }
+    if (!element.matches('input, textarea, select')) {
+      element =
+        element.closest(
+          'button, [role=button], [role=checkbox], [role=radio]'
+        ) || element
+    }
+    if (behavior === 'follow-label') {
+      if (
+        !element.matches(
+          'input, textarea, button, select, [role=button], [role=checkbox], [role=radio]'
+        ) &&
+        !element.isContentEditable
+      ) {
+        // Go up to the label that might be connected to the input/textarea.
+        element = element.closest('label') || element
+      }
+      if (element.nodeName === 'LABEL') {
+        element = element.control || element
+      }
+    }
+    return element
+  }
+
+  checkElementState(node, state) {
+    const element = this._retarget(
+      node,
+      ['stable', 'visible', 'hidden'].includes(state)
+        ? 'no-follow-label'
+        : 'follow-label'
+    )
+    if (!element || !element.isConnected) {
+      if (state === 'hidden') {
+        return true
+      }
+      return 'error:notconnected'
+    }
+
+    if (state === 'visible') {
+      return this.isVisible(element)
+    }
+    if (state === 'hidden') {
+      return !this.isVisible(element)
+    }
+
+    const disabled =
+      ['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA'].includes(element.nodeName) &&
+      element.hasAttribute('disabled')
+    if (state === 'disabled') {
+      return disabled
+    }
+    if (state === 'enabled') {
+      return !disabled
+    }
+
+    const editable = !(
+      ['INPUT', 'TEXTAREA', 'SELECT'].includes(element.nodeName) &&
+      element.hasAttribute('readonly')
+    )
+    if (state === 'editable') {
+      return !disabled && editable
+    }
+
+    if (state === 'checked') {
+      if (element.getAttribute('role') === 'checkbox') {
+        return element.getAttribute('aria-checked') === 'true'
+      }
+      if (element.nodeName !== 'INPUT') {
+        return 'error:notcheckbox'
+      }
+      if (!['radio', 'checkbox'].includes(element.type.toLowerCase())) {
+        return 'error:notcheckbox'
+      }
+      return element.checked
+    }
+    return 'error:unexpected element state "' + state + '"'
+  }
+
+  checkHitTargetAt(node, point) {
+    let element =
+      node.nodeType === 1 /*Node.ELEMENT_NODE*/ ? node : node.parentElement
+    if (!element || !element.isConnected) {
+      return 'error:notconnected'
+    }
+    element = element.closest('button, [role=button]') || element
+    let hitElement = this.deepElementFromPoint(document, point.x, point.y)
+    const hitParents = []
+    while (hitElement && hitElement !== element) {
+      hitParents.push(hitElement)
+      hitElement = this.parentElementOrShadowHost(hitElement)
+    }
+    if (hitElement === element) {
+      return 'done'
+    }
+    const hitTargetDescription = this.previewNode(
+      hitParents[0] || document.documentElement
+    )
+    // Root is the topmost element in the hitTarget's chain that is not in the
+    // element's chain. For example, it might be a dialog element that overlays
+    // the target.
+    let rootHitTargetDescription
+    while (element) {
+      const index = hitParents.indexOf(element)
+      if (index !== -1) {
+        if (index > 1) {
+          rootHitTargetDescription = this.previewNode(hitParents[index - 1])
+        }
+        break
+      }
+      element = this.parentElementOrShadowHost(element)
+    }
+    if (rootHitTargetDescription)
+      return {
+        hitTargetDescription: `${hitTargetDescription} from ${rootHitTargetDescription} subtree`,
+      }
+    return { hitTargetDescription }
+  }
+
+  deepElementFromPoint(document, x, y) {
+    let container = document
+    let element
+    while (container) {
+      // elementFromPoint works incorrectly in Chromium (http://crbug.com/1188919),
+      // so we use elementsFromPoint instead.
+      const elements = container.elementsFromPoint(x, y)
+      const innerElement = elements[0]
+      if (!innerElement || element === innerElement) {
+        break
+      }
+      element = innerElement
+      container = element.shadowRoot
+    }
+    return element
+  }
+
+  dispatchEvent(node, type, eventInit) {
+    let event
+    eventInit = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      ...eventInit,
+    }
+    switch (eventType.get(type)) {
+      case 'mouse':
+        event = new MouseEvent(type, eventInit)
+        break
+      case 'keyboard':
+        event = new KeyboardEvent(type, eventInit)
+        break
+      case 'touch':
+        event = new TouchEvent(type, eventInit)
+        break
+      case 'pointer':
+        event = new PointerEvent(type, eventInit)
+        break
+      case 'focus':
+        event = new FocusEvent(type, eventInit)
+        break
+      case 'drag':
+        event = new DragEvent(type, eventInit)
+        break
+      default:
+        event = new Event(type, eventInit)
+        break
+    }
+    node.dispatchEvent(event)
+  }
+
+  setInputFiles(node, payloads) {
+    if (node.nodeType !== Node.ELEMENT_NODE) return 'error:notelement'
+    if (node.nodeName.toLowerCase() !== 'input') return 'error:notinput'
+    const type = (node.getAttribute('type') || '').toLowerCase()
+    if (type !== 'file') return 'error:notfile'
+
+    const dt = new DataTransfer()
+    if (payloads) {
+      const files = payloads.map((file) => {
+        const bytes = Uint8Array.from(atob(file.buffer), (c) => c.charCodeAt(0))
+        return new File([bytes], file.name, {
+          type: file.mimeType,
+          lastModified: file.lastModifiedMs,
+        })
+      })
+      for (const file of files) dt.items.add(file)
+    }
+    node.files = dt.files
+    node.dispatchEvent(new Event('input', { bubbles: true }))
+    node.dispatchEvent(new Event('change', { bubbles: true }))
+    return 'done'
+  }
+
+  getElementBorderWidth(node) {
+    if (
+      node.nodeType !== 1 /*Node.ELEMENT_NODE*/ ||
+      !node.ownerDocument ||
+      !node.ownerDocument.defaultView
+    ) {
+      return { left: 0, top: 0 }
+    }
+    const style = node.ownerDocument.defaultView.getComputedStyle(node)
+    return {
+      left: parseInt(style.borderLeftWidth || '', 10),
+      top: parseInt(style.borderTopWidth || '', 10),
+    }
+  }
+
+  fill(node, value = '') {
+    const element = this._retarget(node, 'follow-label')
+    if (!element) {
+      return 'error:notconnected'
+    }
+    if (element.nodeName.toLowerCase() === 'input') {
+      const input = element
+      const type = input.type.toLowerCase()
+      const kDateTypes = new k6BrowserNative.Set([
+        'date',
+        'time',
+        'datetime',
+        'datetime-local',
+        'month',
+        'week',
+      ])
+      const kTextInputTypes = new k6BrowserNative.Set([
+        '',
+        'email',
+        'number',
+        'password',
+        'search',
+        'tel',
+        'text',
+        'url',
+      ])
+      if (!kTextInputTypes.has(type) && !kDateTypes.has(type)) {
+        return 'error:notfillableinputtype'
+      }
+      value = value.trim()
+      if (type === 'number' && isNaN(Number(value))) {
+        return 'error:notfillablenumberinput'
+      }
+      if (kDateTypes.has(type)) {
+        input.focus()
+        input.value = value
+        if (input.value !== value) {
+          return 'error:notvaliddate'
+        }
+        element.dispatchEvent(new Event('input', { bubbles: true }))
+        element.dispatchEvent(new Event('change', { bubbles: true }))
+        return 'done' // We have already changed the value, no need to input it.
+      }
+    } else if (element.nodeName.toLowerCase() === 'textarea') {
+      // Nothing to check here.
+    } else if (!element.isContentEditable) {
+      return 'error:notfillableelement'
+    }
+    this.selectText(element)
+    return 'needsinput' // Still need to input the value.
+  }
+
+  focusNode(node, resetSelectionIfNotFocused) {
+    if (!node.isConnected) {
+      return 'error:notconnected'
+    }
+    if (node.nodeType !== 1 /*Node.ELEMENT_NODE*/) {
+      return 'error:notelement'
+    }
+    const wasFocused =
+      node.getRootNode().activeElement === node &&
+      node.ownerDocument &&
+      node.ownerDocument.hasFocus()
+    node.focus()
+    if (
+      resetSelectionIfNotFocused &&
+      !wasFocused &&
+      node.nodeName.toLowerCase() === 'input'
+    ) {
+      try {
+        node.setSelectionRange(0, 0)
+      } catch (e) {
+        // Some inputs do not allow selection.
+      }
+    }
+    return 'done'
+  }
+
+  getDocumentElement(node) {
+    const doc = node
+    if (doc.documentElement && doc.documentElement.ownerDocument === doc) {
+      return doc.documentElement
+    }
+    return node.ownerDocument ? node.ownerDocument.documentElement : null
+  }
+
+  isVisible(element) {
+    return isVisible(element)
+  }
+
+  parentElementOrShadowHost(element) {
+    if (element.parentElement) {
+      return element.parentElement
+    }
+    if (!element.parentNode) {
+      return
+    }
+    if (
+      element.parentNode.nodeType === 11 /*Node.DOCUMENT_FRAGMENT_NODE*/ &&
+      element.parentNode.host
+    ) {
+      return element.parentNode.host
+    }
+  }
+
+  previewNode(node) {
+    if (node.nodeType === 3 /*Node.TEXT_NODE*/) {
+      return oneLine(`#text=${node.nodeValue || ''}`)
+    }
+    if (node.nodeType !== 1 /*Node.ELEMENT_NODE*/) {
+      return oneLine(`<${node.nodeName.toLowerCase()} />`)
+    }
+    const element = node
+
+    const attrs = []
+    for (let i = 0; i < element.attributes.length; i++) {
+      const { name, value } = element.attributes[i]
+      if (name === 'style') {
+        continue
+      }
+      if (!value && booleanAttributes.has(name)) {
+        attrs.push(` ${name}`)
+      } else {
+        attrs.push(` ${name}="${value}"`)
+      }
+    }
+    attrs.sort((a, b) => a.length - b.length)
+    let attrText = attrs.join('')
+    if (attrText.length > 50) {
+      attrText = attrText.substring(0, 49) + '\u2026'
+    }
+    if (autoClosingTags.has(element.nodeName)) {
+      return oneLine(`<${element.nodeName.toLowerCase()}${attrText}/>`)
+    }
+
+    const children = element.childNodes
+    let onlyText = false
+    if (children.length <= 5) {
+      onlyText = true
+      for (let i = 0; i < children.length; i++) {
+        onlyText = onlyText && children[i].nodeType === 3 /*Node.TEXT_NODE*/
+      }
+    }
+    let text = onlyText
+      ? element.textContent || ''
+      : children.length
+        ? '\u2026'
+        : ''
+    if (text.length > 50) {
+      text = text.substring(0, 49) + '\u2026'
+    }
+    return oneLine(
+      `<${element.nodeName.toLowerCase()}${attrText}>${text}</${element.nodeName.toLowerCase()}>`
+    )
+  }
+
+  querySelector(selector, strict, root) {
+    if (!root['querySelector']) {
+      return 'error:notqueryablenode'
+    }
+    const result = this._querySelectorRecursively(
+      [{ element: root, capture: undefined }],
+      selector,
+      0,
+      new k6BrowserNative.Map()
+    )
+    if (strict && result.length > 1) {
+      throw 'error:strictmodeviolation'
+    }
+    if (result.length == 0) {
+      return null
+    }
+    return result[0].capture || result[0].element
+  }
+
+  querySelectorAll(selector, root) {
+    if (!root['querySelectorAll']) {
+      return 'error:notqueryablenode'
+    }
+    const result = this._querySelectorRecursively(
+      [{ element: root, capture: undefined }],
+      selector,
+      0,
+      new k6BrowserNative.Map()
+    )
+    const set = new k6BrowserNative.Set()
+    for (const r of result) {
+      set.add(r.capture || r.element)
+    }
+    return [...set]
+  }
+
+  selectOptions(node, optionsToSelect) {
+    const element = this._retarget(node, 'follow-label')
+    if (!element) {
+      return 'error:notconnected'
+    }
+    if (element.nodeName.toLowerCase() !== 'select') {
+      return 'error:notselect'
+    }
+    const select = element
+    const options = Array.from(select.options)
+    const selectedOptions = []
+    let remainingOptionsToSelect = optionsToSelect.slice()
+    for (let index = 0; index < options.length; index++) {
+      const option = options[index]
+      const filter = (optionToSelect) => {
+        if (optionToSelect instanceof Node) {
+          return option === optionToSelect
+        }
+        let matches = true
+        if (
+          optionToSelect.value !== undefined &&
+          optionToSelect.value !== null
+        ) {
+          matches = matches && optionToSelect.value === option.value
+        }
+        if (
+          optionToSelect.label !== undefined &&
+          optionToSelect.label !== null
+        ) {
+          matches = matches && optionToSelect.label === option.label
+        }
+        if (
+          optionToSelect.index !== undefined &&
+          optionToSelect.index !== null
+        ) {
+          matches = matches && optionToSelect.index === index
+        }
+        return matches
+      }
+      if (!remainingOptionsToSelect.some(filter)) {
+        continue
+      }
+      selectedOptions.push(option)
+      if (select.multiple) {
+        remainingOptionsToSelect = remainingOptionsToSelect.filter(
+          (o) => !filter(o)
+        )
+      } else {
+        remainingOptionsToSelect = []
+        break
+      }
+    }
+    /*if (remainingOptionsToSelect.length) {
+            return continuePolling;
+        }*/
+    select.value = undefined
+    selectedOptions.forEach((option) => (option.selected = true))
+    select.dispatchEvent(new Event('input', { bubbles: true }))
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    return selectedOptions.map((option) => option.value)
+  }
+
+  selectText(node) {
+    const element = this._retarget(node, 'follow-label')
+    if (!element) {
+      return 'error:notconnected'
+    }
+    if (element.nodeName.toLowerCase() === 'input') {
+      const input = element
+      input.select()
+      input.focus()
+      return 'done'
+    }
+    if (element.nodeName.toLowerCase() === 'textarea') {
+      const textarea = element
+      textarea.selectionStart = 0
+      textarea.selectionEnd = textarea.value.length
+      textarea.focus()
+      return 'done'
+    }
+    const range = element.ownerDocument.createRange()
+    range.selectNodeContents(element)
+    const selection = element.ownerDocument.defaultView.getSelection()
+    if (selection) {
+      selection.removeAllRanges()
+      selection.addRange(range)
+    }
+    element.focus()
+    return 'done'
+  }
+
+  async waitForPredicateFunction(predicateFn, polling, timeout, ...args) {
+    let timedOut = false
+    let timeoutPoll = null
+    const predicate = () => {
+      return predicateFn(...args) || continuePolling
+    }
+    if (timeout !== undefined || timeout !== null) {
+      setTimeout(() => {
+        timedOut = true
+        if (timeoutPoll) timeoutPoll()
+      }, timeout)
+    }
+    if (polling === 'raf') return await pollRaf()
+    if (polling === 'mutation') return await pollMutation()
+    if (typeof polling === 'number') return await pollInterval(polling)
+
+    async function pollMutation() {
+      const success = predicate()
+      if (success !== continuePolling) return Promise.resolve(success)
+
+      let resolve, reject
+      const result = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      try {
+        const observer = new MutationObserver(async () => {
+          if (timedOut) {
+            observer.disconnect()
+            reject(`timed out after ${timeout}ms`)
+          }
+          const success = predicate()
+          if (success !== continuePolling) {
+            observer.disconnect()
+            resolve(success)
+          }
+        })
+        timeoutPoll = () => {
+          observer.disconnect()
+          reject(`timed out after ${timeout}ms`)
+        }
+        observer.observe(document, {
+          childList: true,
+          subtree: true,
+          attributes: true,
+        })
+      } catch (error) {
+        reject(error)
+        return
+      }
+      return result
+    }
+
+    async function pollRaf() {
+      let resolve, reject
+      const result = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      await onRaf()
+      return result
+
+      async function onRaf() {
+        try {
+          if (timedOut) {
+            reject(`timed out after ${timeout}ms`)
+            return
+          }
+          const success = predicate()
+          if (success !== continuePolling) {
+            resolve(success)
+            return
+          } else {
+            requestAnimationFrame(onRaf)
+          }
+        } catch (error) {
+          reject(error)
+          return
+        }
+      }
+    }
+
+    async function pollInterval(pollInterval) {
+      let resolve, reject
+      const result = new Promise((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+      await onTimeout()
+      return result
+
+      async function onTimeout() {
+        try {
+          if (timedOut) {
+            reject(`timed out after ${timeout}ms`)
+            return
+          }
+          const success = predicate()
+          if (success !== continuePolling) resolve(success)
+          else setTimeout(onTimeout, pollInterval)
+        } catch (error) {
+          reject(error)
+          return
+        }
+      }
+    }
+  }
+
+  waitForElementStates(node, states = [], timeout, ...args) {
+    let lastRect = undefined
+    let counter = 0
+    let samePositionCounter = 0
+
+    const predicate = () => {
+      if (states.includes('stable')) {
+        const element = this._retarget(node, 'no-follow-label')
+        if (!element) {
+          return 'error:notconnected'
+        }
+
+        // First raf happens in the same animation frame as evaluation, so it does not produce
+        // any client rect difference compared to synchronous call. We skip the synchronous call
+        // and only force layout during actual rafs as a small optimisation.
+        if (++counter === 1) {
+          return continuePolling
+        }
+
+        const clientRect = element.getBoundingClientRect()
+        const rect = {
+          x: clientRect.top,
+          y: clientRect.left,
+          width: clientRect.width,
+          height: clientRect.height,
+        }
+        const samePosition =
+          lastRect &&
+          rect.x === lastRect.x &&
+          rect.y === lastRect.y &&
+          rect.width === lastRect.width &&
+          rect.height === lastRect.height
+        if (samePosition) {
+          ++samePositionCounter
+        } else {
+          samePositionCounter = 0
+        }
+        const isStable = samePositionCounter >= this._stableRafCount
+        const isStableForLogs = isStable || !lastRect
+        lastRect = rect
+        if (!isStable) {
+          return continuePolling
+        }
+      }
+
+      for (const state of states) {
+        if (state !== 'stable') {
+          const result = this.checkElementState(node, state)
+          if (typeof result !== 'boolean') {
+            return result
+          }
+          if (!result) {
+            return continuePolling
+          }
+          continue
+        }
+      }
+
+      return true // All states are good!
+    }
+
+    if (this._replaceRafWithTimeout) {
+      return this.waitForPredicateFunction(predicate, 16, timeout, ...args)
+    } else {
+      return this.waitForPredicateFunction(predicate, 'raf', timeout, ...args)
+    }
+  }
+
+  waitForSelector(selector, root, strict, state, polling, timeout, ...args) {
+    let lastElement
+    const predicate = () => {
+      const elements = this.querySelectorAll(selector, root || document)
+      const element = elements[0]
+      const visible = element ? isVisible(element) : false
+
+      if (lastElement !== element) {
+        lastElement = element
+        if (!element) {
+          // assume that the element is not attached.
+          console.debug(
+            `'${selector.selector}' did not match any elements with state '${state}'`
+          )
+        } else {
+          if (elements.length > 1) {
+            if (strict) {
+              throw 'error:strictmodeviolation'
+            }
+          }
+        }
+      }
+
+      switch (state) {
+        case 'attached':
+          return element ? element : continuePolling
+        case 'detached':
+          return !element ? true : continuePolling
+        case 'visible':
+          return visible ? element : continuePolling
+        case 'hidden':
+          return !visible ? element : continuePolling
+      }
+    }
+
+    return this.waitForPredicateFunction(predicate, polling, timeout, ...args)
+  }
+
+  count(selector, root) {
+    const elements = this.querySelectorAll(selector, root || document)
+    return elements.length
+  }
+}
+
+export { InjectedScript }

--- a/src/browser/injectedScript.js
+++ b/src/browser/injectedScript.js
@@ -14,9 +14,28 @@
  * limitations under the License.
  */
 
+// ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+//
+// IF YOU COPY A NEWER VERSION OF THIS FILE FROM THE K6 REPO, MAKE SURE TO ALSO COPY THE CHANGES MADE HERE.
+// WE LOAD THE PAGE SO EARLY THAT THE DOCUMENT ELEMENT DOES NOT EXIST YET. WE HAVE TO DO THIS LOOP TO GET
+// TO CATCH THE MOMEMENT WHEN THE DOCUMENT ELEMENT IS CREATED.
+//
+// ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
+//
 // k6BrowserNative allows accessing native browser objects
 // even if the page under test has overridden them.
-const k6BrowserNative = (() => {
+const k6BrowserNative = {
+  Set,
+  Map,
+}
+
+function waitForElement() {
+  if (!document.documentElement) {
+    setTimeout(waitForElement, 1)
+
+    return
+  }
+
   const iframe = document.createElement('iframe')
   // hide it offscreen with zero size
   iframe.style.position = 'absolute'
@@ -32,12 +51,13 @@ const k6BrowserNative = (() => {
   const win = iframe.contentWindow
   document.documentElement.removeChild(iframe)
 
-  return {
-    Set: win.Set,
-    Map: win.Map,
-    // Add other native browser objects as needed.
-  }
-})()
+  k6BrowserNative.Set = win.Set
+  k6BrowserNative.Map = win.Map
+}
+
+waitForElement()
+
+// ⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
 
 // packages/playwright-core/src/utils/isomorphic/stringUtils.ts
 var normalizedWhitespaceCache

--- a/src/recorder/browser/target.ts
+++ b/src/recorder/browser/target.ts
@@ -1,13 +1,6 @@
 import { finder } from '@medv/finder'
-import {
-  queryAllByAltText,
-  queryAllByLabelText,
-  queryAllByPlaceholderText,
-  queryAllByRole,
-  queryAllByTestId,
-  queryAllByTitle,
-} from '@testing-library/dom'
 
+import { InjectedScript } from '@/browser/injectedScript'
 import {
   AriaDetails,
   BrowserEventTarget,
@@ -16,6 +9,20 @@ import {
 } from '@/schemas/recording'
 
 import { getAriaDetails } from './utils/aria'
+
+let _injectedScript: InjectedScript | null = null
+
+function getInjectedScript(): InjectedScript {
+  if (!_injectedScript) {
+    _injectedScript = new InjectedScript()
+  }
+  return _injectedScript
+}
+
+function queryAll(parts: { name: string; body: string }[]): Element[] {
+  const result = getInjectedScript().querySelectorAll({ parts }, document.body)
+  return typeof result === 'string' ? [] : result
+}
 
 function generateRoleSelector(
   element: Element,
@@ -36,7 +43,12 @@ function generateRoleSelector(
   }
 
   const [selector] = applicableRoles.flatMap((role) => {
-    const matches = queryAllByRole(document.body, role, { name })
+    const matches = queryAll([
+      {
+        name: 'internal:role',
+        body: `${role}[name=${JSON.stringify(name)}s]`,
+      },
+    ])
 
     if (!matches.includes(element)) {
       return []
@@ -74,7 +86,9 @@ function generateAltTextSelector(element: Element): string | undefined {
     return undefined
   }
 
-  const matches = queryAllByAltText(document.body, alt, { exact: true })
+  const matches = queryAll([
+    { name: 'internal:attr', body: `[alt=${JSON.stringify(alt)}s]` },
+  ])
 
   if (matches.length !== 1) {
     return undefined
@@ -94,9 +108,9 @@ function generateLabelSelector(
   for (const label of labels) {
     const trimmed = label.trim()
 
-    const matches = queryAllByLabelText(document.body, trimmed, {
-      exact: true,
-    })
+    const matches = queryAll([
+      { name: 'internal:label', body: `${JSON.stringify(trimmed)}s` },
+    ])
 
     if (!matches.includes(element)) {
       continue
@@ -126,9 +140,12 @@ function generatePlaceholderSelector(element: Element): string | undefined {
     return undefined
   }
 
-  const matches = queryAllByPlaceholderText(document.body, placeholder, {
-    exact: true,
-  })
+  const matches = queryAll([
+    {
+      name: 'internal:attr',
+      body: `[placeholder=${JSON.stringify(placeholder)}s]`,
+    },
+  ])
 
   if (matches.length !== 1) {
     return undefined
@@ -152,7 +169,9 @@ function generateTitleSelector(element: Element): string | undefined {
     return undefined
   }
 
-  const matches = queryAllByTitle(document.body, title, { exact: true })
+  const matches = queryAll([
+    { name: 'internal:attr', body: `[title=${JSON.stringify(title)}s]` },
+  ])
 
   if (matches.length !== 1) {
     return undefined
@@ -176,7 +195,9 @@ function generateTestIdSelector(element: Element): string | undefined {
     return undefined
   }
 
-  const matches = queryAllByTestId(document.body, testId)
+  const matches = queryAll([
+    { name: 'internal:attr', body: `[data-testid=${JSON.stringify(testId)}s]` },
+  ])
 
   if (matches.length > 1 || !matches.includes(element)) {
     return undefined

--- a/src/utils/selectors.test.ts
+++ b/src/utils/selectors.test.ts
@@ -31,13 +31,13 @@ describe('findElementsBySelector', () => {
     expect(full).toHaveLength(1)
   })
 
-  it('defaults role name to exact match when exact is omitted', () => {
+  it('defaults role name to substring match when exact is omitted', () => {
     document.body.innerHTML = '<button type="button">Submit</button>'
     const partial = findElementsBySelector(document.body, {
       type: 'role',
       role: 'button',
       name: { value: 'Sub' },
     })
-    expect(partial).toHaveLength(0)
+    expect(partial).toHaveLength(1)
   })
 })

--- a/src/utils/selectors.ts
+++ b/src/utils/selectors.ts
@@ -1,80 +1,113 @@
-import {
-  queryAllByAltText,
-  queryAllByLabelText,
-  queryAllByPlaceholderText,
-  queryAllByRole,
-  queryAllByTestId,
-  queryAllByText,
-  queryAllByTitle,
-} from '@testing-library/dom'
-
+import { InjectedScript } from '@/browser/injectedScript'
 import { NodeSelector } from '@/schemas/selectors'
 
-// Same implementation as `@testing-library/dom` `fuzzyMatches` with identity normalizer.
-function fuzzyMatch(accessibleName: string, substring: string): boolean {
-  if (typeof accessibleName !== 'string') {
-    return false
-  }
+let _injectedScript: InjectedScript | null = null
 
-  return accessibleName.toLowerCase().includes(substring.toLowerCase())
+function getInjectedScript(): InjectedScript {
+  if (!_injectedScript) {
+    _injectedScript = new InjectedScript()
+  }
+  return _injectedScript
+}
+
+// exact: true → "value"s (case-sensitive exact match)
+// exact: false | undefined → "value"i (case-insensitive substring match, Playwright default)
+function textMatcherBody(value: string, exact?: boolean): string {
+  return `${JSON.stringify(value)}${exact === true ? 's' : 'i'}`
+}
+
+function attrBody(attr: string, value: string, exact?: boolean): string {
+  return `[${attr}=${JSON.stringify(value)}${exact === true ? 's' : 'i'}]`
 }
 
 /**
  * Find elements in the DOM using a NodeSelector.
- * This function supports all selector types (css, role, test-id, alt, label, placeholder, text, title).
+ * Uses the same selector engine as k6 browser (Playwright) for consistent behavior.
  */
 export function findElementsBySelector(
   container: HTMLElement,
   selector: NodeSelector
 ): Element[] {
+  const script = getInjectedScript()
+
+  let parts: { name: string; body: string }[]
+
   switch (selector.type) {
     case 'css':
-      return Array.from(container.querySelectorAll(selector.selector))
+      parts = [{ name: 'css', body: selector.selector }]
+      break
 
     case 'test-id':
-      return queryAllByTestId(container, selector.testId)
+      parts = [
+        {
+          name: 'internal:attr',
+          body: `[data-testid=${JSON.stringify(selector.testId)}s]`,
+        },
+      ]
+      break
 
     case 'role': {
-      const { role, name } = selector
-
-      if (name === undefined) {
-        return queryAllByRole(container, role)
+      let body = selector.role
+      if (selector.name !== undefined) {
+        body += `[name=${JSON.stringify(selector.name.value)}${selector.name.exact === true ? 's' : 'i'}]`
       }
-
-      return queryAllByRole(container, role, {
-        name:
-          name.exact === false
-            ? (accessibleName) => fuzzyMatch(accessibleName, name.value)
-            : name.value,
-      })
+      parts = [{ name: 'internal:role', body }]
+      break
     }
 
     case 'alt':
-      return queryAllByAltText(container, selector.text.value, {
-        exact: selector.text.exact,
-      })
+      parts = [
+        {
+          name: 'internal:attr',
+          body: attrBody('alt', selector.text.value, selector.text.exact),
+        },
+      ]
+      break
 
     case 'label':
-      return queryAllByLabelText(container, selector.text.value, {
-        exact: selector.text.exact,
-      })
+      parts = [
+        {
+          name: 'internal:label',
+          body: textMatcherBody(selector.text.value, selector.text.exact),
+        },
+      ]
+      break
 
     case 'placeholder':
-      return queryAllByPlaceholderText(container, selector.text.value, {
-        exact: selector.text.exact,
-      })
+      parts = [
+        {
+          name: 'internal:attr',
+          body: attrBody(
+            'placeholder',
+            selector.text.value,
+            selector.text.exact
+          ),
+        },
+      ]
+      break
 
     case 'text':
-      return queryAllByText(container, selector.text.value, {
-        exact: selector.text.exact,
-      })
+      parts = [
+        {
+          name: 'internal:text',
+          body: textMatcherBody(selector.text.value, selector.text.exact),
+        },
+      ]
+      break
 
     case 'title':
-      return queryAllByTitle(container, selector.text.value, {
-        exact: selector.text.exact,
-      })
+      parts = [
+        {
+          name: 'internal:attr',
+          body: attrBody('title', selector.text.value, selector.text.exact),
+        },
+      ]
+      break
 
     default:
       return []
   }
+
+  const result = script.querySelectorAll({ parts }, container)
+  return typeof result === 'string' ? [] : result
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

So far we have been relying on the @testing-library/dom package to query the DOM using alternate selectors such as `getByRole` and `getByAltText`. This implementation, however, differs from the implementation in k6/browser and might cause some inconsistencies between generated selectors, element highlights, etc.

To fix this, this PR adds the same `injected_script.js` that is used by k6/browser (with some slight modifications to allow it to run in our recorder)

## How to Test

1. Record a page
    * Inspect generated selectors
    * Check that element highlights is working
3. Test highlighting in browser editor
4. Test highlighting in debugger

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it swaps the selector-matching implementation (including role/name matching defaults) and vendors a large third-party injected script, which could subtly change element targeting/highlighting behavior across the recorder and selector utilities.
> 
> **Overview**
> Refactors selector querying to use a vendored Playwright/k6 `InjectedScript` engine instead of `@testing-library/dom`, aiming to make recorded selectors, highlighting, and element lookup consistent with k6 browser behavior.
> 
> Updates both the recorder target selector generation and `findElementsBySelector` to build Playwright-style selector parts (`internal:role`, `internal:attr`, `internal:label`, `internal:text`) and changes role name matching so omitted `exact` defaults to *substring* matching (test updated accordingly). Adds the large `src/browser/injectedScript.js` (with a small k6-specific early-load workaround) plus a `injectedScript.d.ts`, ignores the JS file in ESLint, and removes `@testing-library/dom` from dependencies (lockfile adjusted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf110e0fb033000b0fbaa1268d04f7f99c3ac0f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->