### PR TITLE
build: Better way to release patches

### DIFF
--- a/.github/workflows/create-patch-branch.yml
+++ b/.github/workflows/create-patch-branch.yml
@@ -1,0 +1,68 @@
+name: "Create Patch Branch"
+
+# Creates a release/<major>.<minor>.x maintenance branch from an existing
+# release tag, so patch releases follow a consistent, enforced naming scheme.
+# release-please then manages the branch (it only triggers on branches matching
+# release/[0-9]+.[0-9]+.x, see release-please.yml).
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: "Release tag to branch from (e.g. v1.13.0)"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: create-patch-branch-${{ inputs.base_tag }}
+  cancel-in-progress: false
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Derive branch name
+        id: derive
+        env:
+          BASE_TAG: ${{ inputs.base_tag }}
+        run: |
+          if [[ ! "$BASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::base_tag must look like v1.13.0 (got '$BASE_TAG')"
+            exit 1
+          fi
+          ver="${BASE_TAG#v}"
+          major="${ver%%.*}"
+          rest="${ver#*.}"
+          minor="${rest%%.*}"
+          branch="release/${major}.${minor}.x"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "Derived branch name: $branch"
+
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        with:
+          github_app: k6-release-app
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          ref: ${{ inputs.base_tag }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
+
+      - name: Create and push patch branch
+        env:
+          BRANCH: ${{ steps.derive.outputs.branch }}
+          BASE_TAG: ${{ inputs.base_tag }}
+        run: |
+          if git ls-remote --exit-code --heads origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Branch $BRANCH already exists"
+            exit 1
+          fi
+          git switch -c "$BRANCH"
+          git push origin "$BRANCH"
+          echo "::notice::Created $BRANCH from $BASE_TAG"

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: ""
+      ref:
+        description: "Git ref to checkout (defaults to the caller's github.ref)"
+        type: string
+        required: false
+        default: ""
 
 permissions: {}
 
@@ -27,6 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
+          ref: ${{ inputs.ref || github.ref }}
           persist-credentials: false
 
       - name: Set version for test release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 permissions: {}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-      - release/*
+      # Patch/maintenance branches. Must be named release/<major>.<minor>.x
+      # (e.g. release/1.13.x). Create them with the "Create Patch Branch" workflow.
+      - 'release/[0-9]+.[0-9]+.x'
 
 permissions: {}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,10 @@ jobs:
       id-token: write
 
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      sha: ${{ steps.release.outputs.sha }}
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
@@ -23,6 +27,25 @@ jobs:
         with:
           github_app: k6-release-app
 
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - id: release
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
+
+  # The draft GitHub release that release-please creates does not push a git tag
+  # (GitHub only creates the tag when the draft is published), so the build runs
+  # against the SHA release-please reports rather than refs/tags/<tag_name>.
+  # publisher-github finds the existing draft by tag_name and uploads artifacts.
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: build-${{ needs.release-please.outputs.tag_name }}
+      cancel-in-progress: false
+    uses: ./.github/workflows/release-base.yml
+    with:
+      ref: ${{ needs.release-please.outputs.sha }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,34 @@
 name: 'Manual Release'
 
 on:
+  release:
+    types: [created]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v1.14.0). Fallback for re-runs.'
+        required: true
+        type: string
 
 permissions: {}
 
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
 jobs:
   release:
+    # Auto-build runs only on drafts created by release-please for v* tags;
+    # human-created drafts must use the workflow_dispatch fallback.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.release.draft == true &&
+       startsWith(github.event.release.tag_name, 'v') &&
+       github.actor == 'k6-release-app[bot]')
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/release-base.yml
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || '' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: 'Manual Release'
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Tag to build (e.g. v1.14.0). Fallback for re-runs.'
+      ref:
+        description: 'Tag, branch, or SHA to build (e.g. v1.14.0). Use for re-runs or recovery.'
         required: true
         type: string
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: 'Manual Release'
 
 on:
-  release:
-    types: [created]
   workflow_dispatch:
     inputs:
       tag:
@@ -13,22 +11,15 @@ on:
 permissions: {}
 
 concurrency:
-  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  group: build-${{ inputs.ref }}
   cancel-in-progress: false
 
 jobs:
   release:
-    # Auto-build runs only on drafts created by release-please for v* tags;
-    # human-created drafts must use the workflow_dispatch fallback.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.release.draft == true &&
-       startsWith(github.event.release.tag_name, 'v') &&
-       github.actor == 'k6-release-app[bot]')
     permissions:
       contents: write
       id-token: write
     uses: ./.github/workflows/release-base.yml
     with:
-      ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || '' }}
+      ref: ${{ inputs.ref }}
     secrets: inherit


### PR DESCRIPTION
## Description

- Main releases now build automatically when the release-please PR is merged. The build attaches artifacts to the draft GitHub release; clicking Publish on the draft is the only remaining manual step.
- Adds support for patch releases via `release/X.Y` branches. Cherry-picked fixes on these branches get their own release-please PR with a patch-only changelog, then run through the same auto-build flow.
- `release.yml` is kept as a manual-dispatch fallback for re-runs and recovery, taking a tag/branch/SHA as input.


## How to Test
TBD

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I added branch protection rules for `release/*` branches
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production binaries are triggered and which git ref is built (SHA vs tag), affecting release correctness; scope is CI-only with no application runtime changes.
> 
> **Overview**
> **Automates multi-platform release builds** when release-please creates a release (main or `release/<major>.<minor>.x`), checking out the reported SHA (not the tag, since draft releases do not create tags until publish) and invoking `release-base.yml` to attach artifacts to the existing draft.
> 
> **Adds patch-release support:** a new **Create Patch Branch** workflow creates `release/<major>.<minor>.x` from a semver tag (validated, idempotent guard if branch exists), and release-please now runs on those branches.
> 
> **Shared release workflow** gains an optional `ref` input; **Manual Release** requires a tag/branch/SHA and uses concurrency keyed by that ref for recovery/re-runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cdf41df3ec68038aed3e5864f9a5ec0c8395ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->