### PR TITLE
chore: Add local claude setting files and folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,8 @@ resources/browser
 # Entry script
 resources/entrypoint.js
 resources/replay.js
+
+# Local claude settings
+.claude/settings.local.json
+.claude/CLAUDE.local.md
+.claude/worktrees


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the following files and folders to gitignore:

* `.claude/settings.local.json`
* `.claude/CLAUDE.local.md`
* `.claude/worktrees`

The two `.local` files should be ignored according to the [docs](https://code.claude.com/docs/en/settings#available-scopes). Ignoring `.claude/worktress` lets you work using `claude --worktree` without upsetting `git`.

## How to Test

Doesn't seem necessary to test, but you could try and add the files and see that they are ignored?

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.gitignore` to exclude local Claude-specific files and directories, with no runtime or build logic changes.
> 
> **Overview**
> Updates `.gitignore` to ignore local Claude artifacts: `.claude/settings.local.json`, `.claude/CLAUDE.local.md`, and `.claude/worktrees`, preventing developer-specific configuration/worktree files from being committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c92b0a69fecc47d20796d414436b764834ea943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->