### PR TITLE
fix: Highlight header and cookie search matches in inspector

### DIFF
--- a/src/components/WebLogView/Filter.hooks.test.ts
+++ b/src/components/WebLogView/Filter.hooks.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { createProxyData, createRequest } from '@/test/factories/proxyData'
+import { ProxyData, ProxyDataWithMatches } from '@/types'
+
+import { useFilterRequests } from './Filter.hooks'
+
+function getMatches(
+  filteredRequest: ProxyData | ProxyDataWithMatches | undefined
+) {
+  if (filteredRequest && 'matches' in filteredRequest) {
+    return filteredRequest.matches
+  }
+
+  return undefined
+}
+
+describe('useFilterRequests', () => {
+  it('returns the leaf value for header matches so they can be highlighted in the inspector', async () => {
+    const proxyData = [
+      createProxyData({
+        id: '1',
+        request: createRequest({
+          headers: [['x-custom-header', 'unique-header-value']],
+        }),
+      }),
+    ]
+
+    const { result } = renderHook(() => useFilterRequests({ proxyData }))
+
+    act(() => {
+      result.current.setFilter('unique-header-value')
+    })
+
+    await waitFor(() => {
+      const matches = getMatches(result.current.filteredRequests[0]) ?? []
+      const headerMatches = matches.filter((match) =>
+        match.key?.includes('headers')
+      )
+
+      // The inspector renders header keys and values separately and highlights
+      // a cell when match.value === cell text. The match value must therefore be
+      // the leaf value, not the comma-joined "key,value" tuple.
+      expect(headerMatches.map((match) => match.value)).toEqual([
+        'unique-header-value',
+      ])
+    })
+  })
+
+  it('deduplicates identical matches produced by repeated header names', async () => {
+    const proxyData = [
+      createProxyData({
+        id: '1',
+        request: createRequest({
+          headers: [
+            ['cookie', 'a=1'],
+            ['cookie', 'b=2'],
+            ['cookie', 'c=3'],
+          ],
+        }),
+      }),
+    ]
+
+    const { result } = renderHook(() => useFilterRequests({ proxyData }))
+
+    act(() => {
+      result.current.setFilter('cookie')
+    })
+
+    await waitFor(() => {
+      const matches = getMatches(result.current.filteredRequests[0]) ?? []
+      const cookieNameMatches = matches.filter(
+        (match) => match.value === 'cookie'
+      )
+
+      // Three "cookie" header names produce three identical fuse matches that
+      // differ only by array position. Rendering each would repeat the cell text.
+      expect(cookieNameMatches).toHaveLength(1)
+    })
+  })
+})

--- a/src/components/WebLogView/Filter.hooks.ts
+++ b/src/components/WebLogView/Filter.hooks.ts
@@ -84,11 +84,21 @@ const basicSearchKeys: Array<FuseOptionKey<ProxyData>> = [
 ]
 
 const fullSearchKeys: Array<FuseOptionKey<ProxyData>> = [
-  'request.cookies',
-  'request.headers',
-  'request.query',
-  'response.cookies',
-  'response.headers',
+  // Headers, cookies and query params are arrays of [key, value] tuples. Fuse
+  // stringifies each tuple as "key,value", which would make the match value
+  // differ from the individual key/value cells rendered in the inspector.
+  // Flatten the tuples so each key and value is searched (and matched) on its own.
+  { name: 'request.cookies', getFn: (data) => data.request.cookies.flat() },
+  { name: 'request.headers', getFn: (data) => data.request.headers.flat() },
+  { name: 'request.query', getFn: (data) => data.request.query.flat() },
+  {
+    name: 'response.cookies',
+    getFn: (data) => data.response?.cookies.flat() ?? [],
+  },
+  {
+    name: 'response.headers',
+    getFn: (data) => data.response?.headers.flat() ?? [],
+  },
   {
     name: 'response.content',
     getFn: (data) => {

--- a/src/utils/fuse.ts
+++ b/src/utils/fuse.ts
@@ -1,4 +1,5 @@
 import { FuseResult } from 'fuse.js'
+import { uniqBy } from 'lodash-es'
 
 import { Match } from '@/types/fuse'
 
@@ -7,13 +8,18 @@ type ResultWithMatch<T> = T & {
 }
 
 export function withMatches<T>(result: FuseResult<T>): ResultWithMatch<T> {
+  const matches =
+    result.matches?.map((match) => ({
+      indices: match.indices,
+      value: match.value,
+      key: match.key,
+    })) ?? []
+
   return {
     ...result.item,
-    matches:
-      result.matches?.flatMap((match) => ({
-        indices: match.indices,
-        value: match.value,
-        key: match.key,
-      })) ?? [],
+    // Fuse emits one match per array element, so repeated header/cookie names
+    // (or repeated values) produce identical matches that differ only by their
+    // position. Deduplicate them to avoid rendering the same text more than once.
+    matches: uniqBy(matches, (match) => JSON.stringify(match)),
   }
 }


### PR DESCRIPTION
## Description

Search highlighting broke in the inspector for headers, cookies, and query parameters (the body still worked). `fuse.js` 7.3 stringifies `[key, value]` tuples as `"key,value"` instead of indexing them individually, so the inspector's `match.value === cell text` check never matched.

Flattens the tuple search keys so Fuse matches each key and value again, and dedupes the now per-element matches so repeated header names don't highlight the same text twice.

<img width="2458" height="2166" alt="screencapture 2026-06-03 at 15 22 17@2x" src="https://github.com/user-attachments/assets/c72bab1e-d0f2-4494-bf90-111d85a42eb9" />


## How to Test

1. Open a recording and search for text in a header, cookie, or query param.
2. Click the result to open the inspector.
3. The match is highlighted in the Headers / Cookies / Query parameters tab.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Fuse search key configuration and match post-processing for the weblog filter; covered by new hook tests with no auth or data-handling impact.
> 
> **Overview**
> Restores **search match highlighting** in the request inspector for headers, cookies, and query parameters after Fuse began stringifying `[key, value]` tuples as `"key,value"`, which no longer aligned with per-cell highlighting.
> 
> **Filter.hooks** now indexes those fields via custom `getFn` handlers that **flatten** each tuple so Fuse matches individual keys and values. **`withMatches`** in **fuse.ts** **deduplicates** identical match objects (e.g. repeated header names) so the same cell is not highlighted multiple times.
> 
> Adds **Filter.hooks** tests covering leaf match values and deduplication behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffdc2d9445b134a2562ec6e7d2e1996cc8dff8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->