### PR TITLE
internal(browser): Stop validation run in browser test editor

### DIFF
--- a/src/components/SessionPlayer/SessionPlayer.hooks.ts
+++ b/src/components/SessionPlayer/SessionPlayer.hooks.ts
@@ -51,7 +51,7 @@ class EnhancedReplayer extends Replayer {
   }
 
   getTotalTime() {
-    return this.getMetaData().totalTime
+    return Math.max(0, this.getMetaData().totalTime)
   }
 
   getCurrentTimestamp() {

--- a/src/views/BrowserTestEditor/BrowserTestEditor.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.tsx
@@ -55,7 +55,7 @@ function BrowserTestEditorView({ file, data }: BrowserTestEditorViewProps) {
   const previewScript = useBrowserScriptPreview(test.actions)
   const validatorScript = useValidatorScript(test.actions)
 
-  const { session, startDebugging } = useDebugSession({
+  const { session, startDebugging, stopDebugging } = useDebugSession({
     type: 'raw',
     content: validatorScript,
     name: file.fileName,
@@ -82,6 +82,7 @@ function BrowserTestEditorView({ file, data }: BrowserTestEditorViewProps) {
           session={session}
           isDirty={test.isDirty}
           onStartDebugging={startDebugging}
+          onStopDebugging={stopDebugging}
           onSave={handleSave}
         />
       }

--- a/src/views/BrowserTestEditor/BrowserTestEditorControls.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditorControls.tsx
@@ -3,6 +3,7 @@ import {
   DropdownMenu,
   Flex,
   IconButton,
+  Spinner,
   Tooltip,
 } from '@radix-ui/themes'
 import {
@@ -28,6 +29,7 @@ interface BrowserTestEditorControlsProps {
   session: DebugSession
   isDirty: boolean
   onStartDebugging: () => void
+  onStopDebugging: () => void
   onSave: () => void
 }
 
@@ -37,6 +39,7 @@ export function BrowserTestEditorControls({
   session,
   isDirty,
   onStartDebugging,
+  onStopDebugging,
   onSave,
 }: BrowserTestEditorControlsProps) {
   const [isExportDialogOpen, setIsExportDialogOpen] = useState(false)
@@ -75,13 +78,17 @@ export function BrowserTestEditorControls({
         </Tooltip>
       </Flex>
       <Flex gap="4" align="center" pl="2">
-        <Button
-          variant="ghost"
-          onClick={onStartDebugging}
-          loading={session.state === 'running'}
-        >
-          <CircleCheckBigIcon /> Validate
-        </Button>
+        {session.state === 'running' && (
+          <Button variant="ghost" onClick={onStopDebugging}>
+            <Spinner />
+            Stop
+          </Button>
+        )}
+        {session.state !== 'running' && (
+          <Button variant="ghost" onClick={onStartDebugging}>
+            <CircleCheckBigIcon /> Validate
+          </Button>
+        )}
         <Button onClick={() => setIsRunInCloudDialogOpen(true)}>
           <GrafanaIcon /> Run in Grafana Cloud
         </Button>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a stop button after starting a validation run in the browser test editor.

## How to Test

1. Create a browser test
2. Start a validation run
3. Click stop

Everything should work as expected.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/control-flow change that calls an existing stop API and a defensive clamp in session playback timing; limited surface area and no auth/data-model changes.
> 
> **Overview**
> Adds the ability to **stop an in-progress validation run** from the Browser Test Editor by wiring `stopDebugging` from `useDebugSession` into `BrowserTestEditorControls` and swapping the Validate button for a running-state Stop button with a spinner.
> 
> Hardens rrweb playback time calculations by clamping `EnhancedReplayer.getTotalTime()` to a non-negative value to avoid UI issues when rrweb reports invalid durations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d19391ab8cf12f3e66db5e8e92919a79f205640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->