### PR TITLE
ci: Install dependencies before signing secrets are materialized

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -25,17 +25,6 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
-        with:
-          repo_secrets: |
-            APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12
-            CERTIFICATE_PASSWORD=apple-certificates:APPLE_CERTIFICATE_P12_PASSWORD
-            APPLE_API_KEY_ID=apple-certificates:APPLE_API_KEY_ID
-            APPLE_API_ISSUER=apple-certificates:APPLE_API_ISSUER
-            APPLE_API_KEY=apple-certificates:APPLE_API_KEY
-            SENTRY_DSN=sentry:SENTRY_DSN
-            SENTRY_AUTH_TOKEN=sentry:SENTRY_AUTH_TOKEN
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
@@ -62,8 +51,22 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install python-setuptools
 
+      # Install before signing secrets are materialized so dependency
+      # install scripts cannot read them from the environment.
       - name: install dependencies
         run: pnpm install --frozen-lockfile
+
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+        with:
+          repo_secrets: |
+            APPLE_CERTIFICATE_P12=apple-certificates:APPLE_CERTIFICATE_P12
+            CERTIFICATE_PASSWORD=apple-certificates:APPLE_CERTIFICATE_P12_PASSWORD
+            APPLE_API_KEY_ID=apple-certificates:APPLE_API_KEY_ID
+            APPLE_API_ISSUER=apple-certificates:APPLE_API_ISSUER
+            APPLE_API_KEY=apple-certificates:APPLE_API_KEY
+            SENTRY_DSN=sentry:SENTRY_DSN
+            SENTRY_AUTH_TOKEN=sentry:SENTRY_AUTH_TOKEN
 
       - name: setup macos keychain
         if: startsWith(matrix.platform, 'macos-')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Install before signing secrets are materialized so dependency install scripts cannot read them from the environment.

## How to Test
- Run the test version release flow from this branch

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only step reordering that reduces secret exposure during dependency install; no application runtime or auth logic changes.
> 
> **Overview**
> Reorders the shared **release** workflow so **`pnpm install --frozen-lockfile`** runs **before** the Vault **`get-secrets`** step that exports Apple signing and Sentry credentials into the job environment.
> 
> The intent is to keep **postinstall / lifecycle scripts** from dependencies from seeing those secrets during install. Signing setup (macOS keychain, publish steps) is unchanged and still runs after secrets are loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77cbfd1fcbf76647bae421a8222f5a7f093e98c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->