### PR TITLE
internal(browser): Explicitly create actions in `onAddAction` callback

### DIFF
--- a/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.hooks.ts
@@ -18,7 +18,6 @@ import {
   fromBrowserActionInstance,
   toBrowserActionInstance,
 } from './actionAdapters'
-import { createActionInstance } from './actionEditorRegistry'
 import { BrowserActionInstance } from './types'
 
 export function useBrowserTest(fileName: string) {
@@ -140,8 +139,7 @@ export function useBrowserTestState(
     actions.map(toBrowserActionInstance)
   )
 
-  const addAction = (method: BrowserActionInstance['method']) => {
-    const action = createActionInstance(method)
+  const addAction = (action: BrowserActionInstance) => {
     setState([...state, action])
   }
 

--- a/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
+++ b/src/views/BrowserTestEditor/EditableBrowserActionList.tsx
@@ -9,14 +9,25 @@ import {
 import { CirclePlusIcon } from 'lucide-react'
 
 import { EmptyMessage } from '@/components/EmptyMessage'
-import { AnyBrowserAction } from '@/main/runner/schema'
 
 import { SortableBrowserActionList } from './SortableBrowserActionList'
+import {
+  createCheckAction,
+  createClearAction,
+  createClickAction,
+  createFillAction,
+  createGoToAction,
+  createPageReloadAction,
+  createSelectOptionAction,
+  createUncheckAction,
+  createWaitForAction,
+  createWaitForTimeoutAction,
+} from './actionFactories'
 import { BrowserActionInstance } from './types'
 
 interface EditableBrowserActionListProps {
   actions: BrowserActionInstance[]
-  onAddAction: (method: BrowserActionInstance['method']) => void
+  onAddAction: (action: BrowserActionInstance) => void
   onRemoveAction: (actionId: string) => void
   onChangeAction: (action: BrowserActionInstance) => void
   onReorderActions: (activeId: string, overId: string) => void
@@ -64,7 +75,7 @@ export function EditableBrowserActionList({
 }
 
 interface NewActionMenuProps {
-  onAddAction: (method: AnyBrowserAction['method']) => void
+  onAddAction: (action: BrowserActionInstance) => void
 }
 
 function NewActionMenu({ onAddAction }: NewActionMenuProps) {
@@ -76,76 +87,42 @@ function NewActionMenu({ onAddAction }: NewActionMenuProps) {
         </Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.click')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createClickAction())}>
           Click element
         </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.fill')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createFillAction())}>
           Fill input
         </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.clear')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createClearAction())}>
           Clear input
         </DropdownMenu.Item>
         <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.selectOption')
-          }}
+          onClick={() => onAddAction(createSelectOptionAction())}
         >
           Select option
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.check')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createCheckAction())}>
           Check input
         </DropdownMenu.Item>
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.uncheck')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createUncheckAction())}>
           Uncheck input
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('locator.waitFor')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createWaitForAction())}>
           Wait for element
         </DropdownMenu.Item>
         <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('page.waitForTimeout')
-          }}
+          onClick={() => onAddAction(createWaitForTimeoutAction())}
         >
           Wait for timeout
         </DropdownMenu.Item>
         <DropdownMenu.Separator />
-        <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('page.goto')
-          }}
-        >
+        <DropdownMenu.Item onClick={() => onAddAction(createGoToAction())}>
           Navigate to URL
         </DropdownMenu.Item>
         <DropdownMenu.Item
-          onClick={() => {
-            onAddAction('page.reload')
-          }}
+          onClick={() => onAddAction(createPageReloadAction())}
         >
           Reload page
         </DropdownMenu.Item>

