### PR TITLE
refactor: Use absolute paths for routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
         "node-forge": "^1.3.2",
         "openid-client": "^6.1.7",
         "papaparse": "^5.5.1",
-        "pathe": "^2.0.3",
         "plist": "^3.1.0",
         "prettier": "^3.3.2",
         "react": "^19.2.4",
@@ -281,7 +280,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -662,7 +660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -686,7 +683,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -708,7 +704,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1236,7 +1231,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1721,7 +1715,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2553,7 +2546,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2915,7 +2907,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3226,7 +3217,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3248,7 +3238,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3261,7 +3250,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -3286,7 +3274,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -3791,7 +3778,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -3818,7 +3804,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6521,6 +6506,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6541,6 +6527,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6550,7 +6537,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -6651,7 +6639,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6937,7 +6926,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -7017,7 +7005,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7028,7 +7015,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8462,7 +8448,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9353,7 +9338,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -11265,7 +11249,6 @@
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -11662,7 +11645,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11841,7 +11823,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13662,7 +13643,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14497,7 +14477,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -15504,6 +15483,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15979,7 +15959,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -16993,6 +16972,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pe-library": {
@@ -17254,6 +17234,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17269,6 +17250,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17281,7 +17263,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proc-log": {
       "version": "2.0.1",
@@ -17623,7 +17606,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17645,7 +17627,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17658,7 +17639,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -18571,7 +18551,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19869,7 +19848,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20162,8 +20140,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -20313,7 +20290,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20738,7 +20714,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -20850,7 +20825,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21543,7 +21517,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "node-forge": "^1.3.2",
     "openid-client": "^6.1.7",
     "papaparse": "^5.5.1",
-    "pathe": "^2.0.3",
     "plist": "^3.1.0",
     "prettier": "^3.3.2",
     "react": "^19.2.4",

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -6,10 +6,10 @@ import { GeneratorFileData } from '@/types/generator'
 import { CustomCodeValue, ParameterizationRule, TestRule } from '@/types/rules'
 import { DataFile, Variable } from '@/types/testData'
 import { ThinkTime } from '@/types/testOptions'
-import { getFileNameWithoutExtension } from '@/utils/file'
 import { safeBtoa } from '@/utils/format'
 import { groupProxyData } from '@/utils/groups'
 import { getContentTypeWithCharsetHeader } from '@/utils/headers'
