### PR TITLE
refactor: Use absolute paths for file saving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -644,7 +643,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -668,7 +666,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -690,7 +687,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -1218,7 +1214,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -1703,7 +1698,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2538,7 +2532,6 @@
       "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -2900,7 +2893,6 @@
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3211,7 +3203,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3233,7 +3224,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3270,7 +3260,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -3801,7 +3790,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -6510,6 +6498,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6530,6 +6519,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6539,7 +6529,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
@@ -6640,7 +6631,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6926,7 +6918,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -7006,7 +6997,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -7017,7 +7007,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8451,7 +8440,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9342,7 +9330,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -11248,6 +11235,29 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -11627,7 +11637,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -11806,7 +11815,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -13627,7 +13635,6 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -14462,7 +14469,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -15469,6 +15475,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15944,7 +15951,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -17220,6 +17226,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17235,6 +17242,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17247,7 +17255,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proc-log": {
       "version": "2.0.1",
@@ -17589,7 +17598,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17611,7 +17619,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17624,7 +17631,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.74.0.tgz",
       "integrity": "sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -18537,7 +18543,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -19835,7 +19840,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20128,8 +20132,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -20279,7 +20282,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20704,7 +20706,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -20816,7 +20817,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21509,7 +21509,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
       "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/handlers/browserTest/index.ts
