### PR TITLE
ci: Restore Linux arm64 publish in release workflows

### DIFF
--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -186,7 +186,7 @@ jobs:
           echo "%__strip /bin/true" >> ~/.rpmmacros
 
           pnpm run publish
-          pnpm run publish -- --arch=arm64
+          pnpm run publish --arch=arm64
 
       - name: cleanup macos certificates
         if: startsWith(matrix.platform, 'macos-')

--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -103,7 +103,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
-          pnpm run publish -- --arch=x64
+          pnpm run publish --arch=x64
 
       - name: Get azure secrets
         id: get-azure-secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         run: |
-          pnpm run publish -- --arch=x64
+          pnpm run publish --arch=x64
 
       - name: Get azure secrets
         id: get-azure-secrets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
           echo "%__strip /bin/true" >> ~/.rpmmacros
 
           pnpm run publish
-          pnpm run publish -- --arch=arm64
+          pnpm run publish --arch=arm64
 
       - name: cleanup macos certificates
         if: startsWith(matrix.platform, 'macos-')


### PR DESCRIPTION
## Description

Linux arm64 `.deb` and `.rpm` artifacts have been missing from draft releases since #1216 (npm → pnpm switch). pnpm 11 forwards trailing flags to scripts inline, so the `--` separator inherited from npm-era usage was being passed to electron-forge as a positional and `--arch=arm64` was silently ignored. The Linux job ended up packaging x64 twice instead of producing arm64 artifacts.

Dropping the `--` restores the intended behavior on both `release.yml` and `release-test-version.yml`.

## How to Test

1. Trigger `Manual Release Test Version` against this branch with any version suffix.
2. Wait for the Linux job to finish.
3. On the draft release, confirm all four Linux artifacts are present:
   - `k6-studio_<version>_amd64.deb`
   - `k6-studio_<version>_arm64.deb`
   - `k6-studio-<version>-1.x86_64.rpm`
   - `k6-studio-<version>-1.arm64.rpm`

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Regressed by https://github.com/grafana/k6-studio/pull/1216

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release/publish workflow commands, which can affect what artifacts get built and uploaded to GitHub releases if the CLI flags are still mis-parsed. Scope is small and limited to GitHub Actions YAML.
> 
> **Overview**
> Fixes manual release workflows so `pnpm run publish` correctly passes architecture flags to the underlying build tooling.
> 
> Removes the npm-era `--` separator from `publish` invocations in `release.yml` and `release-test-version.yml`, ensuring the Linux `--arch=arm64` build actually produces arm64 `.deb`/`.rpm` artifacts (and macOS x64 uses the same corrected flag style).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39ac6120eece357dcacc94005e83886a6ffc39c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->