### PR TITLE
internal(browser): Create browser test from recording

### DIFF
--- a/src/codegen/browser/convertEventsToActions.test.ts
+++ b/src/codegen/browser/convertEventsToActions.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { ElementSelector } from '@/schemas/recording'
+import { BrowserEvent, ElementSelector } from '@/schemas/recording'
 
-import { toLocatorOptions } from './convertEventsToActions'
+import {
+  convertEventsToActions,
+  toLocatorOptions,
+} from './convertEventsToActions'
 
 describe('toLocatorOptions', () => {
   it('populates css locator from selector', () => {
@@ -118,5 +121,265 @@ describe('toLocatorOptions', () => {
     }
     const result = toLocatorOptions(selector)
     expect(result.current).toBe('placeholder')
+  })
+})
+
+function makeTarget(css = 'div.test') {
+  return { selectors: { css } }
+}
+
+describe('convertEventsToActions', () => {
+  it('returns empty array for empty events', () => {
+    expect(convertEventsToActions([])).toEqual([])
+  })
+
+  it('converts navigate-to-page to page.goto', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'navigate-to-page',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        url: 'https://example.com',
+        source: 'address-bar',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'page.goto',
+      url: 'https://example.com',
+    })
+  })
+
+  it('converts reload-page to page.reload', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'reload-page',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        url: 'https://example.com',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'page.reload' })
+  })
+
+  it('converts click to locator.click with button and modifiers', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'click',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('button.submit'),
+        button: 'right',
+        modifiers: { ctrl: true, shift: false, alt: true, meta: false },
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'locator.click',
+      options: { button: 'right', modifiers: ['Alt', 'Control'] },
+    })
+  })
+
+  it('converts click with default button and no modifiers without options', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'click',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget(),
+        button: 'left',
+        modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.click' })
+    expect((actions[0] as { options?: unknown }).options).toBeUndefined()
+  })
+
+  it('converts input-change to locator.fill', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'input-change',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('input.name'),
+        value: 'John',
+        sensitive: false,
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.fill', value: 'John' })
+  })
+
+  it('converts check-change (checked=true) to locator.check', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'check-change',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('input[type=checkbox]'),
+        checked: true,
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.check' })
+  })
+
+  it('converts check-change (checked=false) to locator.uncheck', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'check-change',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('input[type=checkbox]'),
+        checked: false,
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.uncheck' })
+  })
+
+  it('converts radio-change to locator.click', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'radio-change',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('input[type=radio]'),
+        name: 'color',
+        value: 'red',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.click' })
+  })
+
+  it('converts select-change to locator.selectOption', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'select-change',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('select'),
+        selected: ['opt1', 'opt2'],
+        multiple: true,
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'locator.selectOption',
+      values: [{ value: 'opt1' }, { value: 'opt2' }],
+    })
+  })
+
+  it('converts submit-form to locator.click on submitter', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'submit-form',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        form: makeTarget('form'),
+        submitter: makeTarget('button[type=submit]'),
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({ method: 'locator.click' })
+    expect(
+      (actions[0] as { locator: { values: { css: { selector: string } } } })
+        .locator.values.css?.selector
+    ).toBe('button[type=submit]')
+  })
+
+  it('converts wait-for to locator.waitFor with options', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'wait-for',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('div.loading'),
+        options: { state: 'hidden', timeout: 5000 },
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'locator.waitFor',
+      options: { state: 'hidden', timeout: 5000 },
+    })
+  })
+
+  it('skips assert events', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'assert',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget(),
+        assertion: { type: 'visibility', visible: true },
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(0)
+  })
+
+  it('preserves event order and generates unique ids', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'navigate-to-page',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        url: 'https://example.com',
+        source: 'address-bar',
+      },
+      {
+        type: 'click',
+        eventId: '2',
+        timestamp: 100,
+        tab: 'tab1',
+        target: makeTarget('button'),
+        button: 'left',
+        modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      },
+      {
+        type: 'input-change',
+        eventId: '3',
+        timestamp: 200,
+        tab: 'tab1',
+        target: makeTarget('input'),
+        value: 'hello',
+        sensitive: false,
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(3)
+    expect(actions[0]!.method).toBe('page.goto')
+    expect(actions[1]!.method).toBe('locator.click')
+    expect(actions[2]!.method).toBe('locator.fill')
+    const ids = actions.map((action) => action.id)
+    expect(new Set(ids).size).toBe(3)
   })
 })

--- a/src/codegen/browser/convertEventsToActions.test.ts
+++ b/src/codegen/browser/convertEventsToActions.test.ts
@@ -24,7 +24,7 @@ describe('toLocatorOptions', () => {
     expect(result.values.role).toEqual({
       type: 'role',
       role: 'button',
-      options: { name: 'Submit' },
+      options: { name: 'Submit', exact: true },
     })
     expect(result.current).toBe('role')
   })
