### PR TITLE
fix(autocorrelation): Sanitize tool-result outputs to prevent AI SDK validation error

### DIFF
--- a/src/handlers/ai/index.test.ts
+++ b/src/handlers/ai/index.test.ts
@@ -15,6 +15,10 @@ vi.mock('ai', () => ({
   streamText: vi.fn(),
 }))
 
+vi.mock('@sentry/electron/main', () => ({
+  captureException: vi.fn(),
+}))
+
 vi.mock('./grafanaAssistantProvider', () => ({
   GrafanaAssistantLanguageModel: vi.fn(),
 }))
@@ -75,6 +79,60 @@ describe('handleStreamChat', () => {
     expect(event.sender.send).toHaveBeenCalledWith(AiHandler.StreamChatEnd, {
       id: 'test-request-id',
     })
+  })
+
+  it('strips undefined values from tool-result outputs before calling streamText', async () => {
+    const { convertToModelMessages, streamText } = await import('ai')
+    vi.mocked(streamText).mockClear()
+
+    const messagesWithUndefined = [
+      {
+        role: 'user' as const,
+        content: [{ type: 'text' as const, text: 'hi' }],
+      },
+      {
+        role: 'tool' as const,
+        content: [
+          {
+            type: 'tool-result' as const,
+            toolCallId: 'call-1',
+            toolName: 'getRequestsMetadata',
+            output: {
+              type: 'json' as const,
+              value: [
+                { id: '1', statusCode: 200 },
+                { id: '2', statusCode: undefined },
+              ],
+            },
+          },
+        ],
+      },
+    ]
+
+    vi.mocked(convertToModelMessages).mockReturnValue(
+      messagesWithUndefined as never
+    )
+    vi.mocked(streamText).mockReturnValue({} as never)
+
+    const { streamMessages } = await import('./streamMessages')
+    vi.mocked(streamMessages).mockResolvedValue()
+
+    const event = createMockEvent()
+    const request = createRequest()
+
+    await handleStreamChat(event, request)
+
+    expect(streamText).toHaveBeenCalledOnce()
+    const passedMessages = vi.mocked(streamText).mock.calls[0]![0].messages
+    const toolMessage = passedMessages![1] as {
+      content: Array<{
+        output: { value: Array<Record<string, unknown>> }
+      }>
+    }
+    const secondItem = toolMessage.content[0]!.output.value[1]
+
+    expect(secondItem).not.toHaveProperty('statusCode')
+    expect(secondItem).toEqual({ id: '2' })
   })
 
   it('sends Unknown error when catch receives a non-Error value', async () => {

--- a/src/handlers/ai/index.ts
+++ b/src/handlers/ai/index.ts
@@ -1,6 +1,9 @@
-import { convertToModelMessages, streamText } from 'ai'
+import { captureException } from '@sentry/electron/main'
+import { convertToModelMessages, ModelMessage, streamText } from 'ai'
 import { ipcMain, IpcMainEvent } from 'electron'
 import log from 'electron-log/main'
+
+import { stripUndefined } from '@/utils/object'
 
 import * as assistantAuth from './a2a/assistantAuth'
 import { GrafanaAssistantLanguageModel } from './grafanaAssistantProvider'
@@ -22,12 +25,14 @@ export async function handleStreamChat(
   event: IpcMainEvent,
   request: StreamChatRequest
 ) {
-  const messages = convertToModelMessages(request.messages)
-
   const abortController = new AbortController()
   activeAbortControllers.set(request.id, abortController)
 
   try {
+    const messages = sanitizeModelMessages(
+      convertToModelMessages(request.messages)
+    )
+
     const response = streamText({
       model: grafanaAssistantModel,
       messages,
@@ -47,6 +52,8 @@ export async function handleStreamChat(
     }
 
     log.error('handleStreamChat error:', error)
+    captureException(error, { tags: { component: 'ai-chat' } })
+
     event.sender.send(AiHandler.StreamChatChunk, {
       id: request.id,
       chunk: {
@@ -60,6 +67,26 @@ export async function handleStreamChat(
   } finally {
     activeAbortControllers.delete(request.id)
   }
+}
+
+// AI SDK's Zod schema rejects `undefined` in tool-result outputs.
+// Strip undefined-valued keys before validation.
+function sanitizeModelMessages(messages: ModelMessage[]): ModelMessage[] {
+  return messages.map((message) => {
+    if (message.role !== 'tool') return message
+
+    return {
+      ...message,
+      content: message.content.map((part) => {
+        if (part.type !== 'tool-result') return part
+
+        return {
+          ...part,
+          output: stripUndefined(part.output) as typeof part.output,
+        }
+      }),
+    }
+  })
 }
 
 function handleAbortStreamChat(


### PR DESCRIPTION
## Description

Autocorrelation fails with "Invalid prompt: The messages must be a ModelMessage[]" when a recording contains requests without responses (e.g. WebSocket upgrades, incomplete requests). This surfaces as [K6-STUDIO-10D](https://load-impact.sentry.io/issues/K6-STUDIO-10D) in Sentry, affecting 64 users since March.

The root cause is in the AI SDK's internal validation pipeline. Tool handlers like `getRequestsMetadata` return objects with `undefined` values via optional chaining (`data.response?.statusCode` produces `statusCode: undefined` when there's no response). When these tool results are converted to model messages, the SDK's Zod schema rejects `undefined` as an invalid JSON value.

The fix sanitizes tool-result outputs in `handleStreamChat` using the existing `stripUndefined` utility, which removes keys with `undefined` values before the SDK validates them. This runs at the global handler level so all current and future tool outputs are covered.

Additionally:
- Moved `convertToModelMessages` inside the try/catch so conversion errors are caught and reported instead of becoming unhandled rejections
- Added `Sentry.captureException` for AI chat errors so failures are reported from the main process with full error cause chains (previously only the renderer captured a stripped-down error message via console)

## How to Test
[quickpizza.grafana.com - 2025-10-24.har.zip](https://github.com/user-attachments/files/27516114/quickpizza.grafana.com.-.2025-10-24.har.zip)


1. Import the attached HAR recording and create a generator from it - the recording has one of response bodies removed
2. Click **Autocorrelate** > **Analyze recording**
3. Verify autocorrelation completes without the "Something went wrong" error

It's expected that autocorrelation won't solve this, because it's missing crucial response body. 
## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- [K6-STUDIO-10D](https://load-impact.sentry.io/issues/K6-STUDIO-10D)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the main-process AI chat request pipeline by mutating tool-result payloads and adds new Sentry reporting, which could affect prompt/tool behavior and error handling at runtime.
> 
> **Overview**
> Pre-sanitizes AI `tool-result` message outputs in `handleStreamChat` by recursively removing `undefined`-valued keys (via `stripUndefined`) before calling `streamText`, preventing AI SDK validation failures when tools return optional fields.
> 
> Moves message conversion into the `try` block and adds `@sentry/electron/main` `captureException` on chat failures so conversion/streaming errors are caught, reported, and still result in the existing error/end IPC events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94dd2ecc5e8d1b12fd0a9cf40e13687bd14c9f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->