### PR TITLE
fix: verify checksum before executing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,7 @@ module.exports = {
   ignorePatterns: [
     'resources/*.js',
     'install-k6.js',
+    'update-k6-version.js',
     '.eslintrc.cjs',
     '**/__snapshots__/',
     'src/browser/injectedScript.js',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,8 +21,8 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   ignorePatterns: [
     'resources/*.js',
-    'install-k6.js',
-    'update-k6-version.js',
+    'scripts/install-k6.js',
+    'scripts/update-k6-version.js',
     '.eslintrc.cjs',
     '**/__snapshots__/',
     'src/browser/injectedScript.js',

--- a/install-k6.js
+++ b/install-k6.js
@@ -2,29 +2,25 @@ const { execSync } = require('child_process')
 const { createHash } = require('crypto')
 const { existsSync, readFileSync } = require('fs')
 
-const K6_VERSION = 'v1.2.1'
+const K6_VERSION = 'v2.0.0'
 const K6_PATH_MAC_AMD = `k6-${K6_VERSION}-macos-amd64`
 const K6_PATH_MAC_ARM = `k6-${K6_VERSION}-macos-arm64`
 const K6_PATH_WIN_AMD = `k6-${K6_VERSION}-windows-amd64`
 const K6_PATH_LINUX_AMD = `k6-${K6_VERSION}-linux-amd64`
 const K6_PATH_LINUX_ARM = `k6-${K6_VERSION}-linux-arm64`
 
-// To update checksums for a new k6 version:
-// 1. Update K6_VERSION above
-// 2. Download the checksums file:
-//    curl -L https://github.com/grafana/k6/releases/download/<version>/k6-<version>-checksums.txt
-// 3. Replace the hashes below with the values from that file
+// To update to a new k6 version, run: node update-k6-version.js <version>
 const CHECKSUMS = {
   [`k6-${K6_VERSION}-macos-amd64.zip`]:
-    '9d5018eed8a142e2d64374faf9a79a45b7bddb33e19a00ec14b45d619dc84ceb',
+    '287f3b0ab9f936f20c37c649f220842385a7961ead84d695d7b5192268c61b3f',
   [`k6-${K6_VERSION}-macos-arm64.zip`]:
-    'c5b55d160476f75e5b39f0a14871e217dd3a0cdb5419819be12a09038445f562',
+    '9a725f3faf8fc9de70f0bd86fb9783e6fb02f822492862846375ec0d8f2b35f7',
   [`k6-${K6_VERSION}-windows-amd64.zip`]:
-    '7464f71615c839069de54cbbb3e0aa67c5fbdf426802360bd3dd837a089a0c3a',
+    '58bb8530af85c57abeb5cc2bae7581d6aa976d43ca538d4be79a1dcc93388b05',
   [`k6-${K6_VERSION}-linux-amd64.tar.gz`]:
-    'b082f79deef18bdbb4c7b8ab997d048553d8905bc35e9903ab9f2d7e3563993d',
+    '2ae87d976f6cdba17185bdd980d8819a3a98e9092c6f0638cd58272ecefc8b90',
   [`k6-${K6_VERSION}-linux-arm64.tar.gz`]:
-    '4db0f1a277f2fdc48dff6ca8136f213da19d1134dae0e0eb850e61695be24645',
+    '397d338c0c50821994aa51a630e511c599c2e903d00f7fa6c55a82258e7a84e6',
 }
 
 function verifyChecksum(filePath, archiveName) {

--- a/install-k6.js
+++ b/install-k6.js
@@ -1,5 +1,6 @@
 const { execSync } = require('child_process')
-const { existsSync } = require('fs')
+const { createHash } = require('crypto')
+const { existsSync, readFileSync } = require('fs')
 
 const K6_VERSION = 'v1.2.1'
 const K6_PATH_MAC_AMD = `k6-${K6_VERSION}-macos-amd64`
@@ -8,76 +9,109 @@ const K6_PATH_WIN_AMD = `k6-${K6_VERSION}-windows-amd64`
 const K6_PATH_LINUX_AMD = `k6-${K6_VERSION}-linux-amd64`
 const K6_PATH_LINUX_ARM = `k6-${K6_VERSION}-linux-arm64`
 
+// To update checksums for a new k6 version:
+// 1. Update K6_VERSION above
+// 2. Download the checksums file:
+//    curl -L https://github.com/grafana/k6/releases/download/<version>/k6-<version>-checksums.txt
+// 3. Replace the hashes below with the values from that file
+const CHECKSUMS = {
+  [`k6-${K6_VERSION}-macos-amd64.zip`]:
+    '9d5018eed8a142e2d64374faf9a79a45b7bddb33e19a00ec14b45d619dc84ceb',
+  [`k6-${K6_VERSION}-macos-arm64.zip`]:
+    'c5b55d160476f75e5b39f0a14871e217dd3a0cdb5419819be12a09038445f562',
+  [`k6-${K6_VERSION}-windows-amd64.zip`]:
+    '7464f71615c839069de54cbbb3e0aa67c5fbdf426802360bd3dd837a089a0c3a',
+  [`k6-${K6_VERSION}-linux-amd64.tar.gz`]:
+    'b082f79deef18bdbb4c7b8ab997d048553d8905bc35e9903ab9f2d7e3563993d',
+  [`k6-${K6_VERSION}-linux-arm64.tar.gz`]:
+    '4db0f1a277f2fdc48dff6ca8136f213da19d1134dae0e0eb850e61695be24645',
+}
+
+function verifyChecksum(filePath, archiveName) {
+  const expected = CHECKSUMS[archiveName]
+  if (!expected) {
+    throw new Error(
+      `No checksum found for ${archiveName}. Update the CHECKSUMS map.`
+    )
+  }
+  const data = readFileSync(filePath)
+  const actual = createHash('sha256').update(data).digest('hex')
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${archiveName}!\n` +
+        `  Expected: ${expected}\n` +
+        `  Actual:   ${actual}`
+    )
+  }
+  console.log(`checksum verified: ${archiveName}`)
+}
+
 const getMacOSK6Binary = () => {
-  const command = `
-# download binaries
-curl -LO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${K6_PATH_MAC_AMD}.zip
-curl -LO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${K6_PATH_MAC_ARM}.zip
+  const amdArchive = `${K6_PATH_MAC_AMD}.zip`
+  const armArchive = `${K6_PATH_MAC_ARM}.zip`
 
-# unzip & smoke test
-unzip ${K6_PATH_MAC_AMD}.zip
-unzip ${K6_PATH_MAC_ARM}.zip
-${K6_PATH_MAC_AMD}/k6 version
-${K6_PATH_MAC_ARM}/k6 version
+  execSync(
+    `curl -fLO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${amdArchive} && ` +
+      `curl -fLO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${armArchive}`
+  )
 
-# move to resource folder
-mv ${K6_PATH_MAC_AMD}/k6 resources/mac/x86_64
-mv ${K6_PATH_MAC_ARM}/k6 resources/mac/arm64
+  verifyChecksum(amdArchive, amdArchive)
+  verifyChecksum(armArchive, armArchive)
 
-# cleanup
-rm ${K6_PATH_MAC_AMD}.zip
-rm ${K6_PATH_MAC_ARM}.zip
-rmdir ${K6_PATH_MAC_AMD}
-rmdir ${K6_PATH_MAC_ARM}
-`
-
-  execSync(command)
+  execSync(
+    `unzip ${amdArchive} && ` +
+      `unzip ${armArchive} && ` +
+      `${K6_PATH_MAC_AMD}/k6 version && ` +
+      `${K6_PATH_MAC_ARM}/k6 version && ` +
+      `mv ${K6_PATH_MAC_AMD}/k6 resources/mac/x86_64 && ` +
+      `mv ${K6_PATH_MAC_ARM}/k6 resources/mac/arm64 && ` +
+      `rm ${amdArchive} ${armArchive} && ` +
+      `rmdir ${K6_PATH_MAC_AMD} ${K6_PATH_MAC_ARM}`
+  )
 }
 
 const getWindowsK6Binary = () => {
-  const command = `
-# download binaries
-Invoke-WebRequest -Uri "https://github.com/grafana/k6/releases/download/${K6_VERSION}/${K6_PATH_WIN_AMD}.zip" -OutFile "k6-windows-amd64.zip"
+  const archiveName = `${K6_PATH_WIN_AMD}.zip`
+  const localFile = 'k6-windows-amd64.zip'
 
-# unzip & smoke test
-Expand-Archive -Path "k6-windows-amd64.zip" -DestinationPath "."
-${K6_PATH_WIN_AMD}\\k6.exe version
+  execSync(
+    `Invoke-WebRequest -Uri "https://github.com/grafana/k6/releases/download/${K6_VERSION}/${archiveName}" -OutFile "${localFile}"`,
+    { shell: 'powershell.exe' }
+  )
 
-# move to resource folder
-Move-Item -Path "${K6_PATH_WIN_AMD}\\k6.exe" -Destination resources\\win\\x86_64
+  verifyChecksum(localFile, archiveName)
 
-# clean up
-del k6-windows-amd64.zip
-Remove-Item -Path "${K6_PATH_WIN_AMD}" -Recurse
-`
-
-  execSync(command, { shell: 'powershell.exe' })
+  execSync(
+    `Expand-Archive -Path "${localFile}" -DestinationPath "." ; ` +
+      `${K6_PATH_WIN_AMD}\\k6.exe version ; ` +
+      `Move-Item -Path "${K6_PATH_WIN_AMD}\\k6.exe" -Destination resources\\win\\x86_64 ; ` +
+      `del ${localFile} ; ` +
+      `Remove-Item -Path "${K6_PATH_WIN_AMD}" -Recurse`,
+    { shell: 'powershell.exe' }
+  )
 }
 
 const getLinuxK6Binary = () => {
-  const command = `
-# download binaries
-curl -LO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${K6_PATH_LINUX_AMD}.tar.gz
-curl -LO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${K6_PATH_LINUX_ARM}.tar.gz
+  const amdArchive = `${K6_PATH_LINUX_AMD}.tar.gz`
+  const armArchive = `${K6_PATH_LINUX_ARM}.tar.gz`
 
-# unzip & smoke test
-tar -zxf ${K6_PATH_LINUX_AMD}.tar.gz
-tar -zxf ${K6_PATH_LINUX_ARM}.tar.gz
-${K6_PATH_LINUX_AMD}/k6 version
-# ${K6_PATH_LINUX_ARM}/k6 version  ## if we move to separate images for architectures we could test this one as well
+  execSync(
+    `curl -fLO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${amdArchive} && ` +
+      `curl -fLO https://github.com/grafana/k6/releases/download/${K6_VERSION}/${armArchive}`
+  )
 
-# move to resource folder
-mv ${K6_PATH_LINUX_AMD}/k6 resources/linux/x86_64
-mv ${K6_PATH_LINUX_ARM}/k6 resources/linux/arm64
+  verifyChecksum(amdArchive, amdArchive)
+  verifyChecksum(armArchive, armArchive)
 
-# cleanup
-rm ${K6_PATH_LINUX_AMD}.tar.gz
-rm ${K6_PATH_LINUX_ARM}.tar.gz
-rmdir ${K6_PATH_LINUX_AMD}
-rmdir ${K6_PATH_LINUX_ARM}
-`
-
-  execSync(command)
+  execSync(
+    `tar -zxf ${amdArchive} && ` +
+      `tar -zxf ${armArchive} && ` +
+      `${K6_PATH_LINUX_AMD}/k6 version && ` +
+      `mv ${K6_PATH_LINUX_AMD}/k6 resources/linux/x86_64 && ` +
+      `mv ${K6_PATH_LINUX_ARM}/k6 resources/linux/arm64 && ` +
+      `rm ${amdArchive} ${armArchive} && ` +
+      `rmdir ${K6_PATH_LINUX_AMD} ${K6_PATH_LINUX_ARM}`
+  )
 }
 
 switch (process.platform) {

--- a/install-k6.js
+++ b/install-k6.js
@@ -62,12 +62,27 @@ const getMacOSK6Binary = () => {
   verifyChecksum(amdArchive, amdArchive)
   verifyChecksum(armArchive, armArchive)
 
+  execSync(`unzip ${amdArchive} && unzip ${armArchive}`)
+
+  // Smoke-test each binary separately — the cross-arch binary can't execute
+  // (e.g. ARM binary on Intel Mac CI), so only the native arch is required.
+  const nativeArch = process.arch === 'arm64' ? 'arm' : 'amd'
+  const smokeTests = [
+    { path: `${K6_PATH_MAC_AMD}/k6`, arch: 'amd' },
+    { path: `${K6_PATH_MAC_ARM}/k6`, arch: 'arm' },
+  ]
+  for (const { path, arch } of smokeTests) {
+    try {
+      execSync(`${path} version`)
+    } catch {
+      if (arch === nativeArch)
+        throw new Error(`Native binary failed smoke test: ${path}`)
+      console.log(`skipping smoke test for non-native binary: ${path}`)
+    }
+  }
+
   execSync(
-    `unzip ${amdArchive} && ` +
-      `unzip ${armArchive} && ` +
-      `${K6_PATH_MAC_AMD}/k6 version && ` +
-      `${K6_PATH_MAC_ARM}/k6 version && ` +
-      `mv ${K6_PATH_MAC_AMD}/k6 resources/mac/x86_64 && ` +
+    `mv ${K6_PATH_MAC_AMD}/k6 resources/mac/x86_64 && ` +
       `mv ${K6_PATH_MAC_ARM}/k6 resources/mac/arm64 && ` +
       `rm ${amdArchive} ${armArchive} && ` +
       `rmdir ${K6_PATH_MAC_AMD} ${K6_PATH_MAC_ARM}`

--- a/install-k6.js
+++ b/install-k6.js
@@ -1,27 +1,35 @@
 const { execSync } = require('child_process')
 const { createHash } = require('crypto')
 const { existsSync, readFileSync } = require('fs')
+const { join } = require('path')
 
-const K6_VERSION = 'v2.0.0'
+// To update to a new k6 version, run: node update-k6-version.js <version>
+const k6Versions = JSON.parse(
+  readFileSync(join(__dirname, 'k6-versions.json'), 'utf-8')
+)
+
+const K6_VERSION = k6Versions.version
+
+const ARCHIVE_EXTENSIONS = {
+  'macos-amd64': '.zip',
+  'macos-arm64': '.zip',
+  'windows-amd64': '.zip',
+  'linux-amd64': '.tar.gz',
+  'linux-arm64': '.tar.gz',
+}
+
+const CHECKSUMS = Object.fromEntries(
+  Object.entries(k6Versions.checksums).map(([platform, hash]) => [
+    `k6-${K6_VERSION}-${platform}${ARCHIVE_EXTENSIONS[platform]}`,
+    hash,
+  ])
+)
+
 const K6_PATH_MAC_AMD = `k6-${K6_VERSION}-macos-amd64`
 const K6_PATH_MAC_ARM = `k6-${K6_VERSION}-macos-arm64`
 const K6_PATH_WIN_AMD = `k6-${K6_VERSION}-windows-amd64`
 const K6_PATH_LINUX_AMD = `k6-${K6_VERSION}-linux-amd64`
 const K6_PATH_LINUX_ARM = `k6-${K6_VERSION}-linux-arm64`
-
-// To update to a new k6 version, run: node update-k6-version.js <version>
-const CHECKSUMS = {
-  [`k6-${K6_VERSION}-macos-amd64.zip`]:
-    '287f3b0ab9f936f20c37c649f220842385a7961ead84d695d7b5192268c61b3f',
-  [`k6-${K6_VERSION}-macos-arm64.zip`]:
-    '9a725f3faf8fc9de70f0bd86fb9783e6fb02f822492862846375ec0d8f2b35f7',
-  [`k6-${K6_VERSION}-windows-amd64.zip`]:
-    '58bb8530af85c57abeb5cc2bae7581d6aa976d43ca538d4be79a1dcc93388b05',
-  [`k6-${K6_VERSION}-linux-amd64.tar.gz`]:
-    '2ae87d976f6cdba17185bdd980d8819a3a98e9092c6f0638cd58272ecefc8b90',
-  [`k6-${K6_VERSION}-linux-arm64.tar.gz`]:
-    '397d338c0c50821994aa51a630e511c599c2e903d00f7fa6c55a82258e7a84e6',
-}
 
 function verifyChecksum(filePath, archiveName) {
   const expected = CHECKSUMS[archiveName]

--- a/k6-versions.json
+++ b/k6-versions.json
@@ -1,0 +1,10 @@
+{
+  "version": "v2.0.0",
+  "checksums": {
+    "macos-amd64": "287f3b0ab9f936f20c37c649f220842385a7961ead84d695d7b5192268c61b3f",
+    "macos-arm64": "9a725f3faf8fc9de70f0bd86fb9783e6fb02f822492862846375ec0d8f2b35f7",
+    "windows-amd64": "58bb8530af85c57abeb5cc2bae7581d6aa976d43ca538d4be79a1dcc93388b05",
+    "linux-amd64": "2ae87d976f6cdba17185bdd980d8819a3a98e9092c6f0638cd58272ecefc8b90",
+    "linux-arm64": "397d338c0c50821994aa51a630e511c599c2e903d00f7fa6c55a82258e7a84e6"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "postinstall": "node install-k6.js",
+    "update-k6": "node update-k6-version.js",
     "start": "electron-forge start -- --remote-debugging-port=9223",
     "package": "electron-forge package",
     "make": "electron-forge make",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "packageManager": "pnpm@11.0.6",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "postinstall": "node install-k6.js",
-    "update-k6": "node update-k6-version.js",
+    "postinstall": "node scripts/install-k6.js",
+    "update-k6": "node scripts/update-k6-version.js",
     "start": "electron-forge start -- --remote-debugging-port=9223",
     "package": "electron-forge package",
     "make": "electron-forge make",

--- a/scripts/install-k6.js
+++ b/scripts/install-k6.js
@@ -3,9 +3,9 @@ const { createHash } = require('crypto')
 const { existsSync, readFileSync } = require('fs')
 const { join } = require('path')
 
-// To update to a new k6 version, run: node update-k6-version.js <version>
+// To update to a new k6 version, run: node scripts/update-k6-version.js <version>
 const k6Versions = JSON.parse(
-  readFileSync(join(__dirname, 'k6-versions.json'), 'utf-8')
+  readFileSync(join(__dirname, '..', 'k6-versions.json'), 'utf-8')
 )
 
 const K6_VERSION = k6Versions.version

--- a/scripts/install-k6.js
+++ b/scripts/install-k6.js
@@ -122,11 +122,25 @@ const getLinuxK6Binary = () => {
   verifyChecksum(amdArchive, amdArchive)
   verifyChecksum(armArchive, armArchive)
 
+  execSync(`tar -zxf ${amdArchive} && tar -zxf ${armArchive}`)
+
+  const nativeArch = process.arch === 'arm64' ? 'arm' : 'amd'
+  const smokeTests = [
+    { path: `${K6_PATH_LINUX_AMD}/k6`, arch: 'amd' },
+    { path: `${K6_PATH_LINUX_ARM}/k6`, arch: 'arm' },
+  ]
+  for (const { path, arch } of smokeTests) {
+    try {
+      execSync(`${path} version`)
+    } catch {
+      if (arch === nativeArch)
+        throw new Error(`Native binary failed smoke test: ${path}`)
+      console.log(`skipping smoke test for non-native binary: ${path}`)
+    }
+  }
+
   execSync(
-    `tar -zxf ${amdArchive} && ` +
-      `tar -zxf ${armArchive} && ` +
-      `${K6_PATH_LINUX_AMD}/k6 version && ` +
-      `mv ${K6_PATH_LINUX_AMD}/k6 resources/linux/x86_64 && ` +
+    `mv ${K6_PATH_LINUX_AMD}/k6 resources/linux/x86_64 && ` +
       `mv ${K6_PATH_LINUX_ARM}/k6 resources/linux/arm64 && ` +
       `rm ${amdArchive} ${armArchive} && ` +
       `rmdir ${K6_PATH_LINUX_AMD} ${K6_PATH_LINUX_ARM}`

--- a/scripts/update-k6-version.js
+++ b/scripts/update-k6-version.js
@@ -9,7 +9,7 @@ const EXPECTED_SUFFIXES = [
   'linux-arm64.tar.gz',
 ]
 
-const K6_VERSIONS_PATH = join(__dirname, 'k6-versions.json')
+const K6_VERSIONS_PATH = join(__dirname, '..', 'k6-versions.json')
 
 ;(async () => {
   let version = process.argv[2]

--- a/update-k6-version.js
+++ b/update-k6-version.js
@@ -1,0 +1,136 @@
+const { readFileSync, writeFileSync } = require('fs')
+const { join } = require('path')
+
+const EXPECTED_SUFFIXES = [
+  'macos-amd64.zip',
+  'macos-arm64.zip',
+  'windows-amd64.zip',
+  'linux-amd64.tar.gz',
+  'linux-arm64.tar.gz',
+]
+
+const INSTALL_K6_PATH = join(__dirname, 'install-k6.js')
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+;(async () => {
+  let version = process.argv[2]
+
+  if (!version) {
+    console.error('Usage: node update-k6-version.js <version>')
+    console.error('Example: node update-k6-version.js v2.1.0')
+    process.exit(1)
+  }
+
+  if (/^\d+\.\d+\.\d+$/.test(version)) {
+    version = `v${version}`
+    console.log(`Note: prepended "v" → ${version}`)
+  }
+
+  if (!/^v\d+\.\d+\.\d+$/.test(version)) {
+    console.error(`Invalid version format: ${version}`)
+    console.error('Expected format: v1.2.3')
+    process.exit(1)
+  }
+
+  let content
+  try {
+    content = readFileSync(INSTALL_K6_PATH, 'utf-8')
+  } catch {
+    console.error(`Could not read install-k6.js at ${INSTALL_K6_PATH}`)
+    process.exit(1)
+  }
+
+  const currentMatch = content.match(/const K6_VERSION = '([^']+)'/)
+  const currentVersion = currentMatch?.[1]
+
+  if (currentVersion === version) {
+    console.log(`install-k6.js is already at ${version}`)
+    process.exit(0)
+  }
+
+  const checksumsUrl = `https://github.com/grafana/k6/releases/download/${version}/k6-${version}-checksums.txt`
+  console.log(`Fetching checksums from ${checksumsUrl}`)
+
+  let response
+  try {
+    response = await fetch(checksumsUrl)
+  } catch (err) {
+    console.error(`Network error: ${err.message}`)
+    process.exit(1)
+  }
+
+  if (response.status === 404) {
+    console.error(
+      `Version ${version} not found. Check: https://github.com/grafana/k6/releases/tag/${version}`
+    )
+    process.exit(1)
+  }
+
+  if (!response.ok) {
+    console.error(`HTTP ${response.status} fetching checksums`)
+    process.exit(1)
+  }
+
+  const body = await response.text()
+  const checksumMap = new Map()
+  for (const line of body.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    const parts = trimmed.split(/\s+/)
+    if (parts.length === 2) {
+      checksumMap.set(parts[1], parts[0])
+    }
+  }
+
+  const newChecksums = {}
+  const missing = []
+  for (const suffix of EXPECTED_SUFFIXES) {
+    const filename = `k6-${version}-${suffix}`
+    const hash = checksumMap.get(filename)
+    if (!hash) {
+      missing.push(filename)
+    } else {
+      newChecksums[suffix] = hash
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error('Missing checksums for:')
+    for (const f of missing) console.error(`  ${f}`)
+    process.exit(1)
+  }
+
+  content = content.replace(
+    /const K6_VERSION = '[^']+'/,
+    `const K6_VERSION = '${version}'`
+  )
+
+  for (const suffix of EXPECTED_SUFFIXES) {
+    const pattern = new RegExp(
+      `(\\[\`k6-\\$\\{K6_VERSION\\}-${escapeRegex(suffix)}\`\\]:\\s*\\n\\s*')([a-f0-9]{64})(')`
+    )
+    const match = content.match(pattern)
+    if (!match) {
+      console.error(`Could not find checksum slot for ${suffix} in install-k6.js`)
+      process.exit(1)
+    }
+    content = content.replace(pattern, `$1${newChecksums[suffix]}$3`)
+  }
+
+  writeFileSync(INSTALL_K6_PATH, content, 'utf-8')
+
+  console.log(`\nUpdated install-k6.js to k6 ${version}\n`)
+  if (currentVersion) {
+    console.log(`  K6_VERSION: ${currentVersion} → ${version}\n`)
+  }
+  console.log('  Checksums:')
+  for (const suffix of EXPECTED_SUFFIXES) {
+    const hash = newChecksums[suffix]
+    const short = `${hash.slice(0, 8)}…${hash.slice(-8)}`
+    console.log(`    ${suffix.padEnd(22)} ${short}`)
+  }
+  console.log('')
+})()

--- a/update-k6-version.js
+++ b/update-k6-version.js
@@ -9,11 +9,7 @@ const EXPECTED_SUFFIXES = [
   'linux-arm64.tar.gz',
 ]
 
-const INSTALL_K6_PATH = join(__dirname, 'install-k6.js')
-
-function escapeRegex(str) {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
+const K6_VERSIONS_PATH = join(__dirname, 'k6-versions.json')
 
 ;(async () => {
   let version = process.argv[2]
@@ -35,19 +31,16 @@ function escapeRegex(str) {
     process.exit(1)
   }
 
-  let content
+  let k6Versions
   try {
-    content = readFileSync(INSTALL_K6_PATH, 'utf-8')
+    k6Versions = JSON.parse(readFileSync(K6_VERSIONS_PATH, 'utf-8'))
   } catch {
-    console.error(`Could not read install-k6.js at ${INSTALL_K6_PATH}`)
+    console.error(`Could not read k6-versions.json at ${K6_VERSIONS_PATH}`)
     process.exit(1)
   }
 
-  const currentMatch = content.match(/const K6_VERSION = '([^']+)'/)
-  const currentVersion = currentMatch?.[1]
-
-  if (currentVersion === version) {
-    console.log(`install-k6.js is already at ${version}`)
+  if (k6Versions.version === version) {
+    console.log(`k6-versions.json is already at ${version}`)
     process.exit(0)
   }
 
@@ -93,7 +86,8 @@ function escapeRegex(str) {
     if (!hash) {
       missing.push(filename)
     } else {
-      newChecksums[suffix] = hash
+      const platform = suffix.replace(/\.(zip|tar\.gz)$/, '')
+      newChecksums[platform] = hash
     }
   }
 
@@ -103,34 +97,27 @@ function escapeRegex(str) {
     process.exit(1)
   }
 
-  content = content.replace(
-    /const K6_VERSION = '[^']+'/,
-    `const K6_VERSION = '${version}'`
+  const currentVersion = k6Versions.version
+
+  k6Versions.version = version
+  k6Versions.checksums = newChecksums
+
+  writeFileSync(
+    K6_VERSIONS_PATH,
+    JSON.stringify(k6Versions, null, 2) + '\n',
+    'utf-8'
   )
 
-  for (const suffix of EXPECTED_SUFFIXES) {
-    const pattern = new RegExp(
-      `(\\[\`k6-\\$\\{K6_VERSION\\}-${escapeRegex(suffix)}\`\\]:\\s*\\n\\s*')([a-f0-9]{64})(')`
-    )
-    const match = content.match(pattern)
-    if (!match) {
-      console.error(`Could not find checksum slot for ${suffix} in install-k6.js`)
-      process.exit(1)
-    }
-    content = content.replace(pattern, `$1${newChecksums[suffix]}$3`)
-  }
-
-  writeFileSync(INSTALL_K6_PATH, content, 'utf-8')
-
-  console.log(`\nUpdated install-k6.js to k6 ${version}\n`)
+  console.log(`\nUpdated k6-versions.json to k6 ${version}\n`)
   if (currentVersion) {
-    console.log(`  K6_VERSION: ${currentVersion} → ${version}\n`)
+    console.log(`  version: ${currentVersion} → ${version}\n`)
   }
   console.log('  Checksums:')
   for (const suffix of EXPECTED_SUFFIXES) {
-    const hash = newChecksums[suffix]
+    const platform = suffix.replace(/\.(zip|tar\.gz)$/, '')
+    const hash = newChecksums[platform]
     const short = `${hash.slice(0, 8)}…${hash.slice(-8)}`
-    console.log(`    ${suffix.padEnd(22)} ${short}`)
+    console.log(`    ${platform.padEnd(16)} ${short}`)
   }
   console.log('')
 })()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->
k6 binary checksums are now verified before executing them.
An utility script was added to automatically update a k6 version with minimal manual work:
<img width="878" height="326" alt="image" src="https://github.com/user-attachments/assets/3f1ebe0e-ff50-4cd7-8f79-72d4bad82182" />

Also updates to k6 `2.0.0`


## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to install-time scripts and pinned binary metadata; they reduce supply-chain risk rather than altering app runtime behavior.
> 
> **Overview**
> **Bundles k6 v2.0.0** with a safer install path: the downloader moves to `scripts/install-k6.js`, reads version and SHA-256 checksums from new `k6-versions.json`, and **verifies each archive before unzip or execution**. `postinstall` and ESLint ignore paths follow the new layout; **`pnpm update-k6`** runs `scripts/update-k6-version.js` to pull official checksums from GitHub and refresh the manifest.
> 
> **CI-friendly smoke tests** on macOS/Linux only require the native-arch `k6 version` to succeed; cross-arch binaries may be skipped when they cannot run on the host.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b5dd9b9bb7b9760b5af81cde1fef5b88a8b7605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->