### PR TITLE
fix: Prevent debug script button from passing React event to IPC

### DIFF
--- a/src/views/Validator/DebuggerEmptyState.tsx
+++ b/src/views/Validator/DebuggerEmptyState.tsx
@@ -15,7 +15,7 @@ export function DebuggerEmptyState({
   return (
     <EmptyMessage
       message={children}
-      action={<Button onClick={onDebugScript}>Debug script</Button>}
+      action={<Button onClick={() => onDebugScript()}>Debug script</Button>}
       justify="center"
       maxHeight="800px"
       illustration={undefined}


### PR DESCRIPTION
## Description

Clicking "Debug script" from the empty state panel in the Validator view crashes with `Error: An object could not be cloned`. The button in `DebuggerEmptyState` passes `onDebugScript` directly to `onClick`, so React's MouseEvent becomes the first argument. That event flows through as `scenarioName` into `window.studio.script.runScript(path, mouseEvent)`, and the MouseEvent fails structured clone serialization at the IPC boundary.

The toolbar's debug button works fine because `ValidatorControls` wraps calls in arrow functions that pass explicit scenario names.

Fix: wrap the `onClick` so the event is discarded and `onDebugScript()` is called with no arguments, as intended.

<img width="1954" height="1094" alt="screencapture 2026-05-20 at 15 48 12@2x" src="https://github.com/user-attachments/assets/b35b9a58-35c5-492f-b6f0-ba3481dc2821" />


## How to Test

1. Open a script in the Validator
2. In the debug panel (not the toolbar), click "Debug script"
3. Script should start debugging without errors

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small UI handler change that only affects how the empty-state debug button invokes `onDebugScript`, reducing the chance of IPC/serialization errors.
> 
> **Overview**
> Prevents the Validator debug empty-state button from forwarding React’s click event by wrapping `onDebugScript` in an arrow function (`onClick={() => onDebugScript()}`), ensuring the callback is invoked with no arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5d2026a4e04ddc4bb3e90153a391cf7ebb0aa12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->