+++ b/src/handlers/browserTest/index.ts
@@ -50,13 +50,10 @@ export function initialize() {
 
   ipcMain.handle(
     BrowserTestHandler.Save,
-    async (_, fileName: string, data: BrowserTestFile) => {
+    async (_, filePath: string, data: BrowserTestFile) => {
       console.info(`${BrowserTestHandler.Save} event received`)
 
-      await writeFile(
-        path.join(BROWSER_TESTS_PATH, fileName),
-        JSON.stringify(data, null, 2)
-      )
+      await writeFile(filePath, JSON.stringify(data, null, 2))
 
       trackEvent({
         event: UsageEventName.BrowserTestUpdated,

--- a/src/handlers/browserTest/preload.ts
+++ b/src/handlers/browserTest/preload.ts
@@ -15,10 +15,10 @@ export function open(fileName: string) {
   ) as Promise<BrowserTestFile>
 }
 
-export function save(fileName: string, data: BrowserTestFile) {
+export function save(filePath: string, data: BrowserTestFile) {
   return ipcRenderer.invoke(
     BrowserTestHandler.Save,
-    fileName,
+    filePath,
     data
   ) as Promise<void>
 }

--- a/src/handlers/generator/index.ts
+++ b/src/handlers/generator/index.ts
@@ -1,12 +1,8 @@
 import { ipcMain } from 'electron'
 import { writeFile, readFile } from 'fs/promises'
 import path from 'path'
-import invariant from 'tiny-invariant'
 
-import {
-  INVALID_FILENAME_CHARS,
-  K6_GENERATOR_FILE_EXTENSION,
-} from '@/constants/files'
+import { K6_GENERATOR_FILE_EXTENSION } from '@/constants/files'
 import { GENERATORS_PATH } from '@/constants/workspace'
 import { GeneratorFileDataSchema } from '@/schemas/generator'
 import { trackEvent } from '@/services/usageTracking'
@@ -37,14 +33,10 @@ export function initialize() {
 
   ipcMain.handle(
     GeneratorHandler.Save,
-    async (_, generator: GeneratorFileData, fileName: string) => {
+    async (_, generator: GeneratorFileData, filePath: string) => {
       console.log(`${GeneratorHandler.Save} event received`)
-      invariant(!INVALID_FILENAME_CHARS.test(fileName), 'Invalid file name')
 
-      await writeFile(
-        path.join(GENERATORS_PATH, fileName),
-        JSON.stringify(generator, null, 2)
-      )
+      await writeFile(filePath, JSON.stringify(generator, null, 2))
 
       trackGeneratorUpdated(generator)
     }

--- a/src/handlers/generator/preload.ts
+++ b/src/handlers/generator/preload.ts
@@ -11,11 +11,11 @@ export function createGenerator(recordingPath: string) {
   ) as Promise<string>
 }
 
-export function saveGenerator(generator: GeneratorFileData, fileName: string) {
+export function saveGenerator(generator: GeneratorFileData, filePath: string) {
   return ipcRenderer.invoke(
     GeneratorHandler.Save,
     generator,
-    fileName
+    filePath
   ) as Promise<void>
 }
 

--- a/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
@@ -2,6 +2,7 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import { debounce } from 'lodash-es'
+import { basename } from 'pathe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { emitScript } from '@/codegen/browser'
@@ -30,14 +31,14 @@ export function useBrowserTest(fileName: string) {
   })
 }
 
-export function useSaveBrowserTest(fileName: string) {
+export function useSaveBrowserTest(filePath: string) {
   const showToast = useToast()
 
   return useMutation({
     mutationFn: async (data: BrowserTestFile) => {
-      await window.studio.browserTest.save(fileName, data)
+      await window.studio.browserTest.save(filePath, data)
       await queryClient.invalidateQueries({
-        queryKey: ['browserTest', fileName],
+        queryKey: ['browserTest', basename(filePath)],
       })
     },
 

--- a/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
@@ -2,7 +2,6 @@ import { arrayMove } from '@dnd-kit/sortable'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
 import { debounce } from 'lodash-es'
-import { basename } from 'pathe'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { emitScript } from '@/codegen/browser'
@@ -13,6 +12,7 @@ import {
 } from '@/components/primitives/ResizablePanel'
 import { BrowserTestFile } from '@/schemas/browserTest/v1'
 import { useToast } from '@/store/ui/useToast'
+import { basename } from '@/utils/path'
 import { queryClient } from '@/utils/query'
 
 import {

--- a/src/views/BrowserTestEditor/BrowserTestEditor.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.tsx
@@ -45,7 +45,7 @@ function BrowserTestEditorView({ file, data }: BrowserTestEditorViewProps) {
   const { drawerLayout, mainLayout, setDrawer, onTabClick } =
     useBrowserTestEditorLayout()
 
-  const { mutateAsync: saveBrowserTest } = useSaveBrowserTest(file.fileName)
+  const { mutateAsync: saveBrowserTest } = useSaveBrowserTest(file.path)
 
   const consoleFilter = useConsoleFilter()
   const highlightedLocator = useHighlightedLocator()

--- a/src/views/Generator/Generator.hooks.ts
+++ b/src/views/Generator/Generator.hooks.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
+import { basename } from 'pathe'
 import { useCallback } from 'react'
 
 import { selectGeneratorData, useGeneratorStore } from '@/store/generator'
@@ -24,25 +25,29 @@ export function useLoadGeneratorFile(fileName: string) {
   })
 }
 
-export function useUpdateValueInGeneratorFile(fileName: string) {
+export function useUpdateValueInGeneratorFile(filePath: string) {
   return useMutation({
     mutationFn: async ({ key, value }: { key: string; value: unknown }) => {
-      const generator = await loadGeneratorFile(fileName)
+      const generator = await loadGeneratorFile(basename(filePath))
+
       await window.studio.generator.saveGenerator(
         { ...generator, [key]: value },
-        fileName
+        filePath
       )
     },
   })
 }
 
-export function useSaveGeneratorFile(fileName: string) {
+export function useSaveGeneratorFile(filePath: string) {
   const showToast = useToast()
 
   return useMutation({
     mutationFn: async (generator: GeneratorFileData) => {
-      await window.studio.generator.saveGenerator(generator, fileName)
-      await queryClient.invalidateQueries({ queryKey: ['generator', fileName] })
+      await window.studio.generator.saveGenerator(generator, filePath)
+
+      await queryClient.invalidateQueries({
+        queryKey: ['generator', basename(filePath)],
+      })
     },
 
     onSuccess: () => {
@@ -81,11 +86,11 @@ export function useIsGeneratorDirty(fileName: string) {
   )
 }
 
-export function useScriptExport(generatorFileName: string) {
+export function useScriptExport(generatorFilePath: string) {
   const showToast = useToast()
   const setScriptName = useGeneratorStore((store) => store.setScriptName)
   const { mutateAsync: updateGeneratorFile } =
-    useUpdateValueInGeneratorFile(generatorFileName)
+    useUpdateValueInGeneratorFile(generatorFilePath)
 
   return useCallback(
     async (scriptName: string) => {

--- a/src/views/Generator/Generator.hooks.ts
+++ b/src/views/Generator/Generator.hooks.ts
@@ -1,11 +1,11 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
 import log from 'electron-log/renderer'
-import { basename } from 'pathe'
 import { useCallback } from 'react'
 
 import { selectGeneratorData, useGeneratorStore } from '@/store/generator'
 import { useToast } from '@/store/ui/useToast'
 import { GeneratorFileData } from '@/types/generator'
+import { basename } from '@/utils/path'
 import { queryClient } from '@/utils/query'
 
 import { exportScript, loadGeneratorFile, loadHarFile } from './Generator.utils'

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -46,7 +46,7 @@ export function Generator() {
     error: harError,
   } = useLoadHarFile(generatorFileData?.recordingPath)
 
-  const { mutateAsync: saveGenerator } = useSaveGeneratorFile(fileName)
+  const { mutateAsync: saveGenerator } = useSaveGeneratorFile(file.path)
 
   const isLoading = isLoadingGenerator || isLoadingRecording
 

--- a/src/views/Generator/GeneratorControls/GeneratorControls.tsx
+++ b/src/views/Generator/GeneratorControls/GeneratorControls.tsx
@@ -34,12 +34,11 @@ export function GeneratorControls({ onSave, isDirty }: GeneratorControlsProps) {
     useState(false)
   const [isRunInCloudDialogOpen, setIsRunInCloudDialogOpen] = useState(false)
   const file = useCurrentFile('generator')
-  const { fileName } = file
   const { preview, hasError } = useScriptPreview()
   const proxyStatus = useProxyStatus()
   const isScriptExportable = !hasError && !!preview
 
-  const handleExportScript = useScriptExport(fileName)
+  const handleExportScript = useScriptExport(file.path)
 
   const handleDelete = useDeleteFile({
     file,
@@ -118,7 +117,7 @@ export function GeneratorControls({ onSave, isDirty }: GeneratorControlsProps) {
         <>
           <RunInCloudDialog
             open={isRunInCloudDialogOpen}
-            script={{ type: 'raw', name: fileName, content: preview }}
+            script={{ type: 'raw', name: file.fileName, content: preview }}
             onOpenChange={setIsRunInCloudDialogOpen}
           />
           <ValidatorDialog


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In my ongoing effort of removing our reliance on bare filenames, this PR updates the saving of files to receive the absolute path instead of just the filename.

## How to Test

For both a browser and http test:

1. Open a file
2. Modify and save it
3. Move away from the file
4. Open it again
    * The changes should have been saved

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because IPC save handlers now trust a provided `filePath` (removing filename validation and directory joining), which could lead to writing to unintended locations if callers pass incorrect or malicious paths. Functional behavior should be unchanged for normal usage but touches persistence for both generator and browser-test flows.
> 
> **Overview**
> Refactors generator and browser-test saving to pass an *absolute `filePath`* through the preload APIs and IPC handlers, instead of saving by `fileName` under a fixed workspace directory.
> 
> Updates editor/hooks to call save with `file.path` and adjusts React Query cache invalidation to key by `basename(filePath)`; generator export also switches to use the full path while keeping the cloud-run script name as `file.fileName`. `package-lock.json` is updated (notably adding optional `encoding` and adjusting various `peer` flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a7447adf653c7e6525f4ddf92a0ef5107820b89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->