### PR TITLE
ci: Bump grafana actions and migrate to lint-pr-title

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -15,21 +15,10 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@71b07ef490c9e8ef772f64a62d41545ae5b9ef22
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
-          types: |
-            fix
-            feat
-            refactor
-            style
-            test
-            perf
-            docs
-            deps
-            build
-            ci
-            chore
-            internal
-            revert
+          persist-credentials: false
+
+      - uses: grafana/shared-workflows/actions/lint-pr-title@0239db2665246f3b078d8d9166e4d8f09c071cae # lint-pr-title/v1.2.2
+        with:
+          config-path: "${{ github.workspace }}/commitlint.config.js"

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -7,12 +7,14 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   main:
     name: Validate PR title
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         with:
           repo_secrets: |
             APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12
@@ -106,7 +106,7 @@ jobs:
 
       - name: Get azure secrets
         id: get-azure-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
         if: startsWith(matrix.platform, 'windows-')
         with:
           export_env: false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
           github_app: k6-release-app
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [0],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'deps',
+        'docs',
+        'feat',
+        'fix',
+        'internal',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
+  },
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Update grafana actions that used Node 20
- Migrate to our own lint-pr-title action

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and commitlint configuration; no application runtime or security logic is modified.
> 
> **Overview**
> **PR title validation** now checks out the repo and runs Grafana’s `lint-pr-title` action against a new root `commitlint.config.js` (conventional types including `internal`, `deps`, etc.; subject case rule disabled). Workflow permissions are tightened: empty default at workflow level, read-only `contents` + `pull-requests` on the lint job; the old `amannn/action-semantic-pull-request` step and inline type list are removed.
> 
> **Release automation** bumps shared Grafana actions: `get-vault-secrets` to v1.3.2 in `release-base.yml` (both secret-fetch steps) and `create-github-app-token` to v0.2.3 in `release-please.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b5bf328d5ca9e624491ff5af4824aeab8dd800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->