### PR TITLE
fix: Add path traversal protection to IPC file handlers

### DIFF
--- a/src/handlers/browserTest/index.ts
+++ b/src/handlers/browserTest/index.ts
@@ -11,6 +11,7 @@ import {
 import { trackEvent } from '@/services/usageTracking'
 import { UsageEventName } from '@/services/usageTracking/types'
 import { createFileWithUniqueName, readFile, writeFile } from '@/utils/fs'
+import * as path from '@/utils/path'
 
 import { BrowserTestHandler } from './types'
 
@@ -44,7 +45,12 @@ export function initialize() {
   ipcMain.handle(BrowserTestHandler.Open, async (_, filePath: string) => {
     console.info(`${BrowserTestHandler.Open} event received`)
 
-    const data = await readFile(filePath, {
+    const resolvedPath = path.ensureWithinDirectory(
+      BROWSER_TESTS_PATH,
+      filePath
+    )
+
+    const data = await readFile(resolvedPath, {
       encoding: 'utf-8',
       flag: 'r',
     })
@@ -57,7 +63,12 @@ export function initialize() {
     async (_, filePath: string, data: BrowserTestFile) => {
       console.info(`${BrowserTestHandler.Save} event received`)
 
-      await writeFile(filePath, JSON.stringify(data, null, 2))
+      const resolvedPath = path.ensureWithinDirectory(
+        BROWSER_TESTS_PATH,
+        filePath
+      )
+
+      await writeFile(resolvedPath, JSON.stringify(data, null, 2))
 
       trackEvent({
         event: UsageEventName.BrowserTestUpdated,

--- a/src/handlers/cloud/index.ts
+++ b/src/handlers/cloud/index.ts
@@ -7,7 +7,7 @@ import { UsageEventName } from '@/services/usageTracking/types'
 import { browserWindowFromEvent } from '@/utils/electron'
 import { logError } from '@/utils/errors'
 import { unlink, writeFile } from '@/utils/fs'
-import { basename, ensureWithinDirectory, extname, join } from '@/utils/path'
+import { basename, extname, isAbsolute, join } from '@/utils/path'
 
 import { RunInCloudStateMachine } from './states'
 import { CloudHandlers, RawScript, Script } from './types'
@@ -50,7 +50,9 @@ export function initialize() {
     const browserWindow = browserWindowFromEvent(event)
     const file = await toScriptFile(script)
 
-    const absolutePath = ensureWithinDirectory(SCRIPTS_PATH, file.path)
+    const absolutePath = !isAbsolute(file.path)
+      ? join(SCRIPTS_PATH, file.path)
+      : file.path
 
     try {
       if (stateMachine !== null) {

--- a/src/handlers/cloud/index.ts
+++ b/src/handlers/cloud/index.ts
@@ -7,7 +7,7 @@ import { UsageEventName } from '@/services/usageTracking/types'
 import { browserWindowFromEvent } from '@/utils/electron'
 import { logError } from '@/utils/errors'
 import { unlink, writeFile } from '@/utils/fs'
-import { basename, extname, isAbsolute, join } from '@/utils/path'
+import { basename, ensureWithinDirectory, extname, join } from '@/utils/path'
 
 import { RunInCloudStateMachine } from './states'
 import { CloudHandlers, RawScript, Script } from './types'
@@ -50,9 +50,7 @@ export function initialize() {
     const browserWindow = browserWindowFromEvent(event)
     const file = await toScriptFile(script)
 
-    const absolutePath = !isAbsolute(file.path)
-      ? join(SCRIPTS_PATH, file.path)
-      : file.path
+    const absolutePath = ensureWithinDirectory(SCRIPTS_PATH, file.path)
 
     try {
       if (stateMachine !== null) {

--- a/src/handlers/dataFiles/index.ts
+++ b/src/handlers/dataFiles/index.ts
@@ -43,9 +43,7 @@ export function initialize() {
   ipcMain.handle(
     DataFileHandler.LoadPreview,
     async (_, filePath: string): Promise<DataFilePreview> => {
-      const resolvedPath = path.isAbsolute(filePath)
-        ? filePath
-        : path.join(DATA_FILES_PATH, filePath)
+      const resolvedPath = path.ensureWithinDirectory(DATA_FILES_PATH, filePath)
 
       const fileType = path.extname(resolvedPath).slice(1)
 

--- a/src/handlers/generator/index.ts
+++ b/src/handlers/generator/index.ts
@@ -40,9 +40,11 @@ export function initialize() {
     async (_, generator: GeneratorFileData, filePath: string) => {
       console.log(`${GeneratorHandler.Save} event received`)
 
+      const resolvedPath = path.ensureWithinDirectory(GENERATORS_PATH, filePath)
+
       await writeFile(
-        filePath,
-        JSON.stringify(serializeGenerator(filePath, generator), null, 2)
+        resolvedPath,
+        JSON.stringify(serializeGenerator(resolvedPath, generator), null, 2)
       )
 
       trackGeneratorUpdated(generator)
@@ -54,12 +56,14 @@ export function initialize() {
     async (_, filePath: string): Promise<GeneratorFileData> => {
       console.log(`${GeneratorHandler.Open} event received`)
 
-      const data = await readFile(filePath, {
+      const resolvedPath = path.ensureWithinDirectory(GENERATORS_PATH, filePath)
+
+      const data = await readFile(resolvedPath, {
         encoding: 'utf-8',
         flag: 'r',
       })
 
-      return deserializeGenerator(filePath, data)
+      return deserializeGenerator(resolvedPath, data)
     }
   )
 }

--- a/src/handlers/har/index.ts
+++ b/src/handlers/har/index.ts
@@ -41,9 +41,7 @@ export function initialize() {
     async (_, filePath: string): Promise<Recording> => {
       console.info(`${HarHandler.OpenFile} event received`)
 
-      const resolvedPath = path.isAbsolute(filePath)
-        ? filePath
-        : path.join(RECORDINGS_PATH, filePath)
+      const resolvedPath = path.ensureWithinDirectory(RECORDINGS_PATH, filePath)
 
       const data = await readFile(resolvedPath, {
         encoding: 'utf-8',

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -65,10 +65,9 @@ export function initialize() {
       try {
         await waitForProxy()
 
-        const resolvedScriptPath = path.ensureWithinDirectory(
-          SCRIPTS_PATH,
-          scriptPath
-        )
+        const resolvedScriptPath = path.isAbsolute(scriptPath)
+          ? scriptPath
+          : path.join(SCRIPTS_PATH, scriptPath)
 
         currentTestRun = await runScript({
           browserWindow,
@@ -115,17 +114,13 @@ export function initialize() {
       console.info(`${ScriptHandler.RunFromGenerator} event received`)
 
       const browserWindow = browserWindowFromEvent(event)
-      const resolvedScriptPath = path.ensureWithinDirectory(
-        SCRIPTS_PATH,
-        scriptPath
-      )
 
       try {
-        await writeFile(resolvedScriptPath, script)
+        await writeFile(scriptPath, script)
 
         currentTestRun = await runScript({
           browserWindow,
-          scriptPath: resolvedScriptPath,
+          scriptPath,
           proxySettings: k6StudioState.appSettings.proxy,
           usageReport: k6StudioState.appSettings.telemetry.usageReport,
         })
@@ -149,7 +144,7 @@ export function initialize() {
 
         throw error
       } finally {
-        await unlink(resolvedScriptPath).catch(() => {
+        await unlink(scriptPath).catch(() => {
           // Best case effort cleanup.
         })
       }

--- a/src/handlers/script/index.ts
+++ b/src/handlers/script/index.ts
@@ -65,10 +65,10 @@ export function initialize() {
       try {
         await waitForProxy()
 
-        const absolute = path.isAbsolute(scriptPath)
-        const resolvedScriptPath = absolute
-          ? scriptPath
-          : path.join(SCRIPTS_PATH, scriptPath)
+        const resolvedScriptPath = path.ensureWithinDirectory(
+          SCRIPTS_PATH,
+          scriptPath
+        )
 
         currentTestRun = await runScript({
           browserWindow,
@@ -115,13 +115,17 @@ export function initialize() {
       console.info(`${ScriptHandler.RunFromGenerator} event received`)
 
       const browserWindow = browserWindowFromEvent(event)
+      const resolvedScriptPath = path.ensureWithinDirectory(
+        SCRIPTS_PATH,
+        scriptPath
+      )
 
       try {
-        await writeFile(scriptPath, script)
+        await writeFile(resolvedScriptPath, script)
 
         currentTestRun = await runScript({
           browserWindow,
-          scriptPath,
+          scriptPath: resolvedScriptPath,
           proxySettings: k6StudioState.appSettings.proxy,
           usageReport: k6StudioState.appSettings.telemetry.usageReport,
         })
@@ -145,7 +149,7 @@ export function initialize() {
 
         throw error
       } finally {
-        await unlink(scriptPath).catch(() => {
+        await unlink(resolvedScriptPath).catch(() => {
           // Best case effort cleanup.
         })
       }

--- a/src/utils/path.test.ts
+++ b/src/utils/path.test.ts
@@ -98,3 +98,45 @@ describe('equal', () => {
     expect(path.equal('/foo', '/foo')).toBe(true)
   })
 })
+
+describe('ensureWithinDirectory', () => {
+  it('resolves a relative filename within directory', () => {
+    expect(path.ensureWithinDirectory('/base', 'file.txt')).toBe(
+      '/base/file.txt'
+    )
+  })
+
+  it('passes a valid absolute path within directory', () => {
+    expect(path.ensureWithinDirectory('/base', '/base/sub/file.txt')).toBe(
+      '/base/sub/file.txt'
+    )
+  })
+
+  it('throws on ../ traversal', () => {
+    expect(() =>
+      path.ensureWithinDirectory('/base/sub', '../../../etc/passwd')
+    ).toThrow('Path is outside allowed directory')
+  })
+
+  it('throws on absolute path outside directory', () => {
+    expect(() => path.ensureWithinDirectory('/base', '/etc/passwd')).toThrow(
+      'Path is outside allowed directory'
+    )
+  })
+
+  it('throws on sibling-prefix attack', () => {
+    expect(() =>
+      path.ensureWithinDirectory('/foo/bar', '/foo/barbaz/file.txt')
+    ).toThrow('Path is outside allowed directory')
+  })
+
+  it('passes when path matches the base directory exactly', () => {
+    expect(path.ensureWithinDirectory('/base', '/base')).toBe('/base')
+  })
+
+  it('passes for a deeply nested valid path', () => {
+    expect(path.ensureWithinDirectory('/base', 'a/b/c/d/e/file.txt')).toBe(
+      '/base/a/b/c/d/e/file.txt'
+    )
+  })
+})

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -54,7 +54,7 @@ export function ensureWithinDirectory(
   const normalizedBase = resolve(baseDir)
   if (
     key(resolved) !== key(normalizedBase) &&
-    !key(resolved).startsWith(key(normalizedBase + sep))
+    !key(resolved).startsWith(key(normalizedBase + '/'))
   ) {
     throw new Error('Path is outside allowed directory')
   }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-imports */
-import { parse } from 'pathe'
+import { parse, resolve } from 'pathe'
 
 const platform =
   globalThis.window?.studio?.platform ?? globalThis.process?.platform
@@ -44,6 +44,21 @@ export function key(p: string): string {
  */
 export function equal(a: string, b: string): boolean {
   return key(a) === key(b)
+}
+
+export function ensureWithinDirectory(
+  baseDir: string,
+  filePath: string
+): string {
+  const resolved = resolve(baseDir, filePath)
+  const normalizedBase = resolve(baseDir)
+  if (
+    key(resolved) !== key(normalizedBase) &&
+    !key(resolved).startsWith(key(normalizedBase + sep))
+  ) {
+    throw new Error('Path is outside allowed directory')
+  }
+  return resolved
 }
 
 export {


### PR DESCRIPTION
## Description

IPC handlers that read or write files accept paths from the renderer without validating they stay within their expected workspace directory. A compromised renderer could send `../../../etc/passwd` or an absolute path outside the workspace to read arbitrary files, execute arbitrary scripts, or write to unexpected locations.

This adds `ensureWithinDirectory` to `src/utils/path.ts`, which resolves the path and throws if it escapes the base directory. It handles case-insensitive comparison on macOS/Windows and prevents sibling-prefix attacks (`/foo/barbaz` vs `/foo/bar`).

Applied to 8 call sites across 6 handler files: dataFiles, HAR, generator (Open + Save), browserTest (Open + Save), script (Run + RunFromGenerator), and cloud. `ScriptHandler.Open` and `ScriptHandler.Save` are intentionally excluded because they support external scripts selected via native file dialog.

## How to Test

1. Open a recording, generator, browser test, and script from the file list
2. Generate and validate a script
3. Save a generator and browser test
4. Run a script in the cloud

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Part of security hardening for critical findings from a codebase audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces path-traversal risk on main-process file I/O but leaves script run/open/save paths less restricted; behavior changes only when malicious or malformed paths are sent.
> 
> **Overview**
> Adds **`ensureWithinDirectory`** in `src/utils/path.ts` so renderer-supplied paths are resolved under a workspace root and rejected when they escape (e.g. `../`, absolute paths outside the base, or sibling-prefix tricks), using the existing **`key()`** normalization for case-insensitive platforms.
> 
> **Open/Save/Load** IPC handlers for **browser tests**, **generators**, **HAR recordings**, and **data file previews** now resolve paths through this helper instead of trusting absolute paths or naive `join`. **Unit tests** cover traversal, out-of-tree absolutes, and prefix edge cases.
> 
> **`ScriptHandler.Run`** only drops a redundant absolute-path branch; it does **not** use `ensureWithinDirectory` in this diff (and **Open/Save** remain unchanged for external scripts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bc11b33dd74c906f679e9f58a6c8648d0913fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->