### PR TITLE
ci: Update release-please workflow to use GATB

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,32 +13,14 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
-      
+
     runs-on: ubuntu-latest
     steps:
-      - name: Retrieve release app credentials
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
         with:
-          repo_secrets: |
-            GITHUB_APP_ID=github-app:app-id
-            GITHUB_APP_INSTALLATION_ID=github-app:app-installation-id
-            GITHUB_APP_PRIVATE_KEY=github-app:private-key
-
-      - name: Get repository name
-        env:
-          REPOSITORY: ${{ github.repository }}
-        id: info
-        run: echo "repository_name=${REPOSITORY#*/}" >> "$GITHUB_OUTPUT"
-
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ steps.info.outputs.repository_name }}
+          github_app: k6-release-app
 
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,4 +24,4 @@ jobs:
 
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          token: ${{ steps.generate-token.outputs.token }}
+          token: ${{ steps.get-github-app-token.outputs.token }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR switch the release-please workflow from using `get-secrets` to GATB.

## How to Test

...

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CI workflow authentication for release automation; primary risk is misconfigured app/token generation breaking releases.
> 
> **Overview**
> Switches the `release-please` workflow from fetching Vault secrets + manually generating a GitHub App token to using `grafana/shared-workflows/actions/create-github-app-token` with `github_app: k6-release-app`.
> 
> Updates `release-please-action` to use the new step’s token output, removing the intermediate repo-name parsing and app credential plumbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab28d3cca664e1875db8f5651e72c60c227b69f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->