### PR TITLE
chore: Migrate recording + browser event schema to Zod v4

### DIFF
--- a/src/recorder/browser/messaging/index.ts
+++ b/src/recorder/browser/messaging/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { EventEmitter } from '@/utils/events'
 

--- a/src/recorder/browser/messaging/transports/transport.ts
+++ b/src/recorder/browser/messaging/transports/transport.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { EventEmitter } from '@/utils/events'
 

--- a/src/recorder/browser/messaging/types.ts
+++ b/src/recorder/browser/messaging/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { BrowserEventSchema } from '@/schemas/recording'
 import { NodeSelectorSchema } from '@/schemas/selectors'

--- a/src/schemas/recording/browser/v1/index.ts
+++ b/src/schemas/recording/browser/v1/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { BrowserEventsSchema as BrowserEventsSchemaV2 } from '../v2'
 

--- a/src/schemas/recording/browser/v2/index.ts
+++ b/src/schemas/recording/browser/v2/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 const AriaDetailsSchema = z.object({
   roles: z.array(z.string()),

--- a/src/schemas/recording/har/index.ts
+++ b/src/schemas/recording/har/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import { HarEntry, HarPage } from '@/types/recording'
 

--- a/src/schemas/recording/index.ts
+++ b/src/schemas/recording/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 import * as v1 from './browser/v1'
 import * as v2 from './browser/v2'

--- a/src/schemas/selectors.ts
+++ b/src/schemas/selectors.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod/v4'
 
 export const CssNodeSelectorSchema = z.object({
   type: z.literal('css'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We have two implementation of selectors in the code (`NodeSelector` and `ActionLocator`) and I want to remove one of them. The problem is that their schemas use different versions of Zod. `ActionLocator` is implemented in `zod/v4` and `NodeSelector` uses `zod/v3`.

This PR updates the recording and browser events schemas to use the `zod/v4` module instead.

## How to Test

Check that you can open a recording.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although the diff is mostly import-path changes, it impacts runtime validation/parsing for recordings, HAR logs, selectors, and extension messaging, where subtle Zod v3→v4 behavior differences could break loading existing recordings or message decoding.
> 
> **Overview**
> Updates recorder messaging and all recording-related schemas (browser events v1/v2, HAR `LogSchema`, `RecordingSchema`, and `NodeSelectorSchema`) to import Zod via `zod/v4` instead of `zod`, aligning these schemas with the v4-based selector implementation and removing mixed-Zod-version usage during recording/message parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530f6710697f3dc9db6c0185e082fbd144afce08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->