+import * as path from '@/utils/path'
 import { exhaustive } from '@/utils/typescript'
 
 import {
@@ -100,7 +100,7 @@ export function generateDataFileDeclarations(files: DataFile[]): string {
 
   const fileKeyValuePairs = files
     .map(({ name }) => {
-      const displayName = getFileNameWithoutExtension(name)
+      const displayName = path.name(name)
       const isCSV = name.toLowerCase().endsWith('csv')
 
       if (isCSV) {

--- a/src/components/FileNameHeader.tsx
+++ b/src/components/FileNameHeader.tsx
@@ -16,7 +16,7 @@ import { FileTypeToLabel } from '@/constants/files'
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
 import { useRenameFile } from '@/hooks/useRenameFile'
 import { StudioFile } from '@/types'
-import { getFileExtension } from '@/utils/file'
+import * as path from '@/utils/path'
 
 import { FieldGroup } from './Form'
 
@@ -35,7 +35,7 @@ export function FileNameHeader({
 }: FileNameHeaderProps) {
   const subTitleRef = useRef<HTMLHeadingElement>(null)
   const hasEllipsis = useOverflowCheck(subTitleRef)
-  const fileExtension = getFileExtension(file.fileName)
+  const fileExtension = path.extname(file.fileName).slice(1)
 
   return (
     <>
@@ -75,7 +75,7 @@ interface RenameFileDialogProps {
 function RenameFileDialog({ file }: RenameFileDialogProps) {
   const [isOpen, setIsOpen] = useState(false)
   const { mutateAsync, isPending } = useRenameFile(file)
-  const fileExtension = getFileExtension(file.fileName)
+  const fileExtension = path.extname(file.fileName).slice(1)
 
   const {
     register,

--- a/src/components/FileTree/File.tsx
+++ b/src/components/FileTree/File.tsx
@@ -6,7 +6,8 @@ import { useBoolean } from 'react-use'
 
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
 import { useRenameFile } from '@/hooks/useRenameFile'
-import { getFileExtension, getViewPath } from '@/utils/file'
+import { getViewPath } from '@/routeMap'
+import { getFileExtension } from '@/utils/file'
 
 import { HighlightedText } from '../HighlightedText'
 
@@ -131,7 +132,7 @@ function EditableFile({
             }
           `,
         ]}
-        to={getViewPath(file.type, file.fileName)}
+        to={getViewPath(file.type, file.path)}
       >
         <HighlightedText text={file.displayName} matches={file.matches} />
       </NavLink>

--- a/src/components/FileTree/File.tsx
+++ b/src/components/FileTree/File.tsx
@@ -7,7 +7,7 @@ import { useBoolean } from 'react-use'
 import { useOverflowCheck } from '@/hooks/useOverflowCheck'
 import { useRenameFile } from '@/hooks/useRenameFile'
 import { getViewPath } from '@/routeMap'
-import { getFileExtension } from '@/utils/file'
+import * as path from '@/utils/path'
 
 import { HighlightedText } from '../HighlightedText'
 
@@ -84,7 +84,7 @@ function EditableFile({
 
   const { mutateAsync: renameFile } = useRenameFile(file)
 
-  const fileExtension = getFileExtension(file.fileName)
+  const fileExtension = path.extname(file.fileName).slice(1)
 
   const handleSave = async (newValue: string) => {
     const newFileName = `${newValue.trim()}.${fileExtension}`

--- a/src/components/FileTree/FileList.tsx
+++ b/src/components/FileTree/FileList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react'
 
-import { useActiveFileName } from '@/hooks/useCurrentFile'
+import { useActiveFilePath } from '@/hooks/useCurrentFile'
 
 import { File, NoFileMessage } from './File'
 import { FileItem } from './types'
@@ -11,7 +11,7 @@ interface FileListProps {
 }
 
 export function FileList({ files, noFilesMessage }: FileListProps) {
-  const activeFileName = useActiveFileName()
+  const activeFilePath = useActiveFilePath()
 
   if (files.length === 0) {
     return <NoFileMessage message={noFilesMessage} />
@@ -27,7 +27,7 @@ export function FileList({ files, noFilesMessage }: FileListProps) {
     >
       {files.map((file) => (
         <li key={file.displayName}>
-          <File file={file} isSelected={file.fileName === activeFileName} />
+          <File file={file} isSelected={file.path === activeFilePath} />
         </li>
       ))}
     </ul>

--- a/src/handlers/browserTest/index.ts
+++ b/src/handlers/browserTest/index.ts
@@ -23,7 +23,7 @@ export function initialize() {
       actions: [],
     }
 
-    const fileName = await createFileWithUniqueName({
+    const filePath = await createFileWithUniqueName({
       data: JSON.stringify(emptyBrowserTest, null, 2),
       directory: BROWSER_TESTS_PATH,
       ext: K6_BROWSER_TEST_FILE_EXTENSION,
@@ -34,7 +34,7 @@ export function initialize() {
       event: UsageEventName.BrowserTestCreated,
     })
 
-    return fileName
+    return filePath
   })
 
   ipcMain.handle(BrowserTestHandler.Open, async (_, fileName: string) => {

--- a/src/handlers/dataFiles/index.ts
+++ b/src/handlers/dataFiles/index.ts
@@ -37,7 +37,7 @@ export function initialize() {
       COPYFILE_EXCL
     )
 
-    return path.basename(filePath)
+    return path.join(DATA_FILES_PATH, path.basename(filePath))
   })
 
   ipcMain.handle(

--- a/src/handlers/generator/index.ts
+++ b/src/handlers/generator/index.ts
@@ -21,7 +21,7 @@ export function initialize() {
   ipcMain.handle(GeneratorHandler.Create, async (_, recordingPath: string) => {
     console.log(`${GeneratorHandler.Create} event received`)
     const generator = createNewGeneratorFile(recordingPath)
-    const fileName = await createFileWithUniqueName({
+    const filePath = await createFileWithUniqueName({
       data: JSON.stringify(generator, null, 2),
       directory: GENERATORS_PATH,
       ext: K6_GENERATOR_FILE_EXTENSION,
@@ -32,7 +32,7 @@ export function initialize() {
       event: UsageEventName.GeneratorCreated,
     })
 
-    return fileName
+    return filePath
   })
 
   ipcMain.handle(

--- a/src/handlers/har/index.ts
+++ b/src/handlers/har/index.ts
@@ -17,7 +17,7 @@ export function initialize() {
     async (_, data: Recording, prefix: string) => {
       console.info(`${HarHandler.SaveFile} event received`)
 
-      const fileName = await createFileWithUniqueName({
+      const filePath = await createFileWithUniqueName({
         data: JSON.stringify(data, null, 2),
         directory: RECORDINGS_PATH,
         ext: '.har',
@@ -28,7 +28,7 @@ export function initialize() {
         event: UsageEventName.RecordingCreated,
       })
 
-      return fileName
+      return filePath
     }
   )
 

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -138,6 +138,8 @@ export function initialize() {
           title: 'Script exported successfully',
           status: 'success',
         })
+
+        return filePath
       } catch (error) {
         sendToast(browserWindow.webContents, {
           title: 'Failed to export the script',

--- a/src/handlers/script/preload.ts
+++ b/src/handlers/script/preload.ts
@@ -31,7 +31,7 @@ export function saveScript(script: string, fileName: string) {
     ScriptHandler.Save,
     script,
     fileName
-  ) as Promise<void>
+  ) as Promise<string | undefined>
 }
 
 export function runScript(scriptPath: string) {

--- a/src/hooks/useCreateBrowserTest.ts
+++ b/src/hooks/useCreateBrowserTest.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { getRoutePath } from '@/routeMap'
+import { getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 
 export function useCreateBrowserTest() {
@@ -12,11 +12,7 @@ export function useCreateBrowserTest() {
     try {
       const fileName = await window.studio.browserTest.create()
 
-      navigate(
-        getRoutePath('browserTestEditor', {
-          fileName: encodeURIComponent(fileName),
-        })
-      )
+      navigate(getViewPath('browser-test', fileName))
     } catch {
       showToast({
         status: 'error',

--- a/src/hooks/useCreateGenerator.test.ts
+++ b/src/hooks/useCreateGenerator.test.ts
@@ -3,7 +3,7 @@ import { act } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getRoutePath } from '@/routeMap'
+import { getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 
 import { useCreateGenerator } from './useCreateGenerator'
@@ -11,9 +11,11 @@ import { useCreateGenerator } from './useCreateGenerator'
 vi.mock('react-router-dom', () => ({
   useNavigate: vi.fn(),
 }))
-vi.mock('@/routeMap', () => ({
-  getRoutePath: vi.fn(),
-}))
+vi.mock('@/routeMap', () => {
+  return {
+    getViewPath: vi.fn(),
+  }
+})
 vi.mock('@/store/ui/useToast', () => ({
   useToast: vi.fn(),
 }))
@@ -34,13 +36,13 @@ describe('useCreateGenerator', () => {
   })
 
   it('should navigate to the correct path on successful generator creation', async () => {
-    const fileName = 'test-file.json'
-    const routePath = '/generator/test-file.json'
+    const filePath = '/some/path/test-file.json'
+    const routePath = `/generator/${encodeURIComponent(filePath)}`
 
-    vi.mocked(getRoutePath).mockReturnValue(routePath)
+    vi.mocked(getViewPath).mockReturnValue(routePath)
     vi.stubGlobal('studio', {
       generator: {
-        createGenerator: vi.fn().mockResolvedValue(fileName),
+        createGenerator: vi.fn().mockResolvedValue(filePath),
         saveGenerator: vi.fn(),
         loadGenerator: vi.fn(),
       },
@@ -53,7 +55,9 @@ describe('useCreateGenerator', () => {
     })
 
     expect(window.studio.generator.createGenerator).toHaveBeenCalledWith('')
-    expect(navigate).toHaveBeenCalledWith(routePath)
+    expect(navigate).toHaveBeenCalledWith(
+      '/generator/%2Fsome%2Fpath%2Ftest-file.json'
+    )
   })
 
   it('should show a toast message on failure', async () => {

--- a/src/hooks/useCreateGenerator.ts
+++ b/src/hooks/useCreateGenerator.ts
@@ -2,7 +2,7 @@ import log from 'electron-log/renderer'
 import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { getRoutePath } from '@/routeMap'
+import { getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 
 export function useCreateGenerator() {
@@ -15,9 +15,7 @@ export function useCreateGenerator() {
         const fileName =
           await window.studio.generator.createGenerator(recordingPath)
 
-        navigate(
-          getRoutePath('generator', { fileName: encodeURIComponent(fileName) })
-        )
+        navigate(getViewPath('generator', fileName))
       } catch (error) {
         showToast({
           status: 'error',

--- a/src/hooks/useCurrentFile.ts
+++ b/src/hooks/useCurrentFile.ts
@@ -1,23 +1,26 @@
-import * as path from 'pathe'
+import { parse } from 'pathe'
 import { useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
 import { StudioFile, StudioFileType } from '@/types'
 
-export function useActiveFileName() {
-  const { fileName } = useParams<{ fileName: string }>()
+export function useActiveFilePath() {
+  const { filePath } = useParams<{ filePath: string }>()
 
-  return fileName
+  return filePath
 }
 
 export function useCurrentFile(type: StudioFileType): StudioFile {
-  const file = useActiveFileName()
+  const filePath = useActiveFilePath()
 
-  invariant(file, 'fileName param is required')
+  invariant(filePath, 'filePath param is required')
+
+  const { base, name } = parse(filePath)
 
   return {
     type,
-    displayName: path.basename(file, path.extname(file)),
-    fileName: file,
+    path: filePath,
+    fileName: base,
+    displayName: name,
   }
 }

--- a/src/hooks/useCurrentFile.ts
+++ b/src/hooks/useCurrentFile.ts
@@ -1,8 +1,8 @@
-import { parse } from 'pathe'
 import { useParams } from 'react-router-dom'
 import invariant from 'tiny-invariant'
 
 import { StudioFile, StudioFileType } from '@/types'
+import * as path from '@/utils/path'
 
 export function useActiveFilePath() {
   const { filePath } = useParams<{ filePath: string }>()
@@ -15,7 +15,7 @@ export function useCurrentFile(type: StudioFileType): StudioFile {
 
   invariant(filePath, 'filePath param is required')
 
-  const { base, name } = parse(filePath)
+  const { base, name } = path.parse(filePath)
 
   return {
     type,

--- a/src/hooks/useDeleteFile.test.ts
+++ b/src/hooks/useDeleteFile.test.ts
@@ -20,6 +20,7 @@ describe('useDeleteFile', () => {
     type: 'recording',
     fileName: 'file-name',
     displayName: 'test-file',
+    path: '/recordings/file-name',
   }
 
   beforeEach(() => {

--- a/src/hooks/useImportDataFile.ts
+++ b/src/hooks/useImportDataFile.ts
@@ -1,9 +1,9 @@
 import log from 'electron-log/renderer'
+import { parse } from 'pathe'
 import { useCallback } from 'react'
 
 import { useStudioUIStore } from '@/store/ui'
 import { useToast } from '@/store/ui/useToast'
-import { getFileNameWithoutExtension } from '@/utils/file'
 
 export function useImportDataFile() {
   const showToast = useToast()
@@ -11,11 +11,13 @@ export function useImportDataFile() {
 
   return useCallback(async () => {
     try {
-      const fileName = await window.studio.data.importFile()
+      const filePath = await window.studio.data.importFile()
 
-      if (fileName) {
+      if (filePath) {
+        const { base, name } = parse(filePath)
+
         showToast({
-          title: `Imported ${fileName}`,
+          title: `Imported ${base}`,
           status: 'success',
         })
 
@@ -24,12 +26,13 @@ export function useImportDataFile() {
         // is actually missing. To prevent this, we optimistically update the file list.
         addFile({
           type: 'data-file',
-          fileName,
-          displayName: getFileNameWithoutExtension(fileName),
+          path: filePath,
+          fileName: base,
+          displayName: name,
         })
       }
 
-      return fileName
+      return filePath
     } catch (error) {
       showToast({
         title: 'Failed to import data file',

--- a/src/hooks/useImportDataFile.ts
+++ b/src/hooks/useImportDataFile.ts
@@ -1,9 +1,9 @@
 import log from 'electron-log/renderer'
-import { parse } from 'pathe'
 import { useCallback } from 'react'
 
 import { useStudioUIStore } from '@/store/ui'
 import { useToast } from '@/store/ui/useToast'
+import * as path from '@/utils/path'
 
 export function useImportDataFile() {
   const showToast = useToast()
@@ -14,7 +14,7 @@ export function useImportDataFile() {
       const filePath = await window.studio.data.importFile()
 
       if (filePath) {
-        const { base, name } = parse(filePath)
+        const { base, name } = path.parse(filePath)
 
         showToast({
           title: `Imported ${base}`,

--- a/src/hooks/useRenameFile.ts
+++ b/src/hooks/useRenameFile.ts
@@ -1,14 +1,15 @@
 import { useMutation } from '@tanstack/react-query'
+import { dirname, join, parse } from 'pathe'
 import { useNavigate } from 'react-router-dom'
 
-import { useActiveFileName } from '@/hooks/useCurrentFile'
+import { useActiveFilePath } from '@/hooks/useCurrentFile'
+import { getViewPath } from '@/routeMap'
 import { useStudioUIStore } from '@/store/ui'
 import { StudioFile } from '@/types'
-import { getFileNameWithoutExtension, getViewPath } from '@/utils/file'
 import { queryClient } from '@/utils/query'
 
 export function useRenameFile(file: StudioFile) {
-  const activeFileName = useActiveFileName()
+  const activeFilePath = useActiveFilePath()
 
   const navigate = useNavigate()
   const addFile = useStudioUIStore((state) => state.addFile)
@@ -21,16 +22,18 @@ export function useRenameFile(file: StudioFile) {
       // There's a slight delay between the add and remove callbacks being triggered,
       // causing the UI to flicker because it thinks the renamed file is actually
       // a new file. To prevent this, we optimistically update the file list.
+      const newPath = join(dirname(file.path), newName)
       const updatedFile = {
         ...file,
-        displayName: getFileNameWithoutExtension(newName),
+        path: newPath,
+        displayName: parse(newName).name,
         fileName: newName,
       }
 
       removeFile(file)
       addFile(updatedFile)
 
-      if (activeFileName !== file.fileName) {
+      if (activeFilePath !== file.path) {
         return
       }
 
@@ -41,7 +44,7 @@ export function useRenameFile(file: StudioFile) {
         )
       }
 
-      navigate(getViewPath(file.type, newName), { replace: true })
+      navigate(getViewPath(file.type, newPath), { replace: true })
     },
   })
 }

--- a/src/hooks/useRenameFile.ts
+++ b/src/hooks/useRenameFile.ts
@@ -1,11 +1,11 @@
 import { useMutation } from '@tanstack/react-query'
-import { dirname, join, parse } from 'pathe'
 import { useNavigate } from 'react-router-dom'
 
 import { useActiveFilePath } from '@/hooks/useCurrentFile'
 import { getViewPath } from '@/routeMap'
 import { useStudioUIStore } from '@/store/ui'
 import { StudioFile } from '@/types'
+import * as path from '@/utils/path'
 import { queryClient } from '@/utils/query'
 
 export function useRenameFile(file: StudioFile) {
@@ -22,11 +22,11 @@ export function useRenameFile(file: StudioFile) {
       // There's a slight delay between the add and remove callbacks being triggered,
       // causing the UI to flicker because it thinks the renamed file is actually
       // a new file. To prevent this, we optimistically update the file list.
-      const newPath = join(dirname(file.path), newName)
+      const newPath = path.join(path.dirname(file.path), newName)
       const updatedFile = {
         ...file,
         path: newPath,
-        displayName: parse(newName).name,
+        displayName: path.name(newName),
         fileName: newName,
       }
 

--- a/src/main/file.ts
+++ b/src/main/file.ts
@@ -21,6 +21,7 @@ export function getStudioFileFromPath(
   const file = {
     displayName: path.parse(filePath).name,
     fileName: path.basename(filePath),
+    path: filePath,
   }
 
   if (

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -33,6 +33,7 @@ const studio = {
   browserRemote,
   cloud,
   ai,
+  platform: process.platform,
 } as const
 
 contextBridge.exposeInMainWorld('studio', studio)

--- a/src/routeMap.ts
+++ b/src/routeMap.ts
@@ -1,13 +1,16 @@
 import { generatePath } from 'react-router-dom'
 
+import { StudioFileType } from '@/types'
+import { exhaustive } from '@/utils/typescript'
+
 const routes = {
   home: '/',
   recorder: '/recorder',
-  recordingPreviewer: '/recording-previewer/:fileName',
-  validator: '/validator/:fileName?',
-  generator: '/generator/:fileName',
-  browserTestEditor: '/editor/:fileName',
-  dataFilePreviewer: '/data-file/:fileName',
+  recordingPreviewer: '/recording-previewer/:filePath',
+  validator: '/validator/:filePath?',
+  generator: '/generator/:filePath',
+  browserTestEditor: '/editor/:filePath',
+  dataFilePreviewer: '/data-file/:filePath',
 }
 
 export type RouteName = keyof typeof routes
@@ -31,4 +34,28 @@ export const routeMap = {
   browserTestEditor: getRoutePath('browserTestEditor'),
   validator: getRoutePath('validator'),
   dataFilePreviewer: getRoutePath('dataFilePreviewer'),
+}
+
+export function getViewPath(type: StudioFileType, filePath: string) {
+  const encodedFilePath = encodeURIComponent(filePath)
+
+  switch (type) {
+    case 'recording':
+      return getRoutePath('recordingPreviewer', { filePath: encodedFilePath })
+
+    case 'generator':
+      return getRoutePath('generator', { filePath: encodedFilePath })
+
+    case 'browser-test':
+      return getRoutePath('browserTestEditor', { filePath: encodedFilePath })
+
+    case 'script':
+      return getRoutePath('validator', { filePath: encodedFilePath })
+
+    case 'data-file':
+      return getRoutePath('dataFilePreviewer', { filePath: encodedFilePath })
+
+    default:
+      return exhaustive(type)
+  }
 }

--- a/src/rules/parameterization.ts
+++ b/src/rules/parameterization.ts
@@ -4,7 +4,7 @@ import {
   ParameterizationRuleInstance,
   ParameterizationState,
 } from '@/types/rules'
-import { getFileNameWithoutExtension } from '@/utils/file'
+import * as path from '@/utils/path'
 import { exhaustive } from '@/utils/typescript'
 
 import { replaceRequestValues } from './selectors'
@@ -88,7 +88,7 @@ function getRuleValue(rule: ParameterizationRule, id: number) {
       return `\${VARS['${value.variableName}']}`
 
     case 'dataFileValue': {
-      const displayName = getFileNameWithoutExtension(value.fileName)
+      const displayName = path.name(value.fileName)
       return `\${getUniqueItem(FILES['${displayName}'])['${value.propertyName}']}`
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,6 +91,7 @@ export interface StudioFile {
   type: 'recording' | 'generator' | 'script' | 'data-file' | 'browser-test'
   displayName: string
   fileName: string
+  path: string
 }
 
 export type StudioFileType = StudioFile['type']

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,37 +1,7 @@
-import { StudioFileType } from '@/types'
-
-import { getRoutePath } from '../routeMap'
-
-import { exhaustive } from './typescript'
-
 export function getFileNameWithoutExtension(fileName: string) {
   return fileName.replace(/\.[^/.]+$/, '')
 }
 
 export function getFileExtension(fileName: string) {
   return fileName.split('.').pop()
-}
-
-export function getViewPath(type: StudioFileType, fileName: string) {
-  const encodedFileName = encodeURIComponent(fileName)
-
-  switch (type) {
-    case 'recording':
-      return getRoutePath('recordingPreviewer', { fileName: encodedFileName })
-
-    case 'generator':
-      return getRoutePath('generator', { fileName: encodedFileName })
-
-    case 'browser-test':
-      return getRoutePath('browserTestEditor', { fileName: encodedFileName })
-
-    case 'script':
-      return getRoutePath('validator', { fileName: encodedFileName })
-
-    case 'data-file':
-      return getRoutePath('dataFilePreviewer', { fileName: encodedFileName })
-
-    default:
-      return exhaustive(type)
-  }
 }

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,7 +1,0 @@
-export function getFileNameWithoutExtension(fileName: string) {
-  return fileName.replace(/\.[^/.]+$/, '')
-}
-
-export function getFileExtension(fileName: string) {
-  return fileName.split('.').pop()
-}

--- a/src/utils/fileSystem.ts
+++ b/src/utils/fileSystem.ts
@@ -40,5 +40,5 @@ export async function createFileWithUniqueName({
     }
   } while (!fileCreated)
 
-  return uniqueFileName
+  return path.join(directory, uniqueFileName)
 }

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -4,7 +4,7 @@ import type * as PathModule from './path'
 
 async function importPath(platform: string): Promise<typeof PathModule> {
   vi.resetModules()
-  vi.stubGlobal('process', { ...process, platform })
+  vi.stubGlobal('window', { ...window, studio: { platform } })
   return import('./path')
 }
 

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as PathModule from './path'
+
+async function importPath(platform: string): Promise<typeof PathModule> {
+  vi.resetModules()
+  vi.stubGlobal('process', { ...process, platform })
+  return import('./path')
+}
+
+describe('path (posix)', () => {
+  let path: typeof PathModule
+
+  beforeEach(async () => {
+    path = await importPath('linux')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sep is /', () => {
+    expect(path.sep).toBe('/')
+  })
+
+  describe('join', () => {
+    it('joins segments with /', () => {
+      expect(path.join('a', 'b', 'c')).toBe('a/b/c')
+    })
+
+    it('preserves leading /', () => {
+      expect(path.join('/a', 'b')).toBe('/a/b')
+    })
+
+    it('resolves ..', () => {
+      expect(path.join('a', 'b', '..', 'c')).toBe('a/c')
+    })
+
+    it('collapses multiple separators', () => {
+      expect(path.join('a//b', 'c')).toBe('a/b/c')
+    })
+  })
+
+  describe('basename', () => {
+    it('returns last segment', () => {
+      expect(path.basename('/foo/bar/baz.txt')).toBe('baz.txt')
+    })
+
+    it('strips extension when provided', () => {
+      expect(path.basename('/foo/bar/baz.txt', '.txt')).toBe('baz')
+    })
+
+    it('handles trailing slash', () => {
+      expect(path.basename('/foo/bar/')).toBe('bar')
+    })
+  })
+
+  describe('dirname', () => {
+    it('returns parent directory', () => {
+      expect(path.dirname('/foo/bar/baz.txt')).toBe('/foo/bar')
+    })
+
+    it('returns / for top-level file', () => {
+      expect(path.dirname('/foo')).toBe('/')
+    })
+
+    it('returns . for relative single segment', () => {
+      expect(path.dirname('foo')).toBe('.')
+    })
+  })
+
+  describe('extname', () => {
+    it('returns extension with dot', () => {
+      expect(path.extname('file.txt')).toBe('.txt')
+    })
+
+    it('returns empty string for no extension', () => {
+      expect(path.extname('file')).toBe('')
+    })
+
+    it('returns empty string for hidden file with no extension', () => {
+      expect(path.extname('.gitignore')).toBe('')
+    })
+
+    it('returns last extension for multiple dots', () => {
+      expect(path.extname('file.tar.gz')).toBe('.gz')
+    })
+  })
+
+  describe('name', () => {
+    it('returns filename without extension', () => {
+      expect(path.name('/foo/bar/baz.txt')).toBe('baz')
+    })
+
+    it('returns filename for file with no extension', () => {
+      expect(path.name('/foo/bar/baz')).toBe('baz')
+    })
+
+    it('returns filename for hidden file with no extension', () => {
+      expect(path.name('/foo/.gitignore')).toBe('.gitignore')
+    })
+
+    it('returns filename without last extension for multiple dots', () => {
+      expect(path.name('/foo/file.tar.gz')).toBe('file.tar')
+    })
+  })
+
+  describe('parse', () => {
+    it('parses absolute path', () => {
+      expect(path.parse('/home/user/file.txt')).toEqual({
+        root: '/',
+        dir: '/home/user',
+        base: 'file.txt',
+        ext: '.txt',
+        name: 'file',
+      })
+    })
+
+    it('parses relative path', () => {
+      expect(path.parse('foo/bar.js')).toEqual({
+        root: '',
+        dir: 'foo',
+        base: 'bar.js',
+        ext: '.js',
+        name: 'bar',
+      })
+    })
+  })
+})
+
+describe('path (windows)', () => {
+  let path: typeof PathModule
+
+  beforeEach(async () => {
+    path = await importPath('win32')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sep is \\', () => {
+    expect(path.sep).toBe('\\')
+  })
+
+  describe('join', () => {
+    it('joins segments with \\', () => {
+      expect(path.join('a', 'b', 'c')).toBe('a\\b\\c')
+    })
+
+    it('preserves drive letter root', () => {
+      expect(path.join('C:\\', 'foo', 'bar')).toBe('C:\\foo\\bar')
+    })
+
+    it('resolves ..', () => {
+      expect(path.join('C:\\a', 'b', '..', 'c')).toBe('C:\\a\\c')
+    })
+
+    it('normalizes forward slashes to backslashes', () => {
+      expect(path.join('a/b', 'c')).toBe('a\\b\\c')
+    })
+  })
+
+  describe('basename', () => {
+    it('returns last segment', () => {
+      expect(path.basename('C:\\foo\\bar\\baz.txt')).toBe('baz.txt')
+    })
+
+    it('strips extension when provided', () => {
+      expect(path.basename('C:\\foo\\baz.txt', '.txt')).toBe('baz')
+    })
+
+    it('handles forward-slash paths', () => {
+      expect(path.basename('C:/foo/bar.txt')).toBe('bar.txt')
+    })
+  })
+
+  describe('dirname', () => {
+    it('returns parent directory', () => {
+      expect(path.dirname('C:\\foo\\bar\\baz.txt')).toBe('C:\\foo\\bar')
+    })
+
+    it('returns drive root for top-level file', () => {
+      expect(path.dirname('C:\\foo')).toBe('C:\\')
+    })
+
+    it('returns . for relative single segment', () => {
+      expect(path.dirname('foo')).toBe('.')
+    })
+  })
+
+  describe('extname', () => {
+    it('returns extension with dot', () => {
+      expect(path.extname('C:\\file.txt')).toBe('.txt')
+    })
+
+    it('returns empty string for no extension', () => {
+      expect(path.extname('C:\\file')).toBe('')
+    })
+  })
+
+  describe('parse', () => {
+    it('parses absolute path with drive letter', () => {
+      expect(path.parse('C:\\Users\\user\\file.txt')).toEqual({
+        root: 'C:\\',
+        dir: 'C:\\Users\\user',
+        base: 'file.txt',
+        ext: '.txt',
+        name: 'file',
+      })
+    })
+
+    it('parses UNC path', () => {
+      const result = path.parse('\\\\server\\share\\file.txt')
+      expect(result.root).toBe('\\\\server\\')
+      expect(result.base).toBe('file.txt')
+    })
+  })
+})

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,6 +1,6 @@
 const isWindows =
-  (globalThis.window && globalThis.window.studio.platform === 'win32') ||
-  (globalThis.process && process.platform === 'win32')
+  (globalThis.window && globalThis.window.studio?.platform === 'win32') ||
+  (globalThis.process && globalThis.process.platform === 'win32')
 
 export const sep = isWindows ? '\\' : '/'
 

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,118 @@
+const isWindows =
+  (globalThis.window && globalThis.window.studio.platform === 'win32') ||
+  (globalThis.process && process.platform === 'win32')
+
+export const sep = isWindows ? '\\' : '/'
+
+function getRoot(path: string): string {
+  if (isWindows) {
+    const driveMatch = path.match(/^[a-zA-Z]:[/\\]/)
+
+    if (driveMatch) {
+      return driveMatch[0].replace('/', '\\')
+    }
+
+    const uncMatch = path.match(/^[/\\]{2}[^/\\]+[/\\]/)
+
+    if (uncMatch) {
+      return uncMatch[0].replace(/\//g, '\\')
+    }
+
+    return ''
+  }
+
+  return path.startsWith('/') ? '/' : ''
+}
+
+function splitParts(path: string, root: string): string[] {
+  return path.slice(root.length).split(/[/\\]/).filter(Boolean)
+}
+
+export function normalize(path: string): string {
+  const root = getRoot(path)
+  const parts = splitParts(path, root)
+  const resolved: string[] = []
+
+  for (const part of parts) {
+    if (part === '..') {
+      if (resolved.length > 0) {
+        resolved.pop()
+      } else if (!root) {
+        resolved.push('..')
+      }
+    } else if (part !== '.') {
+      resolved.push(part)
+    }
+  }
+
+  return root + resolved.join(sep) || '.'
+}
+
+export function join(...parts: string[]): string {
+  return normalize(parts.join(sep))
+}
+
+export function basename(path: string, extension?: string): string {
+  const root = getRoot(path)
+  const parts = splitParts(path, root)
+
+  const base = parts[parts.length - 1] ?? ''
+
+  if (extension && base.endsWith(extension)) {
+    return base.slice(0, base.length - extension.length)
+  }
+
+  return base
+}
+
+export function dirname(path: string): string {
+  const root = getRoot(path)
+  const parts = splitParts(path, root)
+
+  if (parts.length <= 1) {
+    return root || '.'
+  }
+
+  return root + parts.slice(0, -1).join(sep)
+}
+
+export function extname(path: string): string {
+  const base = basename(path)
+  const dotIndex = base.lastIndexOf('.')
+
+  if (dotIndex <= 0) {
+    return ''
+  }
+
+  return base.slice(dotIndex)
+}
+
+export function name(path: string) {
+  const base = basename(path)
+  const ext = extname(path)
+
+  return base.slice(0, base.length - ext.length)
+}
+
+export function isAbsolute(path: string): boolean {
+  return getRoot(path) !== ''
+}
+
+export interface ParsedPath {
+  root: string
+  dir: string
+  base: string
+  ext: string
+  name: string
+}
+
+export function parse(path: string): ParsedPath {
+  const root = getRoot(path)
+  const base = basename(path)
+  const ext = extname(path)
+  const dir = dirname(path)
+
+  const name = base.slice(0, base.length - ext.length)
+
+  return { root, dir, base, ext, name }
+}

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -6,8 +6,8 @@ import { AlertTriangleIcon, PlusIcon } from 'lucide-react'
 import { useGeneratorStore } from '@/store/generator'
 import { useStudioUIStore } from '@/store/ui'
 import { useToast } from '@/store/ui/useToast'
-import { getFileNameWithoutExtension } from '@/utils/file'
 import { harToProxyData } from '@/utils/harToProxyData'
+import * as path from '@/utils/path'
 
 export function RecordingSelector({
   compact = false,
@@ -88,13 +88,13 @@ export function RecordingSelector({
                 `}
               />
             )}
-            {getFileNameWithoutExtension(recordingPath)}
+            {path.name(recordingPath)}
           </Flex>
         </Select.Trigger>
         <Select.Content position="popper">
           {isRecordingMissing && (
             <Select.Item value={recordingPath} disabled>
-              {getFileNameWithoutExtension(recordingPath)}
+              {path.name(recordingPath)}
             </Select.Item>
           )}
           {recordings.map((recording) => (

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -5,7 +5,7 @@ import { Link, useNavigate } from 'react-router-dom'
 
 import { GeneratorIcon, RecorderIcon, ValidatorIcon } from '@/components/icons'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
-import { getRoutePath } from '@/routeMap'
+import { getRoutePath, getViewPath } from '@/routeMap'
 
 import { NavigationCard } from './NavigationCard'
 
@@ -22,7 +22,7 @@ export function Home() {
       return
     }
 
-    navigate(getRoutePath('validator', { fileName: encodeURIComponent(path) }))
+    navigate(getViewPath('script', path))
   }
 
   return (

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_GROUP_NAME } from '@/constants'
 import { useListenBrowserEvent } from '@/hooks/useListenBrowserEvent'
 import { useListenProxyData } from '@/hooks/useListenProxyData'
 import { LaunchBrowserOptions } from '@/recorder/types'
-import { getRoutePath, getViewPath } from '@/routeMap'
+import { getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 import { Group, ProxyData } from '@/types'
 import { proxyDataToHar } from '@/utils/proxyDataToHar'
@@ -195,8 +195,7 @@ export function Recorder() {
 
       navigate(getViewPath('recording', fileName), {
         state: { discardable: true },
-      }
-      )
+      })
     })
   }, [validateAndSaveHarFile, showToast, navigate, blocker.state, isAppClosing])
 

--- a/src/views/Recorder/Recorder.tsx
+++ b/src/views/Recorder/Recorder.tsx
@@ -10,7 +10,7 @@ import { DEFAULT_GROUP_NAME } from '@/constants'
 import { useListenBrowserEvent } from '@/hooks/useListenBrowserEvent'
 import { useListenProxyData } from '@/hooks/useListenProxyData'
 import { LaunchBrowserOptions } from '@/recorder/types'
-import { getRoutePath } from '@/routeMap'
+import { getRoutePath, getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 import { Group, ProxyData } from '@/types'
 import { proxyDataToHar } from '@/utils/proxyDataToHar'
@@ -193,13 +193,9 @@ export function Recorder() {
         status: 'success',
       })
 
-      navigate(
-        getRoutePath('recordingPreviewer', {
-          fileName: encodeURIComponent(fileName),
-        }),
-        {
-          state: { discardable: true },
-        }
+      navigate(getViewPath('recording', fileName), {
+        state: { discardable: true },
+      }
       )
     })
   }, [validateAndSaveHarFile, showToast, navigate, blocker.state, isAppClosing])

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -9,7 +9,7 @@ import { convertEventsToTest } from '@/codegen/browser/test'
 import { DeleteFileDialog } from '@/components/DeleteFileDialog'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 import { useDeleteFile } from '@/hooks/useDeleteFile'
-import { getRoutePath } from '@/routeMap'
+import { getRoutePath, getViewPath } from '@/routeMap'
 import { BrowserEvent } from '@/schemas/recording'
 import { useToast } from '@/store/ui/useToast'
 import { StudioFile } from '@/types'
@@ -61,12 +61,10 @@ export function RecordingPreviewControls({
 
     emitScript(test)
       .then((script) => window.studio.script.saveScript(script, fileName))
-      .then(() => {
-        navigate(
-          getRoutePath('validator', {
-            fileName: encodeURIComponent(fileName),
-          })
-        )
+      .then((filePath) => {
+        if (!filePath) return
+
+        navigate(getViewPath('script', filePath))
       })
       .catch((err) => {
         console.error(err)

--- a/src/views/Validator/Validator.tsx
+++ b/src/views/Validator/Validator.tsx
@@ -6,7 +6,7 @@ import { FileNameHeader } from '@/components/FileNameHeader'
 import { View } from '@/components/Layout/View'
 import { RunInCloudDialog } from '@/components/RunInCloudDialog/RunInCloudDialog'
 import { useCurrentFile } from '@/hooks/useCurrentFile'
-import { getRoutePath } from '@/routeMap'
+import { getViewPath } from '@/routeMap'
 import { useToast } from '@/store/ui/useToast'
 import { StudioFile } from '@/types'
 
@@ -19,7 +19,7 @@ interface ValidatorProps {
 }
 
 function Content({ file }: ValidatorProps) {
-  const { data, isLoading } = useScript(file.fileName)
+  const { data, isLoading } = useScript(file.path)
 
   const [showRunInCloudDialog, setShowRunInCloudDialog] = useState(false)
 
@@ -28,7 +28,7 @@ function Content({ file }: ValidatorProps) {
 
   const { session, startDebugging, stopDebugging } = useDebugSession({
     type: 'file',
-    path: file.fileName,
+    path: file.path,
   })
 
   const isRunning = session?.state === 'running'
@@ -40,11 +40,7 @@ function Content({ file }: ValidatorProps) {
       return
     }
 
-    navigate(
-      getRoutePath('validator', {
-        fileName: encodeURIComponent(newScriptPath),
-      })
-    )
+    navigate(getViewPath('script', newScriptPath))
   }, [navigate])
 
   async function handleDebugScript() {
@@ -110,7 +106,7 @@ function Content({ file }: ValidatorProps) {
       </Flex>
       <RunInCloudDialog
         open={showRunInCloudDialog}
-        script={{ type: 'file', path: file.fileName }}
+        script={{ type: 'file', path: file.path }}
         onOpenChange={setShowRunInCloudDialog}
       />
     </View>
@@ -120,5 +116,5 @@ function Content({ file }: ValidatorProps) {
 export function Validator() {
   const file = useCurrentFile('script')
 
-  return <Content key={file.fileName} file={file} />
+  return <Content key={file.path} file={file} />
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The internals of the app relies almost exclusively on concatenating the basename of files to a hardcoded directory based on the type of the file. This makes it impossible to have files outside of the directory that we have dictated and prevents us from having any kind of complex file management, e.g. opening or saving files from a native file dialog (not to mention supporting any kind of workspace).

This PR is a step in the direction of making the app work with absolute paths internally so that we at some point in the future can gives users the freedom to store their files anywhere on disk.

It adds the absolute path of files to the `StudioFile` and uses that for the app routing. Instead of `fileName` the routes now take a `filePath` parameter. This is parsed to extract the `fileName` and `displayName`.

This only applies to the routing. Nothing else has changed in the app. Opening, saving, etc. all still rely on the `fileName`.

## How to Test

* Open files
* Record something
* Create HTTP and browser tests from recording
* Debug an internal script
* Debug an external script

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches routing and file identity across multiple views and IPC boundaries; mistakes in path encoding/normalization could break navigation or file selection, especially on Windows path formats.
> 
> **Overview**
> Shifts in-app navigation from file *names* to URL-encoded absolute `filePath`s. Routes now use `:filePath` params, `StudioFile` gains a `path` field, and navigation/selection/rename flows (file tree, recorder, generator/browser test creation, validator, script export) are updated to pass and compare full paths.
> 
> Introduces a lightweight cross-platform `utils/path` (with tests) and removes `pathe` plus the old `utils/file` helpers; main-process file creation/import/export handlers now return full paths (e.g., `createFileWithUniqueName`, data-file import, HAR/generator/browser-test creation, script save), and renderer code parses paths to derive `displayName`/extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 193da8dde9dcd9ab1076656f0f3ef64551b77b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->