### PR TITLE
internal(browser): Support middle and right click in browser test editor

### DIFF
--- a/src/codegen/browser/test.test.ts
+++ b/src/codegen/browser/test.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
-import { convertEventsToTest } from './test'
+import { buildClickAction } from '@/test/factories/browserActions'
+
+import { convertActionsToTest, convertEventsToTest } from './test'
 
 describe('convertEventsToTest', () => {
   it('should not wait for navigation when submit-form is not followed by an implicit navigation', () => {
@@ -78,6 +80,52 @@ describe('convertEventsToTest', () => {
       page: {
         nodeId: 'tab-1',
       },
+    })
+  })
+})
+
+describe('convertActionsToTest', () => {
+  it('defaults to a left click when no options are set', () => {
+    const test = convertActionsToTest({
+      browserActions: [buildClickAction({ options: undefined })],
+    })
+
+    const click = test.defaultScenario?.nodes.find(
+      (node) => node.type === 'click'
+    )
+    expect(click?.button).toBe('left')
+  })
+
+  it('reads options.button so middle and right clicks reach the IR', () => {
+    const test = convertActionsToTest({
+      browserActions: [
+        buildClickAction({ options: { button: 'right' } }),
+        buildClickAction({ options: { button: 'middle' } }),
+      ],
+    })
+
+    const clicks =
+      test.defaultScenario?.nodes.filter((node) => node.type === 'click') ?? []
+    expect(clicks.map((c) => c.button)).toEqual(['right', 'middle'])
+  })
+
+  it('translates options.modifiers into the IR modifier flags', () => {
+    const test = convertActionsToTest({
+      browserActions: [
+        buildClickAction({
+          options: { button: 'left', modifiers: ['Control', 'Shift'] },
+        }),
+      ],
+    })
+
+    const click = test.defaultScenario?.nodes.find(
+      (node) => node.type === 'click'
+    )
+    expect(click?.modifiers).toEqual({
+      ctrl: true,
+      shift: true,
+      alt: false,
+      meta: false,
     })
   })
 })

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -5,6 +5,7 @@ import {
   BrowserEvent,
   BrowserEventTarget,
 } from '@/schemas/recording'
+import { toClickButton, toClickModifiers } from '@/utils/clickOptions'
 import { exhaustive } from '@/utils/typescript'
 import {
   BrowserActionInstance,
@@ -387,13 +388,8 @@ function buildBrowserNodeGraphFromActions(
         return {
           type: 'click',
           nodeId: crypto.randomUUID(),
-          button: 'left',
-          modifiers: {
-            ctrl: false,
-            shift: false,
-            alt: false,
-            meta: false,
-          },
+          button: toClickButton(action.options),
+          modifiers: toClickModifiers(action.options?.modifiers),
           inputs: {
             locator: getLocator(action.locator),
           },

--- a/src/main/runner/schema.ts
+++ b/src/main/runner/schema.ts
@@ -371,6 +371,14 @@ export type GenericPageAction = z.infer<typeof GenericPageActionSchema>
 export type LocatorCheckAction = z.infer<typeof LocatorCheckActionSchema>
 export type LocatorClearAction = z.infer<typeof LocatorClearActionSchema>
 export type LocatorClickAction = z.infer<typeof LocatorClickActionSchema>
+
+export type LocatorClickButton = NonNullable<
+  NonNullable<LocatorClickAction['options']>['button']
+>
+
+export type LocatorClickModifier = NonNullable<
+  NonNullable<LocatorClickAction['options']>['modifiers']
+>[number]
 export type LocatorDoubleClickAction = z.infer<
   typeof LocatorDoubleClickActionSchema
 >

--- a/src/test/factories/browserActions.ts
+++ b/src/test/factories/browserActions.ts
@@ -1,0 +1,22 @@
+import { LocatorClickAction } from '@/main/runner/schema'
+import { WithEditorMetadata } from '@/views/BrowserTestEditor/types'
+
+export function buildClickAction(
+  overrides: Partial<WithEditorMetadata<LocatorClickAction>> = {}
+): WithEditorMetadata<LocatorClickAction> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.click',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'button',
+          options: { exact: false },
+        },
+      },
+    },
+    ...overrides,
+  }
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,30 @@
-import { vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import { afterEach, vi } from 'vitest'
 
 vi.mock('electron-log/main', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }))
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver =
+    ResizeObserverStub as unknown as typeof ResizeObserver
+}
+
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn()
+}
+
+if (typeof HTMLElement !== 'undefined' && !HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = vi.fn(() => false)
+  HTMLElement.prototype.releasePointerCapture = vi.fn()
+}
+
+afterEach(() => {
+  cleanup()
+})

