### PR TITLE
fix: Skip nupkg signing to restore Windows autoupdate

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -38,9 +38,14 @@ function getPostMakeHook() {
   return async (forgeConfig: ForgeConfig, makeResults: ForgeMakeResult[]) => {
     const artifactPaths = makeResults.flatMap((o) => o.artifacts)
 
-    const signingPromises = artifactPaths.map((filePath) => {
-      return spawnSignFile(filePath)
-    })
+    // Only sign .exe artifacts. Signing the Squirrel *.nupkg via NuGet's
+    // package-signing format changes its size, but MakerSquirrel has already
+    // written the original size + sha1 into the RELEASES file by this point.
+    // The mismatch makes Squirrel.Windows abort updates with a checksum error
+    // and the "restart to update" dialog never fires.
+    const signingPromises = artifactPaths
+      .filter((filePath) => filePath.toLowerCase().endsWith('.exe'))
+      .map((filePath) => spawnSignFile(filePath))
 
     await Promise.all(signingPromises)
     return makeResults

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/main'
-import { app, BrowserWindow, nativeTheme } from 'electron'
+import { app, autoUpdater, BrowserWindow, nativeTheme } from 'electron'
 import log from 'electron-log/main'
 import isSquirrelStartup from 'electron-squirrel-startup'
 import path from 'path'
@@ -26,10 +26,7 @@ import { getAppIcon, getPlatform } from './utils/electron'
 import { setupProjectStructure } from './utils/workspace'
 
 if (process.env.NODE_ENV !== 'development') {
-  // handle auto updates
-  updateElectronApp({ logger: log.scope('autoUpdater') })
-
-  // initialize Sentry
+  // initialize Sentry first so the autoUpdater error listener below can report
   Sentry.init({
     dsn: SENTRY_DSN,
     integrations: [Sentry.electronMinidumpIntegration()],
@@ -42,6 +39,15 @@ if (process.env.NODE_ENV !== 'development') {
       return null
     },
   })
+
+  // update-electron-app swallows autoUpdater errors at info level via its
+  // default logger, so we capture them directly to surface silent failures.
+  autoUpdater.on('error', (err) => {
+    Sentry.captureException(err, { tags: { component: 'autoUpdater' } })
+  })
+
+  // handle auto updates
+  updateElectronApp({ logger: log.scope('autoUpdater') })
 }
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ import { setupProjectStructure } from './utils/workspace'
 
 if (process.env.NODE_ENV !== 'development') {
   // handle auto updates
-  updateElectronApp()
+  updateElectronApp({ logger: log.scope('autoUpdater') })
 
   // initialize Sentry
   Sentry.init({

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -40,7 +40,7 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
-  log.transports.file.level = 'error'
+  log.transports.file.level = 'info'
 
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -40,7 +40,7 @@ export function initializeLogger() {
   log.errorHandler.startCatching()
 
   log.transports.file.fileName = 'k6-studio.log'
-  log.transports.file.level = 'info'
+  log.transports.file.level = 'error'
 
   if (process.env.NODE_ENV === 'development') {
     log.transports.file.fileName = 'k6-studio-dev.log'


### PR DESCRIPTION
## Description

Windows autoupdate has been silently broken since v1.9.0 (2025-11-25). The `postMake` hook signs `*-full.nupkg` via Azure Trusted Signing's `dotnet sign`, which uses NuGet's package-signing format and grows the file by ~6MB. `MakerSquirrel` has already written the pre-signing size and sha1 into `RELEASES` by that point, so Squirrel.Windows aborts updates with `Checksummed file size doesn't match`, no `update-downloaded` event fires, and the "restart to update" dialog never appears.

This filters postMake signing to `.exe` only, so `Setup.exe` is still Authenticode signed (needed for SmartScreen reputation) while the nupkg, delta, and `RELEASES` are left untouched. The inner `k6-studio.exe` is still signed by `packagerConfig.windowsSign` before MakerSquirrel packs the nupkg.

Also wires `autoUpdater.on('error')` to Sentry tagged `component: autoUpdater` so future silent failures surface in monitoring instead of vanishing into `update-electron-app`'s info-level logger.


## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

<!-- internal report only -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows packaging/signing and auto-update initialization; mistakes could still break release artifacts or mask updater behavior, but changes are small and localized.
> 
> **Overview**
> Fixes broken Windows Squirrel auto-updates by changing the Forge `postMake` signing hook to **only sign `.exe` artifacts**, avoiding `.nupkg` mutations that invalidate `RELEASES` size/sha checks.
> 
> Improves observability of update failures by initializing Sentry before update setup, capturing `autoUpdater` `'error'` events to Sentry (tagged `component: autoUpdater`), and wiring `updateElectronApp` to use an `electron-log` scoped logger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513c0a9b79d2fe7250c94d3a826d658d564297b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->