### PR TITLE
fix: Encrypt Grafana Cloud API tokens

### DIFF
--- a/src/handlers/auth/fs.test.ts
+++ b/src/handlers/auth/fs.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Profile } from '@/schemas/profile'
+
+const mockEncryptString = vi.fn((value: string) => `encrypted:${value}`)
+const mockDecryptString = vi.fn((value: string) => {
+  if (!value.startsWith('encrypted:')) {
+    throw new Error('Decryption failed')
+  }
+  return value.replace('encrypted:', '')
+})
+const mockIsEncryptionAvailable = vi.fn(() => true)
+
+const mockReadFile = vi.fn()
+const mockWriteFile = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/k6-studio-test',
+  },
+}))
+
+vi.mock('electron-log/main', () => ({
+  default: { warn: vi.fn() },
+}))
+
+vi.mock('@/main/encryption', () => ({
+  encryptString: mockEncryptString,
+  decryptString: mockDecryptString,
+  isEncryptionAvailable: mockIsEncryptionAvailable,
+}))
+
+vi.mock('@/utils/fs', () => ({
+  readFile: mockReadFile,
+  writeFile: mockWriteFile,
+}))
+
+const testProfile: Profile = {
+  version: '1.0',
+  tokens: {
+    'stack-1': 'token-abc',
+    'stack-2': 'token-def',
+  },
+  profiles: {
+    currentStack: 'stack-1',
+    stacks: {
+      'stack-1': {
+        id: 'stack-1',
+        url: 'https://stack-1.grafana.net',
+        name: 'Stack 1',
+        user: { name: 'Test User', email: 'test@test.com', username: null },
+      },
+    },
+  },
+}
+
+describe('saveProfileData', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockEncryptString.mockImplementation(
+      (value: string) => `encrypted:${value}`
+    )
+    mockDecryptString.mockImplementation((value: string) => {
+      if (!value.startsWith('encrypted:')) {
+        throw new Error('Decryption failed')
+      }
+      return value.replace('encrypted:', '')
+    })
+    mockIsEncryptionAvailable.mockReturnValue(true)
+    mockWriteFile.mockResolvedValue(undefined)
+    mockReadFile.mockResolvedValue(JSON.stringify(testProfile))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('encrypts each token value before writing when encryption is available', async () => {
+    const { saveProfileData } = await import('./fs')
+
+    await saveProfileData(testProfile)
+
+    expect(mockEncryptString).toHaveBeenCalledWith('token-abc')
+    expect(mockEncryptString).toHaveBeenCalledWith('token-def')
+
+    const writtenJson = mockWriteFile.mock.calls[0]?.[1] as string
+    const writtenData = JSON.parse(writtenJson) as Profile
+    expect(writtenData.tokens['stack-1']).toBe('encrypted:token-abc')
+    expect(writtenData.tokens['stack-2']).toBe('encrypted:token-def')
+  })
+
+  it('writes file with mode 0o600', async () => {
+    const { saveProfileData } = await import('./fs')
+
+    await saveProfileData(testProfile)
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      { mode: 0o600 }
+    )
+  })
+
+  it('clears cache so next read re-fetches from disk', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        ...testProfile,
+        tokens: {
+          'stack-1': 'encrypted:token-abc',
+          'stack-2': 'encrypted:token-def',
+        },
+      })
+    )
+
+    const { getProfileData, saveProfileData } = await import('./fs')
+
+    await getProfileData()
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
+
+    await saveProfileData(testProfile)
+
+    await getProfileData()
+    expect(mockReadFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('writes plaintext tokens when encryption is unavailable', async () => {
+    mockIsEncryptionAvailable.mockReturnValue(false)
+
+    const { saveProfileData } = await import('./fs')
+
+    await saveProfileData(testProfile)
+
+    expect(mockEncryptString).not.toHaveBeenCalled()
+
+    const writtenJson = mockWriteFile.mock.calls[0]?.[1] as string
+    const writtenData = JSON.parse(writtenJson) as Profile
+    expect(writtenData.tokens['stack-1']).toBe('token-abc')
+    expect(writtenData.tokens['stack-2']).toBe('token-def')
+  })
+})
+
+describe('getProfileData', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    mockEncryptString.mockImplementation(
+      (value: string) => `encrypted:${value}`
+    )
+    mockDecryptString.mockImplementation((value: string) => {
+      if (!value.startsWith('encrypted:')) {
+        throw new Error('Decryption failed')
+      }
+      return value.replace('encrypted:', '')
+    })
+    mockIsEncryptionAvailable.mockReturnValue(true)
+    mockWriteFile.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('reads and decrypts token values', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        ...testProfile,
+        tokens: {
+          'stack-1': 'encrypted:token-abc',
+          'stack-2': 'encrypted:token-def',
+        },
+      })
+    )
+
+    const { getProfileData } = await import('./fs')
+
+    const result = await getProfileData()
+
+    expect(mockDecryptString).toHaveBeenCalledWith('encrypted:token-abc')
+    expect(mockDecryptString).toHaveBeenCalledWith('encrypted:token-def')
+    expect(result.tokens['stack-1']).toBe('token-abc')
+    expect(result.tokens['stack-2']).toBe('token-def')
+  })
+
+  it('falls back to raw value when decryptString throws (plaintext migration)', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify(testProfile))
+
+    const { getProfileData } = await import('./fs')
+
+    const result = await getProfileData()
+
+    expect(result.tokens['stack-1']).toBe('token-abc')
+    expect(result.tokens['stack-2']).toBe('token-def')
+  })
+
+  it('returns default profile when file does not exist', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'))
+
+    const { getProfileData } = await import('./fs')
+
+    const result = await getProfileData()
+
+    expect(result).toEqual({
+      version: '1.0',
+      tokens: {},
+      profiles: {
+        currentStack: '',
+        stacks: {},
+      },
+    })
+  })
+
+  it('caches result on second call', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        ...testProfile,
+        tokens: {
+          'stack-1': 'encrypted:token-abc',
+        },
+      })
+    )
+
+    const { getProfileData } = await import('./fs')
+
+    await getProfileData()
+    await getProfileData()
+
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/handlers/auth/fs.test.ts
+++ b/src/handlers/auth/fs.test.ts
@@ -86,8 +86,8 @@ describe('saveProfileData', () => {
 
     const writtenJson = mockWriteFile.mock.calls[0]?.[1] as string
     const writtenData = JSON.parse(writtenJson) as Profile
-    expect(writtenData.tokens['stack-1']).toBe('encrypted:token-abc')
-    expect(writtenData.tokens['stack-2']).toBe('encrypted:token-def')
+    expect(writtenData.tokens['stack-1']).toBe('enc:encrypted:token-abc')
+    expect(writtenData.tokens['stack-2']).toBe('enc:encrypted:token-def')
   })
 
   it('writes file with mode 0o600', async () => {
@@ -107,8 +107,8 @@ describe('saveProfileData', () => {
       JSON.stringify({
         ...testProfile,
         tokens: {
-          'stack-1': 'encrypted:token-abc',
-          'stack-2': 'encrypted:token-def',
+          'stack-1': 'enc:encrypted:token-abc',
+          'stack-2': 'enc:encrypted:token-def',
         },
       })
     )
@@ -166,8 +166,8 @@ describe('getProfileData', () => {
       JSON.stringify({
         ...testProfile,
         tokens: {
-          'stack-1': 'encrypted:token-abc',
-          'stack-2': 'encrypted:token-def',
+          'stack-1': 'enc:encrypted:token-abc',
+          'stack-2': 'enc:encrypted:token-def',
         },
       })
     )
@@ -182,7 +182,7 @@ describe('getProfileData', () => {
     expect(result.tokens['stack-2']).toBe('token-def')
   })
 
-  it('falls back to raw value when decryptString throws (plaintext migration)', async () => {
+  it('passes through plaintext tokens without prefix (migration)', async () => {
     mockReadFile.mockResolvedValue(JSON.stringify(testProfile))
 
     const { getProfileData } = await import('./fs')
@@ -191,6 +191,22 @@ describe('getProfileData', () => {
 
     expect(result.tokens['stack-1']).toBe('token-abc')
     expect(result.tokens['stack-2']).toBe('token-def')
+  })
+
+  it('discards tokens that have the encrypted prefix but fail to decrypt', async () => {
+    mockReadFile.mockResolvedValue(
+      JSON.stringify({
+        ...testProfile,
+        tokens: {
+          'stack-1': 'enc:corrupted-data',
+        },
+      })
+    )
+
+    const { getProfileData } = await import('./fs')
+    const result = await getProfileData()
+
+    expect(result.tokens).toEqual({})
   })
 
   it('returns default profile when file does not exist', async () => {
@@ -215,7 +231,7 @@ describe('getProfileData', () => {
       JSON.stringify({
         ...testProfile,
         tokens: {
-          'stack-1': 'encrypted:token-abc',
+          'stack-1': 'enc:encrypted:token-abc',
         },
       })
     )

--- a/src/handlers/auth/fs.ts
+++ b/src/handlers/auth/fs.ts
@@ -10,6 +10,8 @@ import { Profile, ProfileSchema } from '@/schemas/profile'
 import { readFile, writeFile } from '@/utils/fs'
 import * as path from '@/utils/path'
 
+const ENCRYPTED_PREFIX = 'enc:'
+
 const fileName =
   process.env.NODE_ENV === 'development'
     ? 'k6-studio-profile-dev.json'
@@ -30,7 +32,7 @@ function encryptProfileTokens(profile: Profile): Profile {
     tokens: Object.fromEntries(
       Object.entries(profile.tokens).map(([stackId, token]) => [
         stackId,
-        encryptString(token),
+        ENCRYPTED_PREFIX + encryptString(token),
       ])
     ),
   }
@@ -40,12 +42,19 @@ function decryptProfileTokens(profile: Profile): Profile {
   return {
     ...profile,
     tokens: Object.fromEntries(
-      Object.entries(profile.tokens).map(([stackId, token]) => {
-        try {
-          return [stackId, decryptString(token)]
-        } catch {
+      Object.entries(profile.tokens).flatMap(([stackId, token]) => {
+        if (!token.startsWith(ENCRYPTED_PREFIX)) {
           // Plaintext token from before encryption was added
-          return [stackId, token]
+          return [[stackId, token]]
+        }
+        try {
+          return [
+            [stackId, decryptString(token.slice(ENCRYPTED_PREFIX.length))],
+          ]
+        } catch {
+          // Encrypted with different key (e.g. profile copied between machines)
+          log.warn('Failed to decrypt token for stack', stackId, '- discarding')
+          return []
         }
       })
     ),

--- a/src/handlers/auth/fs.ts
+++ b/src/handlers/auth/fs.ts
@@ -1,5 +1,11 @@
 import { app } from 'electron'
+import log from 'electron-log/main'
 
+import {
+  decryptString,
+  encryptString,
+  isEncryptionAvailable,
+} from '@/main/encryption'
 import { Profile, ProfileSchema } from '@/schemas/profile'
 import { readFile, writeFile } from '@/utils/fs'
 import * as path from '@/utils/path'
@@ -13,6 +19,39 @@ const filePath = path.join(app.getPath('userData'), fileName)
 
 let profileDataCache: Profile | null = null
 
+function encryptProfileTokens(profile: Profile): Profile {
+  if (!isEncryptionAvailable()) {
+    log.warn('Encryption unavailable, storing tokens in plaintext')
+    return profile
+  }
+
+  return {
+    ...profile,
+    tokens: Object.fromEntries(
+      Object.entries(profile.tokens).map(([stackId, token]) => [
+        stackId,
+        encryptString(token),
+      ])
+    ),
+  }
+}
+
+function decryptProfileTokens(profile: Profile): Profile {
+  return {
+    ...profile,
+    tokens: Object.fromEntries(
+      Object.entries(profile.tokens).map(([stackId, token]) => {
+        try {
+          return [stackId, decryptString(token)]
+        } catch {
+          // Plaintext token from before encryption was added
+          return [stackId, token]
+        }
+      })
+    ),
+  }
+}
+
 export async function getProfileData(): Promise<Profile> {
   if (profileDataCache) {
     return profileDataCache
@@ -20,7 +59,8 @@ export async function getProfileData(): Promise<Profile> {
 
   try {
     const file = await readFile(filePath, 'utf-8')
-    profileDataCache = ProfileSchema.parse(JSON.parse(file))
+    const parsed = ProfileSchema.parse(JSON.parse(file))
+    profileDataCache = decryptProfileTokens(parsed)
 
     return profileDataCache
   } catch {
@@ -37,7 +77,8 @@ export async function getProfileData(): Promise<Profile> {
 
 export async function saveProfileData(profile: Profile) {
   try {
-    await writeFile(filePath, JSON.stringify(profile, null, 2))
+    const toSave = encryptProfileTokens(profile)
+    await writeFile(filePath, JSON.stringify(toSave, null, 2), { mode: 0o600 })
   } finally {
     profileDataCache = null
   }


### PR DESCRIPTION
## Description

Grafana Cloud API tokens in `k6-studio-profile.json` are stored as plaintext. The assistant token store already encrypts tokens using Electron's `safeStorage` via the utilities in `src/main/encryption.ts`, but the same approach wasn't applied to the main profile tokens.

This encrypts tokens on save and decrypts on read, following the same pattern as `tokenStore.ts`. The file is now written with `mode: 0o600`. Migration is transparent: on read, if decryption fails (plaintext token from before this change), the raw value is used and will be encrypted on the next save.

When encryption is unavailable (Linux without a secure keyring backend), tokens are stored in plaintext with a logged warning.

## How to Test

1. Sign in to Grafana Cloud
2. Verify the app works normally (script validation, cloud runs)
3. Inspect `k6-studio-profile.json` in the app data directory and confirm token values are encoded, not plaintext
4. Sign out and sign back in to verify the migration path

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Part of security hardening for critical findings from a codebase audit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how API credentials are persisted and read; mistakes could break sign-in or leak tokens, though behavior mirrors an existing encrypted store and includes fallbacks and tests.
> 
> **Overview**
> Grafana Cloud API tokens in the profile JSON file are no longer written in plaintext. **`saveProfileData`** encrypts each stack token with Electron **`safeStorage`** (via **`encryptString`**) and stores values with an **`enc:`** prefix; **`getProfileData`** decrypts on read. The profile file is written with **`mode: 0o600`**.
> 
> Existing profiles keep working: tokens without the prefix are returned as-is and get encrypted on the next save. Tokens that look encrypted but cannot be decrypted are dropped with a warning. If encryption is unavailable, save still works but tokens stay plaintext (warned in logs).
> 
> New Vitest coverage in **`fs.test.ts`** exercises encrypt/decrypt, permissions, cache invalidation, migration, corrupt tokens, and missing file behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04e7cfd66b979d476ef4dabb574a04596a4bf53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->