--- a/src/utils/clickOptions.ts
+++ b/src/utils/clickOptions.ts
@@ -1,0 +1,40 @@
+import type {
+  LocatorClickAction,
+  LocatorClickButton,
+  LocatorClickModifier,
+} from '@/main/runner/schema'
+
+export interface ClickModifiers {
+  alt: boolean
+  ctrl: boolean
+  meta: boolean
+  shift: boolean
+}
+
+const NO_MODIFIERS: ClickModifiers = {
+  alt: false,
+  ctrl: false,
+  meta: false,
+  shift: false,
+}
+
+export function toClickModifiers(
+  modifiers: LocatorClickModifier[] | undefined
+): ClickModifiers {
+  if (!modifiers || modifiers.length === 0) {
+    return { ...NO_MODIFIERS }
+  }
+
+  return {
+    alt: modifiers.includes('Alt'),
+    ctrl: modifiers.includes('Control'),
+    meta: modifiers.includes('Meta'),
+    shift: modifiers.includes('Shift'),
+  }
+}
+
+export function toClickButton(
+  options: LocatorClickAction['options']
+): LocatorClickButton {
+  return options?.button ?? 'left'
+}

--- a/src/views/BrowserTestEditor/ActionForms/forms/ClickButtonForm.tsx
+++ b/src/views/BrowserTestEditor/ActionForms/forms/ClickButtonForm.tsx
@@ -1,0 +1,33 @@
+import { Select } from '@radix-ui/themes'
+
+import { LocatorClickButton } from '@/main/runner/schema'
+
+const BUTTON_OPTIONS: { value: LocatorClickButton; label: string }[] = [
+  { value: 'left', label: 'Left' },
+  { value: 'middle', label: 'Middle' },
+  { value: 'right', label: 'Right' },
+]
+
+interface ClickButtonFormProps {
+  value: LocatorClickButton | undefined
+  onChange: (button: LocatorClickButton) => void
+}
+
+export function ClickButtonForm({ value, onChange }: ClickButtonFormProps) {
+  return (
+    <Select.Root size="1" value={value ?? 'left'} onValueChange={onChange}>
+      <Select.Trigger
+        variant="soft"
+        color="gray"
+        aria-label="Mouse button"
+      />
+      <Select.Content>
+        {BUTTON_OPTIONS.map((option) => (
+          <Select.Item key={option.value} value={option.value}>
+            {option.label}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  )
+}

--- a/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.test.tsx
+++ b/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.test.tsx
@@ -1,0 +1,79 @@
+import { Theme } from '@radix-ui/themes'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { HighlightSelectorProvider } from '@/components/HighlightSelectorProvider'
+import { LocatorClickAction } from '@/main/runner/schema'
+import { buildClickAction } from '@/test/factories/browserActions'
+
+import { WithEditorMetadata } from '../../types'
+
+import { ClickActionBody } from './ClickActionBody'
+
+type ClickAction = WithEditorMetadata<LocatorClickAction>
+
+function renderBody(
+  action: ClickAction,
+  onChange: (action: ClickAction) => void = vi.fn()
+) {
+  return render(
+    <Theme>
+      <HighlightSelectorProvider>
+        <ClickActionBody action={action} onChange={onChange} />
+      </HighlightSelectorProvider>
+    </Theme>
+  )
+}
+
+describe('ClickActionBody', () => {
+  it('renders "Left" in the button selector when options are undefined', () => {
+    renderBody(buildClickAction())
+
+    expect(screen.getByRole('combobox').textContent).toContain('Left')
+    expect(screen.getByText('click on')).toBeDefined()
+  })
+
+  it('renders "Middle" when options.button is "middle"', () => {
+    renderBody(buildClickAction({ options: { button: 'middle' } }))
+
+    expect(screen.getByRole('combobox').textContent).toContain('Middle')
+  })
+
+  it('renders "Right" when options.button is "right"', () => {
+    renderBody(buildClickAction({ options: { button: 'right' } }))
+
+    expect(screen.getByRole('combobox').textContent).toContain('Right')
+  })
+
+  it('writes options.button to onChange when a new button is selected', () => {
+    const handleChange = vi.fn<(action: ClickAction) => void>()
+    renderBody(buildClickAction(), handleChange)
+
+    const trigger = screen.getByRole('combobox')
+    fireEvent.click(trigger)
+
+    const rightOption = screen.getByRole('option', { name: 'Right' })
+    fireEvent.click(rightOption)
+
+    const updated = handleChange.mock.lastCall?.[0]
+    expect(updated?.options?.button).toBe('right')
+  })
+
+  it('preserves modifiers already present on options', () => {
+    const handleChange = vi.fn<(action: ClickAction) => void>()
+    renderBody(
+      buildClickAction({ options: { button: 'left', modifiers: ['Shift'] } }),
+      handleChange
+    )
+
+    const trigger = screen.getByRole('combobox')
+    fireEvent.click(trigger)
+
+    const middleOption = screen.getByRole('option', { name: 'Middle' })
+    fireEvent.click(middleOption)
+
+    const updated = handleChange.mock.lastCall?.[0]
+    expect(updated?.options?.button).toBe('middle')
+    expect(updated?.options?.modifiers).toEqual(['Shift'])
+  })
+})

--- a/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.tsx
+++ b/src/views/BrowserTestEditor/Actions/ClickAction/ClickActionBody.tsx
@@ -1,7 +1,8 @@
 import { Grid } from '@radix-ui/themes'
 
-import { LocatorClickAction } from '@/main/runner/schema'
+import { LocatorClickAction, LocatorClickButton } from '@/main/runner/schema'
 
+import { ClickButtonForm } from '../../ActionForms/forms/ClickButtonForm'
 import { LocatorForm } from '../../ActionForms/forms/LocatorForm'
 import { WithEditorMetadata } from '../../types'
 
@@ -17,14 +18,25 @@ export function ClickActionBody({ action, onChange }: ClickActionBodyProps) {
     onChange({ ...action, locator })
   }
 
+  const handleChangeButton = (button: LocatorClickButton) => {
+    onChange({
+      ...action,
+      options: { ...action.options, button },
+    })
+  }
+
   return (
     <Grid
-      columns="max-content minmax(0, max-content) 1fr"
+      columns="max-content max-content minmax(0, max-content) 1fr"
       gap="2"
       align="center"
       width="100%"
     >
-      Click
+      <ClickButtonForm
+        value={action.options?.button}
+        onChange={handleChangeButton}
+      />
+      click on
       <LocatorForm state={action.locator} onChange={handleChangeLocator} />
     </Grid>
   )

--- a/src/views/BrowserTestEditor/Actions/components/OptionsSummary.test.tsx
+++ b/src/views/BrowserTestEditor/Actions/components/OptionsSummary.test.tsx
@@ -1,0 +1,44 @@
+import { Theme } from '@radix-ui/themes'
+import { render, screen } from '@testing-library/react'
+import { ReactElement } from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { OptionsSummary } from './OptionsSummary'
+
+function renderWithTheme(ui: ReactElement) {
+  return render(<Theme>{ui}</Theme>)
+}
+
+describe('OptionsSummary', () => {
+  it('renders all option entries by default', () => {
+    renderWithTheme(
+      <OptionsSummary options={{ button: 'right', timeout: 1000 }} />
+    )
+
+    expect(screen.getByText(/button=right/)).toBeDefined()
+    expect(screen.getByText(/timeout=1000ms/)).toBeDefined()
+  })
+
+  it('hides keys listed in excludeKeys but keeps the rest', () => {
+    renderWithTheme(
+      <OptionsSummary
+        options={{ button: 'right', timeout: 1000 }}
+        excludeKeys={['button']}
+      />
+    )
+
+    expect(screen.queryByText(/button=/)).toBeNull()
+    expect(screen.getByText(/timeout=1000ms/)).toBeDefined()
+  })
+
+  it('renders nothing when every remaining entry is excluded', () => {
+    const { container } = renderWithTheme(
+      <OptionsSummary
+        options={{ button: 'middle' }}
+        excludeKeys={['button']}
+      />
+    )
+
+    expect(container.textContent).toBe('')
+  })
+})

--- a/src/views/BrowserTestEditor/Actions/components/OptionsSummary.tsx
+++ b/src/views/BrowserTestEditor/Actions/components/OptionsSummary.tsx
@@ -5,14 +5,21 @@ type OptionValue = string | number | boolean | null | undefined
 type OptionsSummaryProps = {
   options: unknown
   label?: string
+  excludeKeys?: readonly string[]
 }
 
 export function OptionsSummary({
   options,
   label = 'Options:',
+  excludeKeys,
 }: OptionsSummaryProps) {
+  const excluded = new Set(excludeKeys)
   const entries = Object.entries(normalizeOptions(options)).filter(
-    ([, value]) => {
+    ([key, value]) => {
+      if (excluded.has(key)) {
+        return false
+      }
+
       if (value === undefined || value === null) {
         return false
       }

--- a/src/views/BrowserTestEditor/EditableAction.tsx
+++ b/src/views/BrowserTestEditor/EditableAction.tsx
@@ -52,7 +52,12 @@ export function EditableAction({
           </IconButton>
         </Tooltip>
       </Flex>
-      {'options' in action && <OptionsSummary options={action.options} />}
+      {'options' in action && (
+        <OptionsSummary
+          options={action.options}
+          excludeKeys={editor.summaryExcludeKeys}
+        />
+      )}
     </Flex>
   )
 }

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -42,6 +42,7 @@ interface ActionEditorDefinition<M extends BrowserActionInstance['method']> {
   icon: ReactNode
   render: (props: ActionEditorProps<M>) => ReactElement
   create: () => ActionByMethod<M>
+  summaryExcludeKeys?: readonly string[]
 }
 
 type ActionEditorRegistry = {
@@ -154,6 +155,7 @@ const actionEditors: ActionEditorRegistry = {
         },
       },
     }),
+    summaryExcludeKeys: ['button'],
   },
   'locator.fill': {
     icon: <TextCursorInputIcon aria-hidden="true" />,

--- a/src/views/Validator/Browser/BrowserActionText.utils.ts
+++ b/src/views/Validator/Browser/BrowserActionText.utils.ts
@@ -3,19 +3,13 @@ import {
   LocatorClickAction,
   LocatorDoubleClickAction,
 } from '@/main/runner/schema'
+import { toClickButton, toClickModifiers } from '@/utils/clickOptions'
 
 export function toClickDetails(
   action: LocatorClickAction | LocatorDoubleClickAction
 ): ClickDetails {
-  const modifiers = action.options?.modifiers ?? []
-
   return {
-    button: action.options?.button ?? 'left',
-    modifiers: {
-      alt: modifiers.includes('Alt'),
-      ctrl: modifiers.includes('Control'),
-      meta: modifiers.includes('Meta'),
-      shift: modifiers.includes('Shift'),
-    },
+    button: toClickButton(action.options),
+    modifiers: toClickModifiers(action.options?.modifiers),
   }
 }


### PR DESCRIPTION
## Description

Add support for `left | right | middle` clicks actions in browser tests.

<img width="2058" height="1384" alt="screencapture 2026-04-27 at 14 01 08@2x" src="https://github.com/user-attachments/assets/941350cc-0d95-4f1b-8c44-aca9f83e601f" />


## How to Test

1. Create a browser test and add click action
3. Confirm the click action now reads `[Left ▾] click on <locator>`. 
4. Switch to the **Script** tab and confirm:
   - Left → `await page.locator(...).click();`
   - Middle → `await page.locator(...).click({ button: "middle" });`
   - Right → `await page.locator(...).click({ button: "right" });`
5. Reload the editor and confirm the selection persists.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Resolves https://github.com/grafana/k6-studio/issues/1196

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates click action editing and codegen to preserve and emit `options.button`/modifier flags; risk is moderate because it changes the generated test IR for click actions and adds new UI behavior, but is scoped and covered by new unit/component tests.
> 
> **Overview**
> Adds **middle/right click support** end-to-end in the browser test editor: the click action UI now includes a mouse-button dropdown and persists the selection in `action.options.button`.
> 
> Updates browser-test codegen (`convertActionsToTest`) to stop hardcoding left-click/no-modifiers and instead map `options.button` and `options.modifiers` into the click node via shared `toClickButton`/`toClickModifiers` helpers (also reused by validator click text rendering).
> 
> Improves option display by adding `excludeKeys` to `OptionsSummary` and letting action editors (click) suppress duplicate rendering of `button`; adds supporting types, test factories, jsdom/Radix polyfills in test setup, and new unit/component tests for the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 081316c732e2aa4b1c9bb7fb192525a776ffb3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->