@@ -49,14 +49,22 @@ describe('toLocatorOptions', () => {
   it('populates alt locator when non-empty', () => {
     const selector: ElementSelector = { css: 'img', alt: 'Profile picture' }
     const result = toLocatorOptions(selector)
-    expect(result.values.alt).toEqual({ type: 'alt', text: 'Profile picture' })
+    expect(result.values.alt).toEqual({
+      type: 'alt',
+      text: 'Profile picture',
+      options: { exact: true },
+    })
     expect(result.current).toBe('alt')
   })
 
   it('populates label locator when non-empty', () => {
     const selector: ElementSelector = { css: 'input', label: 'Username' }
     const result = toLocatorOptions(selector)
-    expect(result.values.label).toEqual({ type: 'label', label: 'Username' })
+    expect(result.values.label).toEqual({
+      type: 'label',
+      label: 'Username',
+      options: { exact: true },
+    })
     expect(result.current).toBe('label')
   })
 
@@ -69,6 +77,7 @@ describe('toLocatorOptions', () => {
     expect(result.values.placeholder).toEqual({
       type: 'placeholder',
       placeholder: 'Enter name',
+      options: { exact: true },
     })
     expect(result.current).toBe('placeholder')
   })
@@ -76,7 +85,11 @@ describe('toLocatorOptions', () => {
   it('populates title locator when non-empty', () => {
     const selector: ElementSelector = { css: 'a', title: 'Home link' }
     const result = toLocatorOptions(selector)
-    expect(result.values.title).toEqual({ type: 'title', title: 'Home link' })
+    expect(result.values.title).toEqual({
+      type: 'title',
+      title: 'Home link',
+      options: { exact: true },
+    })
     expect(result.current).toBe('title')
   })
 

--- a/src/codegen/browser/convertEventsToActions.test.ts
+++ b/src/codegen/browser/convertEventsToActions.test.ts
@@ -343,6 +343,124 @@ describe('convertEventsToActions', () => {
     })
   })
 
+  it('skips implicit navigate-to-page events', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'navigate-to-page',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        url: 'https://example.com/login',
+        source: 'implicit',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(0)
+  })
+
+  it('keeps address-bar and history navigate-to-page events', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'navigate-to-page',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        url: 'https://example.com',
+        source: 'address-bar',
+      },
+      {
+        type: 'navigate-to-page',
+        eventId: '2',
+        timestamp: 100,
+        tab: 'tab1',
+        url: 'https://example.com/page',
+        source: 'history',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(2)
+  })
+
+  it('sets waitForNavigation on click followed by implicit navigation', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'click',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('a.link'),
+        button: 'left',
+        modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      },
+      {
+        type: 'navigate-to-page',
+        eventId: '2',
+        timestamp: 100,
+        tab: 'tab1',
+        url: 'https://example.com/next',
+        source: 'implicit',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'locator.click',
+      options: { waitForNavigation: true },
+    })
+  })
+
+  it('does not set waitForNavigation when next navigation is on different tab', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'click',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        target: makeTarget('a.link'),
+        button: 'left',
+        modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      },
+      {
+        type: 'navigate-to-page',
+        eventId: '2',
+        timestamp: 100,
+        tab: 'tab2',
+        url: 'https://example.com/next',
+        source: 'implicit',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect((actions[0] as { options?: unknown }).options).toBeUndefined()
+  })
+
+  it('sets waitForNavigation on submit-form followed by implicit navigation', () => {
+    const events: BrowserEvent[] = [
+      {
+        type: 'submit-form',
+        eventId: '1',
+        timestamp: 0,
+        tab: 'tab1',
+        form: makeTarget('form'),
+        submitter: makeTarget('button[type=submit]'),
+      },
+      {
+        type: 'navigate-to-page',
+        eventId: '2',
+        timestamp: 100,
+        tab: 'tab1',
+        url: 'https://example.com/dashboard',
+        source: 'implicit',
+      },
+    ]
+    const actions = convertEventsToActions(events)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]).toMatchObject({
+      method: 'locator.click',
+      options: { waitForNavigation: true },
+    })
+  })
+
   it('skips assert events', () => {
     const events: BrowserEvent[] = [
       {

--- a/src/codegen/browser/convertEventsToActions.test.ts
+++ b/src/codegen/browser/convertEventsToActions.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import { ElementSelector } from '@/schemas/recording'
+
+import { toLocatorOptions } from './convertEventsToActions'
+
+describe('toLocatorOptions', () => {
+  it('populates css locator from selector', () => {
+    const selector: ElementSelector = { css: 'div.foo' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.css).toEqual({ type: 'css', selector: 'div.foo' })
+    expect(result.current).toBe('css')
+  })
+
+  it('populates role locator and selects it as current', () => {
+    const selector: ElementSelector = {
+      css: 'button',
+      role: { role: 'button', name: 'Submit' },
+    }
+    const result = toLocatorOptions(selector)
+    expect(result.values.role).toEqual({
+      type: 'role',
+      role: 'button',
+      options: { name: 'Submit' },
+    })
+    expect(result.current).toBe('role')
+  })
+
+  it('populates testid locator when non-empty', () => {
+    const selector: ElementSelector = { css: 'div', testId: 'my-component' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.testid).toEqual({
+      type: 'testid',
+      testId: 'my-component',
+    })
+    expect(result.current).toBe('testid')
+  })
+
+  it('skips testid when empty string', () => {
+    const selector: ElementSelector = { css: 'div', testId: '' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.testid).toBeUndefined()
+    expect(result.current).toBe('css')
+  })
+
+  it('populates alt locator when non-empty', () => {
+    const selector: ElementSelector = { css: 'img', alt: 'Profile picture' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.alt).toEqual({ type: 'alt', text: 'Profile picture' })
+    expect(result.current).toBe('alt')
+  })
+
+  it('populates label locator when non-empty', () => {
+    const selector: ElementSelector = { css: 'input', label: 'Username' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.label).toEqual({ type: 'label', label: 'Username' })
+    expect(result.current).toBe('label')
+  })
+
+  it('populates placeholder locator when non-empty', () => {
+    const selector: ElementSelector = {
+      css: 'input',
+      placeholder: 'Enter name',
+    }
+    const result = toLocatorOptions(selector)
+    expect(result.values.placeholder).toEqual({
+      type: 'placeholder',
+      placeholder: 'Enter name',
+    })
+    expect(result.current).toBe('placeholder')
+  })
+
+  it('populates title locator when non-empty', () => {
+    const selector: ElementSelector = { css: 'a', title: 'Home link' }
+    const result = toLocatorOptions(selector)
+    expect(result.values.title).toEqual({ type: 'title', title: 'Home link' })
+    expect(result.current).toBe('title')
+  })
+
+  it('skips locators with empty or whitespace-only strings', () => {
+    const selector: ElementSelector = {
+      css: 'div',
+      alt: '',
+      label: '  ',
+      placeholder: '',
+      title: '',
+      testId: '',
+    }
+    const result = toLocatorOptions(selector)
+    expect(result.values.alt).toBeUndefined()
+    expect(result.values.label).toBeUndefined()
+    expect(result.values.placeholder).toBeUndefined()
+    expect(result.values.title).toBeUndefined()
+    expect(result.values.testid).toBeUndefined()
+    expect(result.current).toBe('css')
+  })
+
+  it('selects current by priority: role > label > alt > placeholder > title > testid > css', () => {
+    const selector: ElementSelector = {
+      css: 'input',
+      role: { role: 'textbox', name: 'Email' },
+      label: 'Email',
+      alt: 'email icon',
+      placeholder: 'Enter email',
+      title: 'Email field',
+      testId: 'email-input',
+    }
+    const result = toLocatorOptions(selector)
+    expect(result.current).toBe('role')
+    expect(Object.keys(result.values)).toHaveLength(7)
+  })
+
+  it('falls back through priority when higher-priority locators are missing', () => {
+    const selector: ElementSelector = {
+      css: 'input',
+      placeholder: 'Search',
+      testId: 'search-box',
+    }
+    const result = toLocatorOptions(selector)
+    expect(result.current).toBe('placeholder')
+  })
+})

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -1,0 +1,60 @@
+import { LocatorOptions } from '@/schemas/locator'
+import { ElementSelector } from '@/schemas/recording'
+
+function hasNonEmptyValue(value: string | undefined): value is string {
+  return value !== undefined && value.trim() !== ''
+}
+
+function pickBestLocatorType(
+  selector: ElementSelector
+): LocatorOptions['current'] {
+  if (selector.role !== undefined) return 'role'
+  if (hasNonEmptyValue(selector.label)) return 'label'
+  if (hasNonEmptyValue(selector.alt)) return 'alt'
+  if (hasNonEmptyValue(selector.placeholder)) return 'placeholder'
+  if (hasNonEmptyValue(selector.title)) return 'title'
+  if (hasNonEmptyValue(selector.testId)) return 'testid'
+  return 'css'
+}
+
+export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
+  const values: LocatorOptions['values'] = {
+    css: { type: 'css', selector: selector.css },
+  }
+
+  if (selector.role !== undefined) {
+    values.role = {
+      type: 'role',
+      role: selector.role.role,
+      options: { name: selector.role.name },
+    }
+  }
+
+  if (hasNonEmptyValue(selector.testId)) {
+    values.testid = { type: 'testid', testId: selector.testId }
+  }
+
+  if (hasNonEmptyValue(selector.alt)) {
+    values.alt = { type: 'alt', text: selector.alt }
+  }
+
+  if (hasNonEmptyValue(selector.label)) {
+    values.label = { type: 'label', label: selector.label }
+  }
+
+  if (hasNonEmptyValue(selector.placeholder)) {
+    values.placeholder = {
+      type: 'placeholder',
+      placeholder: selector.placeholder,
+    }
+  }
+
+  if (hasNonEmptyValue(selector.title)) {
+    values.title = { type: 'title', title: selector.title }
+  }
+
+  return {
+    current: pickBestLocatorType(selector),
+    values,
+  }
+}

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -2,6 +2,8 @@ import { AnyBrowserAction, LocatorClickModifier } from '@/schemas/browserTest'
 import { LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent, ClickEvent, ElementSelector } from '@/schemas/recording'
 
+import { isFollowedByImplicitNavigation } from './navigation'
+
 function hasNonEmptyValue(value: string | undefined): value is string {
   return value !== undefined && value.trim() !== ''
 }
@@ -91,17 +93,6 @@ function buildClickOptions(event: ClickEvent, nextEvent?: BrowserEvent) {
   }
 }
 
-function isFollowedByImplicitNavigation(
-  event: BrowserEvent,
-  nextEvent?: BrowserEvent
-): boolean {
-  return (
-    nextEvent?.type === 'navigate-to-page' &&
-    nextEvent.source === 'implicit' &&
-    nextEvent.tab === event.tab
-  )
-}
-
 function convertEvent(
   event: BrowserEvent,
   nextEvent?: BrowserEvent
@@ -153,16 +144,15 @@ function convertEvent(
         values: event.selected.map((value) => ({ value })),
       }
 
-    case 'submit-form': {
-      const waitForNav = isFollowedByImplicitNavigation(event, nextEvent)
-
+    case 'submit-form':
       return {
         id: crypto.randomUUID(),
         method: 'locator.click',
         locator: toLocatorOptions(event.submitter.selectors),
-        options: waitForNav ? { waitForNavigation: true } : undefined,
+        options: isFollowedByImplicitNavigation(event, nextEvent)
+          ? { waitForNavigation: true }
+          : undefined,
       }
-    }
 
     case 'wait-for':
       return {

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -71,26 +71,45 @@ export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
   }
 }
 
-function buildClickOptions(event: ClickEvent) {
+function buildClickOptions(event: ClickEvent, nextEvent?: BrowserEvent) {
   const modifiers: LocatorClickModifier[] = []
   if (event.modifiers.alt) modifiers.push('Alt')
   if (event.modifiers.ctrl) modifiers.push('Control')
   if (event.modifiers.meta) modifiers.push('Meta')
   if (event.modifiers.shift) modifiers.push('Shift')
 
-  const isDefaultClick = event.button === 'left' && modifiers.length === 0
+  const waitForNavigation = isFollowedByImplicitNavigation(event, nextEvent)
+  const isDefaultClick =
+    event.button === 'left' && modifiers.length === 0 && !waitForNavigation
 
   if (isDefaultClick) return undefined
 
   return {
     ...(event.button !== 'left' && { button: event.button }),
     ...(modifiers.length > 0 && { modifiers }),
+    ...(waitForNavigation && { waitForNavigation: true }),
   }
 }
 
-function convertEvent(event: BrowserEvent): AnyBrowserAction | undefined {
+function isFollowedByImplicitNavigation(
+  event: BrowserEvent,
+  nextEvent?: BrowserEvent
+): boolean {
+  return (
+    nextEvent?.type === 'navigate-to-page' &&
+    nextEvent.source === 'implicit' &&
+    nextEvent.tab === event.tab
+  )
+}
+
+function convertEvent(
+  event: BrowserEvent,
+  nextEvent?: BrowserEvent
+): AnyBrowserAction | undefined {
   switch (event.type) {
     case 'navigate-to-page':
+      if (event.source === 'implicit') return undefined
+
       return { id: crypto.randomUUID(), method: 'page.goto', url: event.url }
 
     case 'reload-page':
@@ -101,7 +120,7 @@ function convertEvent(event: BrowserEvent): AnyBrowserAction | undefined {
         id: crypto.randomUUID(),
         method: 'locator.click',
         locator: toLocatorOptions(event.target.selectors),
-        options: buildClickOptions(event),
+        options: buildClickOptions(event, nextEvent),
       }
 
     case 'input-change':
@@ -134,12 +153,16 @@ function convertEvent(event: BrowserEvent): AnyBrowserAction | undefined {
         values: event.selected.map((value) => ({ value })),
       }
 
-    case 'submit-form':
+    case 'submit-form': {
+      const waitForNav = isFollowedByImplicitNavigation(event, nextEvent)
+
       return {
         id: crypto.randomUUID(),
         method: 'locator.click',
         locator: toLocatorOptions(event.submitter.selectors),
+        options: waitForNav ? { waitForNavigation: true } : undefined,
       }
+    }
 
     case 'wait-for':
       return {
@@ -157,8 +180,8 @@ function convertEvent(event: BrowserEvent): AnyBrowserAction | undefined {
 export function convertEventsToActions(
   events: BrowserEvent[]
 ): AnyBrowserAction[] {
-  return events.flatMap((event) => {
-    const action = convertEvent(event)
+  return events.flatMap((event, index) => {
+    const action = convertEvent(event, events[index + 1])
     return action ? [action] : []
   })
 }

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -4,72 +4,54 @@ import { BrowserEvent, ClickEvent, ElementSelector } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 
 import { isFollowedByImplicitNavigation } from './navigation'
-
-function hasNonEmptyValue(value: string | undefined): value is string {
-  return value !== undefined && value.trim() !== ''
-}
-
-function pickBestLocatorType(
-  selector: ElementSelector
-): LocatorOptions['current'] {
-  if (selector.role !== undefined) return 'role'
-  if (hasNonEmptyValue(selector.label)) return 'label'
-  if (hasNonEmptyValue(selector.alt)) return 'alt'
-  if (hasNonEmptyValue(selector.placeholder)) return 'placeholder'
-  if (hasNonEmptyValue(selector.title)) return 'title'
-  if (hasNonEmptyValue(selector.testId)) return 'testid'
-  return 'css'
-}
+import {
+  getAltTextLocator,
+  getCssLocator,
+  getElementLocator,
+  getLabelLocator,
+  getPlaceholderLocator,
+  getRoleLocator,
+  getTestIdLocator,
+  getTitleLocator,
+} from './selectors'
 
 export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
   const values: LocatorOptions['values'] = {
-    css: { type: 'css', selector: selector.css },
+    css: getCssLocator(selector),
   }
 
-  if (selector.role !== undefined) {
-    values.role = {
-      type: 'role',
-      role: selector.role.role,
-      options: selector.role.name
-        ? { name: selector.role.name, exact: true }
-        : undefined,
-    }
+  const role = getRoleLocator(selector)
+  if (role !== null) {
+    values.role = role
   }
 
-  if (hasNonEmptyValue(selector.testId)) {
-    values.testid = { type: 'testid', testId: selector.testId }
+  const testid = getTestIdLocator(selector)
+  if (testid !== null) {
+    values.testid = testid
   }
 
-  if (hasNonEmptyValue(selector.alt)) {
-    values.alt = { type: 'alt', text: selector.alt, options: { exact: true } }
+  const alt = getAltTextLocator(selector)
+  if (alt !== null) {
+    values.alt = alt
   }
 
-  if (hasNonEmptyValue(selector.label)) {
-    values.label = {
-      type: 'label',
-      label: selector.label,
-      options: { exact: true },
-    }
+  const label = getLabelLocator(selector)
+  if (label !== null) {
+    values.label = label
   }
 
-  if (hasNonEmptyValue(selector.placeholder)) {
-    values.placeholder = {
-      type: 'placeholder',
-      placeholder: selector.placeholder,
-      options: { exact: true },
-    }
+  const placeholder = getPlaceholderLocator(selector)
+  if (placeholder !== null) {
+    values.placeholder = placeholder
   }
 
-  if (hasNonEmptyValue(selector.title)) {
-    values.title = {
-      type: 'title',
-      title: selector.title,
-      options: { exact: true },
-    }
+  const title = getTitleLocator(selector)
+  if (title !== null) {
+    values.title = title
   }
 
   return {
-    current: pickBestLocatorType(selector),
+    current: getElementLocator(selector).type,
     values,
   }
 }

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -27,7 +27,9 @@ export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
     values.role = {
       type: 'role',
       role: selector.role.role,
-      options: { name: selector.role.name },
+      options: selector.role.name
+        ? { name: selector.role.name, exact: true }
+        : undefined,
     }
   }
 
@@ -36,22 +38,31 @@ export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
   }
 
   if (hasNonEmptyValue(selector.alt)) {
-    values.alt = { type: 'alt', text: selector.alt }
+    values.alt = { type: 'alt', text: selector.alt, options: { exact: true } }
   }
 
   if (hasNonEmptyValue(selector.label)) {
-    values.label = { type: 'label', label: selector.label }
+    values.label = {
+      type: 'label',
+      label: selector.label,
+      options: { exact: true },
+    }
   }
 
   if (hasNonEmptyValue(selector.placeholder)) {
     values.placeholder = {
       type: 'placeholder',
       placeholder: selector.placeholder,
+      options: { exact: true },
     }
   }
 
   if (hasNonEmptyValue(selector.title)) {
-    values.title = { type: 'title', title: selector.title }
+    values.title = {
+      type: 'title',
+      title: selector.title,
+      options: { exact: true },
+    }
   }
 
   return {

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -1,6 +1,7 @@
 import { AnyBrowserAction, LocatorClickModifier } from '@/schemas/browserTest'
 import { LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent, ClickEvent, ElementSelector } from '@/schemas/recording'
+import { exhaustive } from '@/utils/typescript'
 
 import { isFollowedByImplicitNavigation } from './navigation'
 
@@ -164,6 +165,9 @@ function convertEvent(
 
     case 'assert':
       return undefined
+
+    default:
+      return exhaustive(event)
   }
 }
 

--- a/src/codegen/browser/convertEventsToActions.ts
+++ b/src/codegen/browser/convertEventsToActions.ts
@@ -1,5 +1,6 @@
+import { AnyBrowserAction, LocatorClickModifier } from '@/schemas/browserTest'
 import { LocatorOptions } from '@/schemas/locator'
-import { ElementSelector } from '@/schemas/recording'
+import { BrowserEvent, ClickEvent, ElementSelector } from '@/schemas/recording'
 
 function hasNonEmptyValue(value: string | undefined): value is string {
   return value !== undefined && value.trim() !== ''
@@ -57,4 +58,96 @@ export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
     current: pickBestLocatorType(selector),
     values,
   }
+}
+
+function buildClickOptions(event: ClickEvent) {
+  const modifiers: LocatorClickModifier[] = []
+  if (event.modifiers.alt) modifiers.push('Alt')
+  if (event.modifiers.ctrl) modifiers.push('Control')
+  if (event.modifiers.meta) modifiers.push('Meta')
+  if (event.modifiers.shift) modifiers.push('Shift')
+
+  const isDefaultClick = event.button === 'left' && modifiers.length === 0
+
+  if (isDefaultClick) return undefined
+
+  return {
+    ...(event.button !== 'left' && { button: event.button }),
+    ...(modifiers.length > 0 && { modifiers }),
+  }
+}
+
+function convertEvent(event: BrowserEvent): AnyBrowserAction | undefined {
+  switch (event.type) {
+    case 'navigate-to-page':
+      return { id: crypto.randomUUID(), method: 'page.goto', url: event.url }
+
+    case 'reload-page':
+      return { id: crypto.randomUUID(), method: 'page.reload' }
+
+    case 'click':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.click',
+        locator: toLocatorOptions(event.target.selectors),
+        options: buildClickOptions(event),
+      }
+
+    case 'input-change':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.fill',
+        locator: toLocatorOptions(event.target.selectors),
+        value: event.value,
+      }
+
+    case 'check-change':
+      return {
+        id: crypto.randomUUID(),
+        method: event.checked ? 'locator.check' : 'locator.uncheck',
+        locator: toLocatorOptions(event.target.selectors),
+      }
+
+    case 'radio-change':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.click',
+        locator: toLocatorOptions(event.target.selectors),
+      }
+
+    case 'select-change':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.selectOption',
+        locator: toLocatorOptions(event.target.selectors),
+        values: event.selected.map((value) => ({ value })),
+      }
+
+    case 'submit-form':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.click',
+        locator: toLocatorOptions(event.submitter.selectors),
+      }
+
+    case 'wait-for':
+      return {
+        id: crypto.randomUUID(),
+        method: 'locator.waitFor',
+        locator: toLocatorOptions(event.target.selectors),
+        options: event.options,
+      }
+
+    case 'assert':
+      return undefined
+  }
+}
+
+export function convertEventsToActions(
+  events: BrowserEvent[]
+): AnyBrowserAction[] {
+  return events.flatMap((event) => {
+    const action = convertEvent(event)
+    return action ? [action] : []
+  })
 }

--- a/src/codegen/browser/navigation.ts
+++ b/src/codegen/browser/navigation.ts
@@ -1,0 +1,12 @@
+import { BrowserEvent } from '@/schemas/recording'
+
+export function isFollowedByImplicitNavigation(
+  event: BrowserEvent,
+  nextEvent?: BrowserEvent
+): boolean {
+  return (
+    nextEvent?.type === 'navigate-to-page' &&
+    nextEvent.source === 'implicit' &&
+    nextEvent.tab === event.tab
+  )
+}

--- a/src/codegen/browser/selectors.ts
+++ b/src/codegen/browser/selectors.ts
@@ -11,6 +11,10 @@ import {
 import { ElementSelector } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 
+function hasNonEmptyString(value: string | undefined): value is string {
+  return value !== undefined && value.trim() !== ''
+}
+
 export function getRoleLocator(selectors: ElementSelector): RoleLocator | null {
   if (selectors.role === undefined) {
     return null
@@ -28,7 +32,7 @@ export function getRoleLocator(selectors: ElementSelector): RoleLocator | null {
 export function getAltTextLocator(
   selectors: ElementSelector
 ): AltLocator | null {
-  if (selectors.alt === undefined) {
+  if (!hasNonEmptyString(selectors.alt)) {
     return null
   }
 
@@ -42,7 +46,7 @@ export function getAltTextLocator(
 export function getLabelLocator(
   selectors: ElementSelector
 ): LabelLocator | null {
-  if (selectors.label === undefined) {
+  if (!hasNonEmptyString(selectors.label)) {
     return null
   }
 
@@ -56,7 +60,7 @@ export function getLabelLocator(
 export function getPlaceholderLocator(
   selectors: ElementSelector
 ): PlaceholderLocator | null {
-  if (selectors.placeholder === undefined) {
+  if (!hasNonEmptyString(selectors.placeholder)) {
     return null
   }
 
@@ -70,7 +74,7 @@ export function getPlaceholderLocator(
 export function getTitleLocator(
   selectors: ElementSelector
 ): TitleLocator | null {
-  if (selectors.title === undefined) {
+  if (!hasNonEmptyString(selectors.title)) {
     return null
   }
 
@@ -84,7 +88,7 @@ export function getTitleLocator(
 export function getTestIdLocator(
   selectors: ElementSelector
 ): TestIdLocator | null {
-  if (selectors.testId === undefined || selectors.testId.trim() === '') {
+  if (!hasNonEmptyString(selectors.testId)) {
     return null
   }
 

--- a/src/codegen/browser/test.ts
+++ b/src/codegen/browser/test.ts
@@ -10,6 +10,7 @@ import {
 import { toClickButton, toClickModifiers } from '@/utils/clickOptions'
 import { exhaustive } from '@/utils/typescript'
 
+import { isFollowedByImplicitNavigation } from './navigation'
 import { isLocatorEqual, getElementLocator } from './selectors'
 import {
   TestNode,
@@ -125,9 +126,7 @@ function buildBrowserNodeGraphFromEvents(events: BrowserEvent[]) {
   ): { page: NodeRef } | undefined {
     if (
       nextEvent === undefined ||
-      nextEvent.type !== 'navigate-to-page' ||
-      nextEvent.source !== 'implicit' ||
-      nextEvent.tab !== currentEvent.tab
+      !isFollowedByImplicitNavigation(currentEvent, nextEvent)
     ) {
       return undefined
     }

--- a/src/handlers/browserTest/index.ts
+++ b/src/handlers/browserTest/index.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { K6_BROWSER_TEST_FILE_EXTENSION } from '@/constants/files'
 import { BROWSER_TESTS_PATH } from '@/constants/workspace'
 import {
+  type AnyBrowserAction,
   BrowserTestFile,
   BrowserTestFileDataSchema,
   defaultBrowserTestOptions,
@@ -15,28 +16,31 @@ import { createFileWithUniqueName } from '@/utils/fileSystem'
 import { BrowserTestHandler } from './types'
 
 export function initialize() {
-  ipcMain.handle(BrowserTestHandler.Create, async () => {
-    console.info(`${BrowserTestHandler.Create} event received`)
+  ipcMain.handle(
+    BrowserTestHandler.Create,
+    async (_, actions?: AnyBrowserAction[]) => {
+      console.info(`${BrowserTestHandler.Create} event received`)
 
-    const emptyBrowserTest: BrowserTestFile = {
-      version: '1.0',
-      actions: [],
-      options: defaultBrowserTestOptions,
+      const browserTest: BrowserTestFile = {
+        version: '1.0',
+        actions: actions ?? [],
+        options: defaultBrowserTestOptions,
+      }
+
+      const filePath = await createFileWithUniqueName({
+        data: JSON.stringify(browserTest, null, 2),
+        directory: BROWSER_TESTS_PATH,
+        ext: K6_BROWSER_TEST_FILE_EXTENSION,
+        prefix: 'Browser',
+      })
+
+      trackEvent({
+        event: UsageEventName.BrowserTestCreated,
+      })
+
+      return filePath
     }
-
-    const filePath = await createFileWithUniqueName({
-      data: JSON.stringify(emptyBrowserTest, null, 2),
-      directory: BROWSER_TESTS_PATH,
-      ext: K6_BROWSER_TEST_FILE_EXTENSION,
-      prefix: 'Browser',
-    })
-
-    trackEvent({
-      event: UsageEventName.BrowserTestCreated,
-    })
-
-    return filePath
-  })
+  )
 
   ipcMain.handle(BrowserTestHandler.Open, async (_, filePath: string) => {
     console.info(`${BrowserTestHandler.Open} event received`)

--- a/src/handlers/browserTest/preload.ts
+++ b/src/handlers/browserTest/preload.ts
@@ -1,11 +1,14 @@
 import { ipcRenderer } from 'electron'
 
-import { BrowserTestFile } from '@/schemas/browserTest'
+import { AnyBrowserAction, BrowserTestFile } from '@/schemas/browserTest'
 
 import { BrowserTestHandler } from './types'
 
-export function create() {
-  return ipcRenderer.invoke(BrowserTestHandler.Create) as Promise<string>
+export function create(actions?: AnyBrowserAction[]) {
+  return ipcRenderer.invoke(
+    BrowserTestHandler.Create,
+    actions
+  ) as Promise<string>
 }
 
 export function open(filePath: string) {

--- a/src/hooks/useCreateBrowserTest.ts
+++ b/src/hooks/useCreateBrowserTest.ts
@@ -2,22 +2,26 @@ import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { getViewPath } from '@/routeMap'
+import { AnyBrowserAction } from '@/schemas/browserTest'
 import { useToast } from '@/store/ui/useToast'
 
 export function useCreateBrowserTest() {
   const showToast = useToast()
   const navigate = useNavigate()
 
-  return useCallback(async () => {
-    try {
-      const fileName = await window.studio.browserTest.create()
+  return useCallback(
+    async (actions?: AnyBrowserAction[]) => {
+      try {
+        const fileName = await window.studio.browserTest.create(actions)
 
-      navigate(getViewPath('browser-test', fileName))
-    } catch {
-      showToast({
-        status: 'error',
-        title: 'Failed to create browser test',
-      })
-    }
-  }, [navigate, showToast])
+        navigate(getViewPath('browser-test', fileName))
+      } catch {
+        showToast({
+          status: 'error',
+          title: 'Failed to create browser test',
+        })
+      }
+    },
+    [navigate, showToast]
+  )
 }

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -9,13 +9,16 @@ import { useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
 import { emitScript } from '@/codegen/browser'
+import { convertEventsToActions } from '@/codegen/browser/convertEventsToActions'
 import { convertEventsToTest } from '@/codegen/browser/test'
 import { DeleteFileDialog } from '@/components/DeleteFileDialog'
 import { RichDropdownMenuItem } from '@/components/RichDropdownMenuItem'
+import { useCreateBrowserTest } from '@/hooks/useCreateBrowserTest'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 import { useDeleteFile } from '@/hooks/useDeleteFile'
 import { getRoutePath, getViewPath } from '@/routeMap'
 import { BrowserEvent } from '@/schemas/recording'
+import { useFeaturesStore } from '@/store/features'
 import { useToast } from '@/store/ui/useToast'
 import { StudioFile } from '@/types'
 
@@ -42,7 +45,17 @@ export function RecordingPreviewControls({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const isDiscardable = Boolean(state?.discardable)
 
+  const isBrowserEditorEnabled = useFeaturesStore(
+    (state) => state.features['browser-test-editor']
+  )
+  const createBrowserTest = useCreateBrowserTest()
+
   const handleCreateGenerator = () => createTestGenerator(file.path)
+
+  const handleCreateBrowserTest = () => {
+    const actions = convertEventsToActions(browserEvents)
+    void createBrowserTest(actions)
+  }
 
   const handleDelete = useDeleteFile({
     file,
@@ -116,9 +129,17 @@ export function RecordingPreviewControls({
           <RichDropdownMenuItem
             icon={<MonitorIcon />}
             label="Browser test"
-            description="Export a k6 script simulating browser interactions"
+            description={
+              isBrowserEditorEnabled
+                ? 'Create a browser test from recorded interactions'
+                : 'Export a k6 script simulating browser interactions'
+            }
             disabled={browserEvents.length === 0}
-            onClick={() => setShowExportDialog(true)}
+            onClick={
+              isBrowserEditorEnabled
+                ? handleCreateBrowserTest
+                : () => setShowExportDialog(true)
+            }
           />
         </DropdownMenu.Content>
       </DropdownMenu.Root>

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -57,6 +57,14 @@ export function RecordingPreviewControls({
     void createBrowserTest(actions)
   }
 
+  const browserTestDescription = isBrowserEditorEnabled
+    ? 'Create a browser test from recorded interactions'
+    : 'Export a k6 script simulating browser interactions'
+
+  const handleBrowserTest = isBrowserEditorEnabled
+    ? handleCreateBrowserTest
+    : () => setShowExportDialog(true)
+
   const handleDelete = useDeleteFile({
     file,
     navigateHomeOnDelete: false,
@@ -129,17 +137,9 @@ export function RecordingPreviewControls({
           <RichDropdownMenuItem
             icon={<MonitorIcon />}
             label="Browser test"
-            description={
-              isBrowserEditorEnabled
-                ? 'Create a browser test from recorded interactions'
-                : 'Export a k6 script simulating browser interactions'
-            }
+            description={browserTestDescription}
             disabled={browserEvents.length === 0}
-            onClick={
-              isBrowserEditorEnabled
-                ? handleCreateBrowserTest
-                : () => setShowExportDialog(true)
-            }
+            onClick={handleBrowserTest}
           />
         </DropdownMenu.Content>
       </DropdownMenu.Root>


### PR DESCRIPTION
## Description

The "Browser test" option in the recording previewer's "Create test" menu now creates a browser test pre-populated with actions converted from the recording's browser events, then navigates to the BrowserTestEditor. Behind the `browser-test-editor` feature flag.

The conversion maps each recorded browser event (clicks, form fills, navigation, etc.) to its corresponding browser test action, populating all available locator options so the user can switch between locator strategies in the editor. Implicit navigations (caused by link clicks or form submissions) are filtered out, and the triggering action gets `waitForNavigation` set instead.

## How to Test

1. Open a recording that has browser events
2. Click "Create test > Browser test"
3. Verify:
   - Navigates to the BrowserTestEditor with a new browser test
   - Actions list is pre-populated matching the recorded events
   - Click actions that triggered navigation show the gear icon with `waitForNavigation` enabled
   - No duplicate `page.goto` actions for implicit navigations
4. Click the "Script" tab to verify the generated k6 script looks correct

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Resolves https://github.com/grafana/k6-studio/issues/1044

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new event-to-action conversion pipeline and wires it into the recording UI/IPC create flow; moderate risk due to new codegen logic affecting how browser tests are initialized and navigation waiting behavior.
> 
> **Overview**
> When the `browser-test-editor` feature flag is enabled, the Recording Previewer’s **Browser test** option now creates a new browser test file pre-populated with actions derived from the recording’s `browserEvents`, instead of only offering script export.
> 
> This introduces `convertEventsToActions` (with comprehensive tests) to map recorded events (navigation, clicks, fills, checks, selects, waits) into `AnyBrowserAction`s, **dropping implicit navigations** and setting `waitForNavigation` on the preceding click/submit when appropriate.
> 
> Locator generation is expanded to include all available locator strategies in `LocatorOptions` (role/label/alt/placeholder/title/testid/css) while filtering out empty strings, and `BrowserTestHandler.Create`/preload/create hook are updated to accept an optional actions payload when creating the test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dca1c6292643f0d84fbb300b91176e63e284974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->