--- a/src/views/BrowserTestEditor/actionEditorRegistry.tsx
+++ b/src/views/BrowserTestEditor/actionEditorRegistry.tsx
@@ -41,7 +41,6 @@ interface ActionEditorProps<M extends BrowserActionInstance['method']> {
 interface ActionEditorDefinition<M extends BrowserActionInstance['method']> {
   icon: ReactNode
   render: (props: ActionEditorProps<M>) => ReactElement
-  create: () => ActionByMethod<M>
   summaryExcludeKeys?: readonly string[]
 }
 
@@ -59,102 +58,30 @@ const notImplementedRender = <M extends BrowserActionInstance['method']>({
   </>
 )
 
-const notImplementedCreate = <M extends BrowserActionInstance['method']>(
-  method: M
-) => {
-  return () => {
-    throw new Error(`Action ${method} not implemented yet`)
-  }
-}
-
 const actionEditors: ActionEditorRegistry = {
   'locator.check': {
     icon: <SquareCheckBigIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <CheckActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.check',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'checkbox',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
   'locator.uncheck': {
     icon: <SquareIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <UncheckActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.uncheck',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'checkbox',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
   'locator.clear': {
     icon: <EraserIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <ClearActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.clear',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'textbox',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
   'locator.click': {
     icon: <MousePointerClickIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <ClickActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.click',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'button',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
     summaryExcludeKeys: ['button'],
   },
   'locator.fill': {
@@ -162,98 +89,34 @@ const actionEditors: ActionEditorRegistry = {
     render: ({ action, onChange }) => (
       <FillActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.fill',
-      value: '',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'textbox',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
   'locator.selectOption': {
     icon: <ListChecksIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <SelectOptionActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.selectOption',
-      values: [{ value: '' }],
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: 'combobox',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
   'page.goto': {
     icon: <GlobeIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <GoToActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'page.goto',
-      url: 'https://example.com',
-    }),
   },
   'page.reload': {
     icon: <RefreshCwIcon aria-hidden="true" />,
     render: () => <PageReloadActionBody />,
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'page.reload',
-    }),
   },
   'page.waitForTimeout': {
     icon: <ClockIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <WaitForTimeoutActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'page.waitForTimeout',
-      timeout: 1000,
-    }),
   },
   'locator.waitFor': {
     icon: <TimerIcon aria-hidden="true" />,
     render: ({ action, onChange }) => (
       <WaitForActionBody action={action} onChange={onChange} />
     ),
-    create: () => ({
-      id: crypto.randomUUID(),
-      method: 'locator.waitFor',
-      locator: {
-        current: 'role',
-        values: {
-          role: {
-            type: 'role',
-            role: '',
-            options: {
-              exact: false,
-            },
-          },
-        },
-      },
-    }),
   },
 }
 
@@ -269,7 +132,6 @@ export function getActionEditor<M extends BrowserActionInstance['method']>(
   return {
     icon: notImplementedIcon,
     render: notImplementedRender,
-    create: notImplementedCreate(method),
   } as ActionEditorDefinition<M>
 }
 
@@ -277,8 +139,4 @@ export function getActionEditorForAction<A extends BrowserActionInstance>(
   action: A
 ): ActionEditorDefinition<A['method']> {
   return getActionEditor(action.method)
-}
-
-export function createActionInstance(method: BrowserActionInstance['method']) {
-  return getActionEditor(method).create()
 }

--- a/src/views/BrowserTestEditor/actionFactories.ts
+++ b/src/views/BrowserTestEditor/actionFactories.ts
@@ -1,0 +1,164 @@
+import { BrowserActionInstance } from './types'
+
+type ActionByMethod<M extends BrowserActionInstance['method']> = Extract<
+  BrowserActionInstance,
+  { method: M }
+>
+
+export function createCheckAction(): ActionByMethod<'locator.check'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.check',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'checkbox',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createUncheckAction(): ActionByMethod<'locator.uncheck'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.uncheck',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'checkbox',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createClearAction(): ActionByMethod<'locator.clear'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.clear',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'textbox',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createClickAction(): ActionByMethod<'locator.click'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.click',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'button',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createFillAction(): ActionByMethod<'locator.fill'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.fill',
+    value: '',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'textbox',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createSelectOptionAction(): ActionByMethod<'locator.selectOption'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.selectOption',
+    values: [{ value: '' }],
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: 'combobox',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}
+
+export function createGoToAction(): ActionByMethod<'page.goto'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'page.goto',
+    url: 'https://example.com',
+  }
+}
+
+export function createPageReloadAction(): ActionByMethod<'page.reload'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'page.reload',
+  }
+}
+
+export function createWaitForTimeoutAction(): ActionByMethod<'page.waitForTimeout'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'page.waitForTimeout',
+    timeout: 1000,
+  }
+}
+
+export function createWaitForAction(): ActionByMethod<'locator.waitFor'> {
+  return {
+    id: crypto.randomUUID(),
+    method: 'locator.waitFor',
+    locator: {
+      current: 'role',
+      values: {
+        role: {
+          type: 'role',
+          role: '',
+          options: {
+            exact: false,
+          },
+        },
+      },
+    },
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The action editor was using a needlessly generic way of creating new actions where the `addAction` function would take the type of action to create, resolve this type to a specific factory function and then create the action.

This way of doing things made it hard to create actions initialized with specific data and would have required me to add an additional function to do so.

This PR refactors this so that it is the responsibility of creating the action lies on each specific menu item in the "Add action" menu. This removes on layer of indirection and makes the creating of actions easier to understand.

## How to Test

Create a browser editor test and add actions to it.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to browser test editor UI wiring; main risk is mismatched defaults or method strings causing newly added actions to be malformed.
> 
> **Overview**
> Refactors the Browser Test Editor so `onAddAction` receives a fully constructed `BrowserActionInstance` rather than a `method` string, shifting responsibility for action instantiation to the UI layer.
> 
> Introduces `actionFactories.ts` with explicit factory helpers (e.g., `createClickAction`, `createGoToAction`) and removes action-creation logic (`createActionInstance` and per-editor `create`) from `actionEditorRegistry.tsx`, simplifying the registry to rendering/metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a72e56177325cdaafe05b06cc06ce82fcbaca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->