### PR TITLE
fix: Validate URL protocol before calling shell.openExternal

### DIFF
--- a/src/handlers/ai/a2a/assistantAuth.ts
+++ b/src/handlers/ai/a2a/assistantAuth.ts
@@ -11,6 +11,7 @@ import {
   startCallbackServer,
 } from '@/services/grafana/assistantAuth'
 import { browserWindowFromEvent } from '@/utils/electron'
+import { validateExternalUrl } from '@/utils/url'
 
 import { abortAllActiveAssistantSessions } from '../grafanaAssistantProvider'
 import { AssistantAuthHandler } from '../types'
@@ -91,7 +92,7 @@ async function performSignIn(
       'on port',
       port
     )
-    void shell.openExternal(authUrl)
+    void shell.openExternal(validateExternalUrl(authUrl))
 
     const code = verificationCode(codeChallenge)
     browserWindow.webContents.send(AssistantAuthHandler.VerificationCode, code)

--- a/src/handlers/auth/states.ts
+++ b/src/handlers/auth/states.ts
@@ -14,6 +14,7 @@ import {
   Stack,
 } from '@/types/auth'
 import { exhaustive } from '@/utils/typescript'
+import { validateExternalUrl } from '@/utils/url'
 
 import { waitFor } from '../utils'
 
@@ -135,7 +136,7 @@ export class SignInStateMachine extends EventEmitter<StateEventMap> {
     const result = await authenticate({
       signal: this.#signal,
       onUserCode: async (verificationUrl, code) => {
-        await shell.openExternal(verificationUrl)
+        await shell.openExternal(validateExternalUrl(verificationUrl))
 
         this.emit('state-change', {
           type: 'awaiting-authorization',

--- a/src/handlers/browser/index.ts
+++ b/src/handlers/browser/index.ts
@@ -5,6 +5,7 @@ import { launchBrowser } from '@/recorder/launch'
 import { BrowserLaunchError } from '@/recorder/launchers/types'
 import { LaunchBrowserOptions } from '@/recorder/types'
 import { browserWindowFromEvent } from '@/utils/electron'
+import { validateExternalUrl } from '@/utils/url'
 
 import { BrowserHandler } from './types'
 
@@ -77,6 +78,6 @@ export function initialize() {
   // TODO: Move to app or ui. The other handlers in this file are related to recording.
   ipcMain.handle(BrowserHandler.OpenExternalLink, (_, url: string) => {
     console.info(`${BrowserHandler.OpenExternalLink} event received`)
-    return shell.openExternal(url)
+    return shell.openExternal(validateExternalUrl(url))
   })
 }

--- a/src/handlers/cloud/index.ts
+++ b/src/handlers/cloud/index.ts
@@ -8,6 +8,7 @@ import { browserWindowFromEvent } from '@/utils/electron'
 import { logError } from '@/utils/errors'
 import { unlink, writeFile } from '@/utils/fs'
 import { basename, extname, isAbsolute, join } from '@/utils/path'
+import { validateExternalUrl } from '@/utils/url'
 
 import { RunInCloudStateMachine } from './states'
 import { CloudHandlers, RawScript, Script } from './types'
@@ -71,7 +72,7 @@ export function initialize() {
         trackEvent({
           event: UsageEventName.ScriptRunInCloud,
         })
-        await shell.openExternal(result.testRunUrl)
+        await shell.openExternal(validateExternalUrl(result.testRunUrl))
       }
 
       return result

--- a/src/utils/url.test.ts
+++ b/src/utils/url.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateExternalUrl } from './url'
+
+describe('validateExternalUrl', () => {
+  it('allows https URLs', () => {
+    expect(validateExternalUrl('https://example.com')).toBe(
+      'https://example.com'
+    )
+  })
+
+  it('allows http URLs', () => {
+    expect(validateExternalUrl('http://example.com')).toBe('http://example.com')
+  })
+
+  it('blocks javascript: protocol', () => {
+    expect(() => validateExternalUrl('javascript:alert(1)')).toThrow(
+      'Blocked URL with disallowed protocol: javascript:'
+    )
+  })
+
+  it('blocks file: protocol', () => {
+    expect(() => validateExternalUrl('file:///etc/passwd')).toThrow(
+      'Blocked URL with disallowed protocol: file:'
+    )
+  })
+
+  it('blocks data: protocol', () => {
+    expect(() => validateExternalUrl('data:text/html,<h1>hi</h1>')).toThrow(
+      'Blocked URL with disallowed protocol: data:'
+    )
+  })
+
+  it('blocks vbscript: protocol', () => {
+    expect(() => validateExternalUrl('vbscript:msgbox')).toThrow(
+      'Blocked URL with disallowed protocol: vbscript:'
+    )
+  })
+
+  it('throws on empty string', () => {
+    expect(() => validateExternalUrl('')).toThrow()
+  })
+
+  it('throws on malformed URL', () => {
+    expect(() => validateExternalUrl('not-a-url')).toThrow()
+  })
+})

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,9 @@
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:'])
+
+export function validateExternalUrl(url: string): string {
+  const parsed = new URL(url)
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`Blocked URL with disallowed protocol: ${parsed.protocol}`)
+  }
+  return url
+}


### PR DESCRIPTION
## Description

`shell.openExternal` is called in 4 places with dynamic URLs (renderer input, API responses, OAuth callbacks). None of them validate the URL protocol, so a compromised renderer or tampered API response could pass `javascript:`, `file:`, or `data:` URLs to open arbitrary local files or execute code.

This adds a `validateExternalUrl` utility that rejects anything other than `http:` or `https:` and applies it to the 4 dynamic call sites. Hardcoded URLs in the bug report helper and help menu are not affected.

## How to Test

1. Sign in to Grafana Cloud, verify the browser opens the auth page normally
2. Run a script in the cloud, verify the test run URL opens
3. Click any external link in the app (docs, release notes)

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Part of security hardening for critical findings from a codebase audit.