### PR TITLE
fix(autocorrelation): Handle context window exceeded error

### DIFF
--- a/src/views/Generator/AutoCorrelation/AutoCorrelation.tsx
+++ b/src/views/Generator/AutoCorrelation/AutoCorrelation.tsx
@@ -74,7 +74,14 @@ export function AutoCorrelation({
   }
 
   if (error) {
-    return <ErrorMessage error={error} onRetry={restart} onReset={reset} />
+    return (
+      <ErrorMessage
+        error={error}
+        onRetry={restart}
+        onReset={reset}
+        onClose={close}
+      />
+    )
   }
 
   return (

--- a/src/views/Generator/AutoCorrelation/ErrorMessage.test.tsx
+++ b/src/views/Generator/AutoCorrelation/ErrorMessage.test.tsx
@@ -14,6 +14,7 @@ vi.mock('@/assets/grot-crashed.svg', () => ({
 const baseProps = {
   onRetry: vi.fn(),
   onReset: vi.fn(),
+  onClose: vi.fn(),
 }
 
 afterEach(cleanup)
@@ -46,6 +47,17 @@ describe('ErrorMessage', () => {
       />
     )
     expect(screen.getByText('Usage limit reached')).toBeDefined()
+  })
+
+  it('renders "Recording too large" for context exceeded error', () => {
+    render(
+      <ErrorMessage
+        {...baseProps}
+        error={new Error('prompt is too long: 213329 tokens > 200000 maximum')}
+      />
+    )
+    expect(screen.getByText('Recording too large')).toBeDefined()
+    expect(screen.getByRole('button', { name: /Close/ })).toBeDefined()
   })
 
   it('renders "Something went wrong" for unknown error', () => {

--- a/src/views/Generator/AutoCorrelation/ErrorMessage.tsx
+++ b/src/views/Generator/AutoCorrelation/ErrorMessage.tsx
@@ -15,12 +15,14 @@ interface AutoCorrelationErrorProps {
   error: Error
   onRetry: () => void
   onReset: () => void
+  onClose: () => void
 }
 
 export function ErrorMessage({
   error,
   onRetry,
   onReset,
+  onClose,
 }: AutoCorrelationErrorProps) {
   const { mutate: signOut } = useAssistantSignOut()
 
@@ -30,6 +32,7 @@ export function ErrorMessage({
       handlers={{
         onRetry,
         onReset,
+        onClose,
         onReconnect: () => {
           signOut()
           onReset()
@@ -42,6 +45,7 @@ export function ErrorMessage({
 interface ErrorActionHandlers {
   onRetry: () => void
   onReset: () => void
+  onClose: () => void
   onReconnect: () => void
 }
 
@@ -74,6 +78,16 @@ const ERROR_CONTENT: Record<AssistantErrorInfo['category'], ErrorContent> = {
       <Button onClick={onReconnect}>
         <LinkIcon />
         Reconnect
+      </Button>
+    ),
+  },
+  'context-exceeded': {
+    title: 'Recording too large',
+    message:
+      'This recording has too many requests for AI analysis. Try filtering out unnecessary requests or splitting your recording into smaller sessions.',
+    renderActions: ({ onClose }) => (
+      <Button onClick={onClose} variant="outline">
+        Close
       </Button>
     ),
   },

--- a/src/views/Generator/AutoCorrelation/utils/classifyError.test.ts
+++ b/src/views/Generator/AutoCorrelation/utils/classifyError.test.ts
@@ -22,6 +22,15 @@ describe('classifyError', () => {
     })
   })
 
+  describe('context exceeded errors', () => {
+    it.each([
+      'prompt is too long: 213329 tokens > 200000 maximum',
+      'Execution failed to complete: LLM streaming failed | stopping_reason=context_window_exceeded',
+    ])('classifies "%s" as context-exceeded', (message) => {
+      expect(classifyError(message).category).toBe('context-exceeded')
+    })
+  })
+
   describe('quota errors', () => {
     it.each([
       'Monthly prompt limit of 10 reached for your account.',

--- a/src/views/Generator/AutoCorrelation/utils/classifyError.ts
+++ b/src/views/Generator/AutoCorrelation/utils/classifyError.ts
@@ -1,5 +1,6 @@
 export type AssistantErrorCategory =
   | 'auth-expired'
+  | 'context-exceeded'
   | 'quota-exceeded'
   | 'network'
   | 'unknown'
@@ -17,6 +18,13 @@ export function classifyError(message: string): AssistantErrorInfo {
     lowerMessage.includes('fetch failed')
   ) {
     return { category: 'network', message }
+  }
+
+  if (
+    lowerMessage.includes('prompt is too long') ||
+    lowerMessage.includes('context_window_exceeded')
+  ) {
+    return { category: 'context-exceeded', message }
   }
 
   if (


### PR DESCRIPTION
## Description

When autocorrelation sends a recording large enough to exceed the LLM context window, the error from Grafana Assistant was classified as unknown, showing a generic "Something went wrong" with a Retry button that would fail again.

This adds a `context-exceeded` error category that matches `"prompt is too long"` and `"context_window_exceeded"` in the error message. The error screen tells the user their recording is too large and offers a Close button that dismisses the dialog so they can reduce the recording size.

This also makes it easier to track how often users hit this limit, since the error is now classified distinctly instead of lumped into unknown errors.

Depends on https://github.com/grafana/grafana-assistant-app/pull/6549 to surface the actual error message from the assistant.

<img width="2450" height="1546" alt="screencapture 2026-05-11 at 09 35 44@2x" src="https://github.com/user-attachments/assets/d00a24a2-6306-4e90-954c-c8b955b9d677" />


## How to Test

1. In `useGenerateRules.ts`, duplicate the system prompt text a bunch times in the `sendMessage` call to exceed the 200k token limit  
    <img width="400" alt="screencapture 2026-05-11 at 09 36 24@2x" src="https://github.com/user-attachments/assets/ef9791a6-6625-4784-a961-a96aa2d28cbc" />
2. Start autocorrelation on any recording
3. Verify "Recording too large" error is displayed with a Close button
4. Click Close, verify it dismisses the autocorrelation dialog

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- https://github.com/grafana/grafana-assistant-app/pull/6549

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped UI/error-classification changes for a specific assistant failure mode, with added unit tests; main risk is misclassification affecting which action buttons users see.
> 
> **Overview**
> Improves autocorrelation error handling by introducing a new `context-exceeded` error category (matching messages like `prompt is too long` / `context_window_exceeded`) and displaying a dedicated "Recording too large" state.
> 
> The error UI now supports an `onClose` handler and shows a **Close** action for context-limit failures so users can dismiss the dialog instead of repeatedly retrying; corresponding tests were added/updated for both classification and rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50888000aca070abb5f2271b1a5aa2074861127a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->