### PR TITLE
feat: Record interactions inside iframes

### DIFF
--- a/src/components/Browser/ElementHighlights.hooks.test.ts
+++ b/src/components/Browser/ElementHighlights.hooks.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useHighlightedElements } from './ElementHighlights.hooks'
+
+// In session replay a clicked element can live inside a nested iframe, i.e. a
+// different realm than the player root. Passed directly as the highlight target,
+// it must still be recognised as an element and highlighted.
+function childRealm(): Document {
+  const iframe = document.createElement('iframe')
+  document.body.append(iframe)
+
+  const doc = iframe.contentDocument
+
+  if (doc === null) {
+    throw new Error('iframe has no contentDocument')
+  }
+
+  return doc
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('useHighlightedElements', () => {
+  it('highlights a cross-realm element passed as the target', async () => {
+    const doc = childRealm()
+    doc.body.innerHTML = '<button>Pay</button>'
+
+    const target = doc.querySelector('button')
+
+    if (target === null) {
+      throw new Error('button not found')
+    }
+
+    // The target is from the iframe's realm, so `instanceof Element` is false.
+    expect(target instanceof Element).toBe(false)
+
+    const { result } = renderHook(() =>
+      useHighlightedElements(document.documentElement, target)
+    )
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1)
+    })
+
+    expect(result.current?.[0]?.element).toBe(target)
+  })
+})

--- a/src/components/Browser/ElementHighlights.hooks.ts
+++ b/src/components/Browser/ElementHighlights.hooks.ts
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from 'react'
 
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
 import { ElementLocator, LocatorOptions } from '@/schemas/locator'
-import { observeWindowsForLayoutShift } from '@/utils/dom/layout'
+import {
+  collectLayoutShiftWindows,
+  observeWindowsForLayoutShift,
+} from '@/utils/dom/layout'
 import { isElement } from '@/utils/dom/realm'
 import { findElementsByFrameChain } from '@/utils/selectors'
 
@@ -67,19 +70,10 @@ export function useHighlightedElements(
     // A highlighted element can live inside a (nested) iframe that scrolls or
     // resizes independently of the top document, so recompute bounds on a shift
     // in any document an element belongs to.
-    const windows = new Set<Window>()
-
-    if (rootWindow !== null) {
-      windows.add(rootWindow)
-    }
-
-    for (const element of elements) {
-      const elementWindow = element.ownerDocument.defaultView
-
-      if (elementWindow !== null) {
-        windows.add(elementWindow)
-      }
-    }
+    const windows = collectLayoutShiftWindows(
+      rootWindow,
+      ...elements.map((element) => element.ownerDocument.defaultView)
+    )
 
     return observeWindowsForLayoutShift(windows, recompute)
   }, [root, target, frames])

--- a/src/components/Browser/ElementHighlights.hooks.ts
+++ b/src/components/Browser/ElementHighlights.hooks.ts
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { useDebouncedValue } from '@/hooks/useDebouncedValue'
-import { ElementLocator } from '@/schemas/locator'
-import { findElementsByLocator } from '@/utils/selectors'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
+import { observeWindowsForLayoutShift } from '@/utils/dom/layout'
+import { isElement } from '@/utils/dom/realm'
+import { findElementsByFrameChain } from '@/utils/selectors'
 
 import { Bounds } from './types'
-import { getElementBounds } from './utils'
+import { getElementBoundsWithin } from './utils'
 
 interface Highlight {
   id: number
@@ -15,7 +17,8 @@ interface Highlight {
 
 export function useHighlightedElements(
   root: HTMLElement | null,
-  target: ElementLocator | Element | null
+  target: ElementLocator | Element | null,
+  frames?: LocatorOptions[]
 ) {
   const idCounter = useRef(0)
   const [highlights, setHighlights] = useState<Highlight[] | null>(null)
@@ -27,60 +30,59 @@ export function useHighlightedElements(
       return
     }
 
-    const toHighlight = (element: Element) => {
-      const bounds = getElementBounds(element)
+    const rootWindow = root.ownerDocument.defaultView
 
-      return {
-        id: idCounter.current++,
-        element,
-        bounds,
+    const toHighlight = (element: Element) => ({
+      id: idCounter.current++,
+      element,
+      bounds: getElementBoundsWithin(element, rootWindow),
+    })
+
+    const resolveElements = (): Element[] => {
+      if (isElement(target)) {
+        return [target]
+      }
+
+      try {
+        return findElementsByFrameChain(root, frames, target)
+      } catch {
+        return []
       }
     }
 
-    const { Element } = root.ownerDocument.defaultView ?? window
+    const elements = resolveElements()
 
-    if (target instanceof Element) {
-      setHighlights([toHighlight(target)])
+    setHighlights(elements.map(toHighlight))
 
-      return
-    }
-
-    try {
-      const elements = findElementsByLocator(root, target)
-      const highlights = elements.map((element) => toHighlight(element))
-
-      setHighlights(highlights)
-    } catch {
-      setHighlights([])
-    }
-  }, [root, target])
-
-  useEffect(() => {
-    if (root === null || target === null) {
-      return
-    }
-
-    const observer = new ResizeObserver(() => {
-      setHighlights((highlights) => {
-        if (highlights === null) {
-          return null
-        }
-
-        return highlights.map((highlight) => {
-          return {
+    const recompute = () => {
+      setHighlights(
+        (highlights) =>
+          highlights?.map((highlight) => ({
             ...highlight,
-            bounds: getElementBounds(highlight.element),
-          }
-        })
-      })
-    })
-
-    observer.observe(document.body)
-
-    return () => {
-      observer.disconnect()
+            bounds: getElementBoundsWithin(highlight.element, rootWindow),
+          })) ?? null
+      )
     }
-  }, [root, target])
+
+    // A highlighted element can live inside a (nested) iframe that scrolls or
+    // resizes independently of the top document, so recompute bounds on a shift
+    // in any document an element belongs to.
+    const windows = new Set<Window>()
+
+    if (rootWindow !== null) {
+      windows.add(rootWindow)
+    }
+
+    for (const element of elements) {
+      const elementWindow = element.ownerDocument.defaultView
+
+      if (elementWindow !== null) {
+        windows.add(elementWindow)
+      }
+    }
+
+    return observeWindowsForLayoutShift(windows, recompute)
+  }, [root, target, frames])
 
   return useDebouncedValue({
     value: highlights,

--- a/src/components/Browser/ElementHighlights.tsx
+++ b/src/components/Browser/ElementHighlights.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react'
 import { ComponentProps, forwardRef } from 'react'
 
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 
 import { useHighlightedElements } from './ElementHighlights.hooks'
 import { Overlay } from './Overlay'
@@ -33,13 +33,18 @@ const ElementOutline = forwardRef<HTMLDivElement, ElementHighlightProps>(
 interface ElementHighlightsProps {
   root: HTMLElement | null
   target: ElementLocator | Element | null
+  frames?: LocatorOptions[]
 }
 
 /**
  * Highlights elements when hovering over selectors inside k6 Studio.
  */
-export function ElementHighlights({ root, target }: ElementHighlightsProps) {
-  const highlights = useHighlightedElements(root, target)
+export function ElementHighlights({
+  root,
+  target,
+  frames,
+}: ElementHighlightsProps) {
+  const highlights = useHighlightedElements(root, target, frames)
 
   if (highlights === null) {
     return null

--- a/src/components/Browser/Locator.tsx
+++ b/src/components/Browser/Locator.tsx
@@ -5,10 +5,12 @@ import {
   CaseSensitiveIcon,
   ImageIcon,
   LucideProps,
+  SquareStackIcon,
   TagIcon,
   TestTubeDiagonalIcon,
   WholeWordIcon,
 } from 'lucide-react'
+import { Fragment } from 'react'
 
 import { ElementLocator } from '@/schemas/locator'
 import { exhaustive } from '@/utils/typescript'
@@ -90,12 +92,37 @@ export function LocatorText({ locator }: LocatorComponentProps) {
   }
 }
 
+const iconStyles = css`
+  align-self: center;
+  && {
+    width: 12px;
+    height: 12px;
+    min-width: 12px;
+    min-height: 12px;
+  }
+`
+
+const codeStyles = css`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
+  font-size: 0.9em;
+`
+
 interface LocatorProps {
   locator: ElementLocator
+  // Chain of iframe locators (outermost first) the element lives in, shown as a
+  // prefix inside the badge so an element inside an iframe is recognizable.
+  frames?: ElementLocator[]
   onHighlightChange?: (highlighted: boolean) => void
 }
 
-export function Locator({ locator, onHighlightChange }: LocatorProps) {
+export function Locator({
+  locator,
+  frames = [],
+  onHighlightChange,
+}: LocatorProps) {
   const handleMouseEnter = () => {
     onHighlightChange?.(true)
   }
@@ -131,27 +158,16 @@ export function Locator({ locator, onHighlightChange }: LocatorProps) {
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <LocatorIcon
-        css={css`
-          align-self: center;
-          && {
-            width: 12px;
-            height: 12px;
-            min-width: 12px;
-            min-height: 12px;
-          }
-        `}
-        locator={locator}
-      />
-      <code
-        css={css`
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          max-width: 300px;
-          font-size: 0.9em;
-        `}
-      >
+      {frames.map((frame, index) => (
+        <Fragment key={index}>
+          <SquareStackIcon aria-label="Inside iframe" css={iconStyles} />
+          <code css={codeStyles}>
+            <LocatorText locator={frame} />
+          </code>
+        </Fragment>
+      ))}
+      <LocatorIcon css={iconStyles} locator={locator} />
+      <code css={codeStyles}>
         <LocatorText locator={locator} />
       </code>
     </div>

--- a/src/components/Browser/Locator.tsx
+++ b/src/components/Browser/Locator.tsx
@@ -110,11 +110,6 @@ const codeStyles = css`
   font-size: 0.9em;
 `
 
-// Frames are de-emphasized so the target element stays in focus.
-const frameStyles = css`
-  color: var(--gray-11);
-`
-
 // Beyond this many frames the chain is summarized as a count.
 const COLLAPSE_THRESHOLD = 2
 
@@ -126,19 +121,16 @@ function FrameChain({ frames }: { frames: ElementLocator[] }) {
   }
 
   if (frames.length > COLLAPSE_THRESHOLD) {
-    return <span css={frameStyles}>in {frames.length} frames</span>
+    return <span>in {frames.length} frames</span>
   }
 
   return (
     <>
       {[...frames].reverse().map((frame, index) => (
         <Fragment key={index}>
-          <span css={frameStyles}>in</span>
-          <SquareStackIcon
-            aria-label="iframe"
-            css={[iconStyles, frameStyles]}
-          />
-          <code css={[codeStyles, frameStyles]}>
+          <span>in</span>
+          <SquareStackIcon aria-label="iframe" css={iconStyles} />
+          <code css={codeStyles}>
             <LocatorText locator={frame} />
           </code>
         </Fragment>

--- a/src/components/Browser/Locator.tsx
+++ b/src/components/Browser/Locator.tsx
@@ -110,10 +110,47 @@ const codeStyles = css`
   font-size: 0.9em;
 `
 
+// Frames are de-emphasized so the target element stays in focus.
+const frameStyles = css`
+  color: var(--gray-11);
+`
+
+// Beyond this many frames the chain is summarized as a count.
+const COLLAPSE_THRESHOLD = 2
+
+// Renders the iframe context after the element, reading "<element> in <frame>
+// in <frame>" innermost-first, or "in N frames" once the chain gets deep.
+function FrameChain({ frames }: { frames: ElementLocator[] }) {
+  if (frames.length === 0) {
+    return null
+  }
+
+  if (frames.length > COLLAPSE_THRESHOLD) {
+    return <span css={frameStyles}>in {frames.length} frames</span>
+  }
+
+  return (
+    <>
+      {[...frames].reverse().map((frame, index) => (
+        <Fragment key={index}>
+          <span css={frameStyles}>in</span>
+          <SquareStackIcon
+            aria-label="iframe"
+            css={[iconStyles, frameStyles]}
+          />
+          <code css={[codeStyles, frameStyles]}>
+            <LocatorText locator={frame} />
+          </code>
+        </Fragment>
+      ))}
+    </>
+  )
+}
+
 interface LocatorProps {
   locator: ElementLocator
-  // Chain of iframe locators (outermost first) the element lives in, shown as a
-  // prefix inside the badge so an element inside an iframe is recognizable.
+  // Chain of iframe locators (outermost first) the element lives in, shown after
+  // the element as " in <frame>" so an element inside an iframe is recognizable.
   frames?: ElementLocator[]
   onHighlightChange?: (highlighted: boolean) => void
 }
@@ -158,18 +195,11 @@ export function Locator({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      {frames.map((frame, index) => (
-        <Fragment key={index}>
-          <SquareStackIcon aria-label="Inside iframe" css={iconStyles} />
-          <code css={codeStyles}>
-            <LocatorText locator={frame} />
-          </code>
-        </Fragment>
-      ))}
       <LocatorIcon css={iconStyles} locator={locator} />
       <code css={codeStyles}>
         <LocatorText locator={locator} />
       </code>
+      <FrameChain frames={frames} />
     </div>
   )
 }

--- a/src/components/Browser/utils.ts
+++ b/src/components/Browser/utils.ts
@@ -1,18 +1,41 @@
+import { getFrameOffset } from '@/utils/dom/layout'
+
 import { Bounds } from './types'
 
-export function toBounds(rect: DOMRect): Bounds {
-  // `getBoundingClientRect` returns the coordinates relative to the viewport
-  // and not the document, so we add the scroll position so that the element
-  // is relative to the page instead. This means that content will stay in place
-  // when scrolling.
+/**
+ * Assembles element bounds from a viewport rect, the accumulated offset of the
+ * iframes the element lives in, and the scroll of the document the overlay is
+ * drawn in. Making the scroll an explicit argument keeps each call site's
+ * coordinate space clear (the recorder uses the top frame's scroll, the editor
+ * the app window's).
+ */
+export function composeBounds(
+  rect: DOMRect,
+  offset: { left: number; top: number },
+  scroll: { x: number; y: number }
+): Bounds {
+  // `getBoundingClientRect` is viewport-relative; adding the scroll makes the
+  // bounds document-relative so the overlay stays put while the page scrolls.
   return {
-    top: rect.top + window.scrollY,
-    left: rect.left + window.scrollX,
+    left: rect.left + offset.left + scroll.x,
+    top: rect.top + offset.top + scroll.y,
     width: rect.width,
     height: rect.height,
   }
 }
 
-export function getElementBounds(element: Element | Range): Bounds {
-  return toBounds(element.getBoundingClientRect())
+/**
+ * Bounds of an element that may live inside an iframe nested under `rootWindow`,
+ * in the document coordinates of the app window the overlay is drawn in.
+ */
+export function getElementBoundsWithin(
+  element: Element,
+  rootWindow: Window | null
+): Bounds {
+  const offset = getFrameOffset(element.ownerDocument.defaultView, rootWindow)
+
+  return composeBounds(element.getBoundingClientRect(), offset, {
+    x: window.scrollX,
+    y: window.scrollY,
+  })
 }

--- a/src/components/BrowserEventList/BrowserEventList.test.tsx
+++ b/src/components/BrowserEventList/BrowserEventList.test.tsx
@@ -79,20 +79,50 @@ describe('BrowserEventList highlighting', () => {
 })
 
 describe('BrowserEventList iframe indicator', () => {
-  it('marks an element captured inside an iframe with the frame in its badge', () => {
-    const event = clickEvent([{ selectors: { css: 'iframe#outer' } }])
+  it('shows the element first, then each frame innermost-first joined by "in"', () => {
+    // frames are stored outermost-first; the badge reads element-first.
+    const event = clickEvent([
+      { selectors: { css: 'iframe#outer' } },
+      { selectors: { css: 'iframe#inner' } },
+    ])
 
-    const { getByLabelText, getByText } = renderList(event, vi.fn())
+    const { getAllByLabelText, getByText } = renderList(event, vi.fn())
 
-    expect(getByLabelText('Inside iframe')).toBeTruthy()
-    expect(getByText('iframe#outer')).toBeTruthy()
+    const badge = getByText('#checkout-button').closest('div')
+
+    if (badge === null) {
+      throw new Error('locator badge not found')
+    }
+
+    expect(getAllByLabelText('iframe')).toHaveLength(2)
+    expect(badge.textContent).toMatch(
+      /#checkout-button.*in.*iframe#inner.*in.*iframe#outer/
+    )
   })
 
-  it('shows no iframe marker for a top-frame event', () => {
+  it('collapses to a frame count when the chain is deep', () => {
+    const event = clickEvent([
+      { selectors: { css: 'iframe#a' } },
+      { selectors: { css: 'iframe#b' } },
+      { selectors: { css: 'iframe#c' } },
+    ])
+
+    const { getByText, queryByText, queryByLabelText } = renderList(
+      event,
+      vi.fn()
+    )
+
+    expect(getByText(/in 3 frames/)).toBeTruthy()
+    expect(queryByText('iframe#a')).toBeNull()
+    expect(queryByLabelText('iframe')).toBeNull()
+  })
+
+  it('shows no frame suffix for a top-frame event', () => {
     const event = clickEvent(undefined)
 
-    const { queryByLabelText } = renderList(event, vi.fn())
+    const { getByText, queryByLabelText } = renderList(event, vi.fn())
 
-    expect(queryByLabelText('Inside iframe')).toBeNull()
+    expect(getByText('#checkout-button')).toBeTruthy()
+    expect(queryByLabelText('iframe')).toBeNull()
   })
 })

--- a/src/components/BrowserEventList/BrowserEventList.test.tsx
+++ b/src/components/BrowserEventList/BrowserEventList.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BrowserEvent, ClickEvent } from '@/schemas/recording'
+import { RecordingContext } from '@/views/Recorder/RecordingContext'
+
+import { BrowserEventList } from './BrowserEventList'
+
+function clickEvent(frames?: ClickEvent['frames']): BrowserEvent {
+  return {
+    type: 'click',
+    eventId: 'event-1',
+    timestamp: 1,
+    tab: 'tab-1',
+    target: { selectors: { css: '#checkout-button' } },
+    button: 'left',
+    modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+    frames,
+  }
+}
+
+function renderList(event: BrowserEvent, onHighlight: () => void) {
+  return render(
+    <RecordingContext recording>
+      <BrowserEventList
+        events={[event]}
+        onNavigate={vi.fn()}
+        onHighlight={onHighlight}
+      />
+    </RecordingContext>
+  )
+}
+
+describe('BrowserEventList highlighting', () => {
+  it('forwards the iframe frame chain when an in-iframe event is hovered', () => {
+    const onHighlight = vi.fn()
+    const event = clickEvent([{ selectors: { css: '#checkout' } }])
+
+    const { getByText } = renderList(event, onHighlight)
+
+    const locator = getByText('#checkout-button').closest('div')
+
+    if (locator === null) {
+      throw new Error('locator element not found')
+    }
+
+    fireEvent.mouseEnter(locator)
+
+    expect(onHighlight).toHaveBeenCalledWith(
+      { type: 'css', selector: '#checkout-button' },
+      [
+        {
+          current: 'css',
+          values: { css: { type: 'css', selector: '#checkout' } },
+        },
+      ]
+    )
+  })
+
+  it('passes no frames for a top-frame event', () => {
+    const onHighlight = vi.fn()
+    const event = clickEvent(undefined)
+
+    const { getByText } = renderList(event, onHighlight)
+
+    const locator = getByText('#checkout-button').closest('div')
+
+    if (locator === null) {
+      throw new Error('locator element not found')
+    }
+
+    fireEvent.mouseEnter(locator)
+
+    expect(onHighlight).toHaveBeenCalledWith(
+      { type: 'css', selector: '#checkout-button' },
+      undefined
+    )
+  })
+})
+
+describe('BrowserEventList iframe indicator', () => {
+  it('marks an element captured inside an iframe with the frame in its badge', () => {
+    const event = clickEvent([{ selectors: { css: 'iframe#outer' } }])
+
+    const { getByLabelText, getByText } = renderList(event, vi.fn())
+
+    expect(getByLabelText('Inside iframe')).toBeTruthy()
+    expect(getByText('iframe#outer')).toBeTruthy()
+  })
+
+  it('shows no iframe marker for a top-frame event', () => {
+    const event = clickEvent(undefined)
+
+    const { queryByLabelText } = renderList(event, vi.fn())
+
+    expect(queryByLabelText('Inside iframe')).toBeNull()
+  })
+})

--- a/src/components/BrowserEventList/BrowserEventList.tsx
+++ b/src/components/BrowserEventList/BrowserEventList.tsx
@@ -2,8 +2,9 @@ import { css } from '@emotion/react'
 
 import { Flex } from '@/components/primitives/Flex'
 import { Table } from '@/components/primitives/Table'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent } from '@/schemas/recording'
+import { toFrameOptions } from '@/utils/locator'
 
 import { EventDescription } from './EventDescription'
 import { EventIcon } from './EventIcon'
@@ -11,7 +12,10 @@ import { EventIcon } from './EventIcon'
 interface BrowserEventListProps {
   events: BrowserEvent[]
   onNavigate: (url: string) => void
-  onHighlight: (locator: ElementLocator | null) => void
+  onHighlight: (
+    locator: ElementLocator | null,
+    frames?: LocatorOptions[]
+  ) => void
 }
 
 export function BrowserEventList({
@@ -28,6 +32,8 @@ export function BrowserEventList({
     >
       <Table.Body>
         {events.map((event) => {
+          const frames = 'frames' in event ? event.frames : undefined
+
           return (
             <Table.Row key={event.eventId}>
               <Table.Cell
@@ -52,7 +58,9 @@ export function BrowserEventList({
                     <EventDescription
                       event={event}
                       onNavigate={onNavigate}
-                      onHighlight={onHighlight}
+                      onHighlight={(locator) =>
+                        onHighlight(locator, toFrameOptions(frames))
+                      }
                     />
                   </div>
                 </Flex>

--- a/src/components/BrowserEventList/EventDescription/AssertDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/AssertDescription.tsx
@@ -11,7 +11,7 @@ interface AssertDescriptionProps {
 }
 
 export function AssertDescription({
-  event: { target, assertion },
+  event: { target, assertion, frames },
   onHighlight,
 }: AssertDescriptionProps) {
   switch (assertion.type) {
@@ -19,7 +19,11 @@ export function AssertDescription({
       return (
         <>
           Assert that{' '}
-          <Selector selectors={target.selectors} onHighlight={onHighlight} />{' '}
+          <Selector
+            selectors={target.selectors}
+            frames={frames}
+            onHighlight={onHighlight}
+          />{' '}
           contains the text{' '}
           <Tooltip asChild content={assertion.operation.value}>
             <em>{`"${assertion.operation.value}"`}</em>
@@ -31,8 +35,12 @@ export function AssertDescription({
       return (
         <>
           Assert that{' '}
-          <Selector selectors={target.selectors} onHighlight={onHighlight} /> is{' '}
-          {assertion.visible ? 'visible' : 'hidden'}
+          <Selector
+            selectors={target.selectors}
+            frames={frames}
+            onHighlight={onHighlight}
+          />{' '}
+          is {assertion.visible ? 'visible' : 'hidden'}
         </>
       )
 
@@ -40,8 +48,12 @@ export function AssertDescription({
       return (
         <>
           Assert that the checked state of{' '}
-          <Selector selectors={target.selectors} onHighlight={onHighlight} /> is{' '}
-          <code>{assertion.expected}</code>
+          <Selector
+            selectors={target.selectors}
+            frames={frames}
+            onHighlight={onHighlight}
+          />{' '}
+          is <code>{assertion.expected}</code>
         </>
       )
 
@@ -49,7 +61,11 @@ export function AssertDescription({
       return (
         <>
           Assert that the input{' '}
-          <Selector selectors={target.selectors} onHighlight={onHighlight} />{' '}
+          <Selector
+            selectors={target.selectors}
+            frames={frames}
+            onHighlight={onHighlight}
+          />{' '}
           has the value{' '}
           <Tooltip asChild content={assertion.expected}>
             <em>{`"${assertion.expected}"`}</em>

--- a/src/components/BrowserEventList/EventDescription/ClickDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/ClickDescription.tsx
@@ -16,7 +16,11 @@ export function ClickDescription({
   return (
     <>
       <ClickPill pastTense details={event} /> on element{' '}
-      <Selector selectors={event.target.selectors} onHighlight={onHighlight} />
+      <Selector
+        selectors={event.target.selectors}
+        frames={event.frames}
+        onHighlight={onHighlight}
+      />
     </>
   )
 }

--- a/src/components/BrowserEventList/EventDescription/EventDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/EventDescription.tsx
@@ -40,6 +40,7 @@ export function EventDescription({
           {event.checked ? 'Checked' : 'Unchecked'} checkbox{' '}
           <Selector
             selectors={event.target.selectors}
+            frames={event.frames}
             onHighlight={onHighlight}
           />
         </>
@@ -52,6 +53,7 @@ export function EventDescription({
           <code>{event.value}</code> from{' '}
           <Selector
             selectors={event.target.selectors}
+            frames={event.frames}
             onHighlight={onHighlight}
           />
         </>
@@ -66,6 +68,7 @@ export function EventDescription({
           Submitted form{' '}
           <Selector
             selectors={event.form.selectors}
+            frames={event.frames}
             onHighlight={onHighlight}
           />
         </>

--- a/src/components/BrowserEventList/EventDescription/InputChangeDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/InputChangeDescription.tsx
@@ -79,7 +79,11 @@ export function InputChangeDescription({
   return (
     <>
       Changed input of{' '}
-      <Selector selectors={event.target.selectors} onHighlight={onHighlight} />{' '}
+      <Selector
+        selectors={event.target.selectors}
+        frames={event.frames}
+        onHighlight={onHighlight}
+      />{' '}
       to{' '}
       <code>
         <MaskedValue sensitive={event.sensitive} value={event.value} />

--- a/src/components/BrowserEventList/EventDescription/SelectChangeDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/SelectChangeDescription.tsx
@@ -41,7 +41,11 @@ export function SelectChangeDescription({
         </div>
       </Tooltip>{' '}
       from{' '}
-      <Selector selectors={event.target.selectors} onHighlight={onHighlight} />
+      <Selector
+        selectors={event.target.selectors}
+        frames={event.frames}
+        onHighlight={onHighlight}
+      />
     </>
   )
 }

--- a/src/components/BrowserEventList/EventDescription/Selector.tsx
+++ b/src/components/BrowserEventList/EventDescription/Selector.tsx
@@ -1,17 +1,21 @@
 import { Locator } from '@/components/Browser/Locator'
 import { ElementLocator } from '@/schemas/locator'
-import { ElementSelector } from '@/schemas/recording'
+import { BrowserEventTarget, ElementSelector } from '@/schemas/recording'
 import { getElementLocator } from '@/utils/locator'
 import { useIsRecording } from '@/views/Recorder/RecordingContext'
 
 interface SelectorProps {
   selectors: ElementSelector
+  frames?: BrowserEventTarget[]
   onHighlight: (locator: ElementLocator | null) => void
 }
 
-export function Selector({ selectors, onHighlight }: SelectorProps) {
+export function Selector({ selectors, frames, onHighlight }: SelectorProps) {
   const isRecording = useIsRecording()
   const locator = getElementLocator(selectors)
+  const frameLocators = (frames ?? []).map((frame) =>
+    getElementLocator(frame.selectors)
+  )
 
   const handleHighlightChange = (highlighted: boolean) => {
     if (!highlighted) {
@@ -26,6 +30,7 @@ export function Selector({ selectors, onHighlight }: SelectorProps) {
   return (
     <Locator
       locator={locator}
+      frames={frameLocators}
       onHighlightChange={isRecording ? handleHighlightChange : undefined}
     />
   )

--- a/src/components/BrowserEventList/EventDescription/WaitForDescription.tsx
+++ b/src/components/BrowserEventList/EventDescription/WaitForDescription.tsx
@@ -15,7 +15,11 @@ export function WaitForDescription({
   return (
     <>
       Wait for{' '}
-      <Selector selectors={event.target.selectors} onHighlight={onHighlight} />
+      <Selector
+        selectors={event.target.selectors}
+        frames={event.frames}
+        onHighlight={onHighlight}
+      />
     </>
   )
 }

--- a/src/handlers/browserRemote/index.ts
+++ b/src/handlers/browserRemote/index.ts
@@ -1,14 +1,14 @@
 import { ipcMain } from 'electron'
 
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 
 import { BrowserRemoteHandlers } from './types'
 
 export function initialize() {
   ipcMain.on(
     BrowserRemoteHandlers.HighlightElement,
-    (_event, locator: ElementLocator | null) => {
-      k6StudioState.currentRecordingSession?.highlightElement(locator)
+    (_event, locator: ElementLocator | null, frames?: LocatorOptions[]) => {
+      k6StudioState.currentRecordingSession?.highlightElement(locator, frames)
     }
   )
 

--- a/src/handlers/browserRemote/preload.ts
+++ b/src/handlers/browserRemote/preload.ts
@@ -1,11 +1,14 @@
 import { ipcRenderer } from 'electron'
 
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 
 import { BrowserRemoteHandlers } from './types'
 
-export function highlightElement(locator: ElementLocator | null) {
-  ipcRenderer.send(BrowserRemoteHandlers.HighlightElement, locator)
+export function highlightElement(
+  locator: ElementLocator | null,
+  frames?: LocatorOptions[]
+) {
+  ipcRenderer.send(BrowserRemoteHandlers.HighlightElement, locator, frames)
 }
 
 export function navigateTo(url: string) {

--- a/src/hooks/useListenBrowserEvent.test.ts
+++ b/src/hooks/useListenBrowserEvent.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { BrowserEvent } from '@/schemas/recording'
+
+import { useListenBrowserEvent } from './useListenBrowserEvent'
+
+type Callback = (events: BrowserEvent[]) => void
+
+function nav(eventId: string, timestamp: number): BrowserEvent {
+  return {
+    type: 'navigate-to-page',
+    eventId,
+    timestamp,
+    tab: 'tab-1',
+    url: 'http://example.test',
+    source: 'address-bar',
+  }
+}
+
+describe('useListenBrowserEvent', () => {
+  let emit: Callback
+
+  beforeAll(() => {
+    vi.stubGlobal('studio', {
+      browser: {
+        onBrowserEvent: (callback: Callback) => {
+          emit = callback
+
+          return () => {}
+        },
+      },
+    })
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // The session broadcasts its full, timestamp-sorted buffer on every record:
+  // frames stream over separate sockets, so a late one carries an earlier
+  // event and the buffer is re-sorted. The hook must mirror that snapshot, not
+  // append each batch, or the live event list shows iframe interactions out of
+  // order.
+  it('mirrors the latest sorted snapshot instead of accumulating batches', () => {
+    const { result } = renderHook(() => useListenBrowserEvent())
+
+    act(() => {
+      emit([nav('b', 2)])
+      emit([nav('a', 1), nav('b', 2)])
+    })
+
+    expect(result.current.map((event) => event.eventId)).toEqual(['a', 'b'])
+  })
+})

--- a/src/hooks/useListenBrowserEvent.ts
+++ b/src/hooks/useListenBrowserEvent.ts
@@ -7,9 +7,7 @@ export function useListenBrowserEvent() {
 
   useEffect(() => {
     return window.studio.browser.onBrowserEvent((events: BrowserEvent[]) => {
-      console.log('Received browser events', events)
-
-      setEvents((prevEvents) => [...prevEvents, ...events])
+      setEvents(events)
     })
   }, [])
 

--- a/src/recorder/browser/frames.test.ts
+++ b/src/recorder/browser/frames.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
+
+import { buildFramePath, getCssFramePathForElement, withFrames } from './frames'
+
+interface FakeWindow {
+  parent: FakeWindow
+  frameElement: Element | null
+}
+
+function fakeFrame(frameElement: Element | null): FakeWindow {
+  const win = { frameElement } as FakeWindow
+  win.parent = win
+  return win
+}
+
+const details = (element: Element): BrowserEventTarget => ({
+  selectors: { css: (element as { id: string }).id },
+})
+
+describe('buildFramePath', () => {
+  it('returns an empty path for the top frame', () => {
+    const top = fakeFrame(null)
+
+    expect(buildFramePath(top as unknown as Window, details)).toEqual([])
+  })
+
+  it('returns the iframe chain outermost first', () => {
+    const top = fakeFrame(null)
+    const middle = fakeFrame({ id: 'iframe#outer' } as unknown as Element)
+    const leaf = fakeFrame({ id: 'iframe#inner' } as unknown as Element)
+
+    middle.parent = top
+    leaf.parent = middle
+
+    expect(buildFramePath(leaf as unknown as Window, details)).toEqual([
+      { selectors: { css: 'iframe#outer' } },
+      { selectors: { css: 'iframe#inner' } },
+    ])
+  })
+
+  it('throws when a frame in the chain has no reachable owning element', () => {
+    const top = fakeFrame(null)
+    const middle = fakeFrame(null)
+    const leaf = fakeFrame({ id: 'iframe#inner' } as unknown as Element)
+
+    middle.parent = top
+    leaf.parent = middle
+
+    // A partial path would resolve the locator in the wrong (shallower) frame,
+    // so the walk fails and the caller falls back to no frame path instead.
+    expect(() => buildFramePath(leaf as unknown as Window, details)).toThrow()
+  })
+})
+
+describe('withFrames', () => {
+  const event: BrowserEvent = {
+    type: 'navigate-to-page',
+    eventId: 'a',
+    timestamp: 1,
+    tab: 'tab-1',
+    url: 'http://example.test',
+    source: 'address-bar',
+  }
+
+  it('attaches the frame path when the event happened inside an iframe', () => {
+    const frames: BrowserEventTarget[] = [{ selectors: { css: '#frame' } }]
+
+    expect(withFrames(event, frames)).toEqual({ ...event, frames })
+  })
+
+  it('leaves a top-frame event untouched when the path is empty', () => {
+    expect(withFrames(event, [])).toBe(event)
+  })
+})
+
+describe('getCssFramePathForElement', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // The iframe-traversal path can't be exercised under jsdom: an iframe's
+  // contentWindow.parent self-references (so the frame walk can't ascend) and
+  // `finder` needs CSS.escape, which jsdom lacks. It is verified in the running
+  // app instead; here we cover the top-frame case.
+  it('returns an empty path for a top-frame element', () => {
+    document.body.innerHTML = '<button id="target">x</button>'
+
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('target not found')
+    }
+
+    expect(getCssFramePathForElement(target)).toEqual([])
+  })
+})

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -1,0 +1,85 @@
+import { cssLocatorOptions, LocatorOptions } from '@/schemas/locator'
+import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
+import { forEachOwningFrame } from '@/utils/dom/frameChain'
+import { getCssSelector, getElementDetails } from '@/utils/dom/selectors'
+
+/**
+ * Walks from `start` up to the top frame, collecting details for each owning
+ * `<iframe>` element along the way. The result is ordered outermost first, so it
+ * can be replayed as a chain of frame locators. Throws if a frame in the chain
+ * has no reachable owning element (e.g. a detached frame): returning the partial
+ * path collected so far would resolve the locator in the wrong, shallower frame,
+ * so callers fall back to no frame path instead.
+ */
+export function buildFramePath(
+  start: Window,
+  getDetails: (element: Element) => BrowserEventTarget
+): BrowserEventTarget[] {
+  const path: BrowserEventTarget[] = []
+
+  forEachOwningFrame(
+    start,
+    () => false,
+    (iframe) => path.unshift(getDetails(iframe))
+  )
+
+  return path
+}
+
+function safeFramePath(start: Window): BrowserEventTarget[] {
+  try {
+    return buildFramePath(start, getElementDetails)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The chain of iframe locators from the top frame down to the current frame,
+ * outermost first. Empty when running in the top frame. Relies on the recorder
+ * launching the browser with web security and site isolation disabled so that
+ * `window.frameElement` is readable across origins.
+ */
+export function getFramePath(): BrowserEventTarget[] {
+  return safeFramePath(window)
+}
+
+/**
+ * The frame path of a specific element, which may live in a different frame than
+ * the code asking for it (e.g. the top-frame inspector picking an element inside
+ * an iframe). Empty when the element is in the top frame.
+ */
+export function getFramePathForElement(element: Element): BrowserEventTarget[] {
+  return safeFramePath(element.ownerDocument.defaultView ?? window)
+}
+
+/**
+ * The frame chain for an element as CSS-only locator options. The live element
+ * highlight resolves frames by CSS, so this avoids the full selector and aria
+ * generation per ancestor iframe that getFramePathForElement performs. Empty
+ * for the top frame.
+ */
+export function getCssFramePathForElement(element: Element): LocatorOptions[] {
+  try {
+    const path = buildFramePath(
+      element.ownerDocument.defaultView ?? window,
+      (iframe) => ({ selectors: { css: getCssSelector(iframe) } })
+    )
+
+    return path.map((frame) => cssLocatorOptions(frame.selectors.css))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Attaches a frame path to a recorded event, omitting it for the top frame (an
+ * empty path) so top-frame events stay frame-less. Centralizes the "no frames
+ * means absent" rule shared by every recorder emit site.
+ */
+export function withFrames<Event extends BrowserEvent>(
+  event: Event,
+  frames: BrowserEventTarget[]
+): Event {
+  return frames.length > 0 ? { ...event, frames } : event
+}

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -3,13 +3,24 @@ import { client } from './routing'
 import { configureStorage } from './storage'
 import { isInFrame } from './utils'
 import { initializeView } from './view'
+import {
+  attachInspectionDetection,
+  attachTextSelectionDetection,
+} from './view/inspection'
 import { trackTabFocus } from './window'
 
-// CDP will inject this script into all frames, but we only want to run it in the top frame.
-if (!isInFrame()) {
-  const storage = configureStorage(client)
+// CDP injects this script into every frame. We capture events in all frames so
+// that interactions inside iframes are recorded, but the recorder UI and tab
+// focus tracking only make sense in the top frame. Child frames instead forward
+// element inspection to the top frame's inspector.
+const storage = configureStorage(client)
 
+if (isInFrame()) {
+  attachInspectionDetection()
+  attachTextSelectionDetection()
+} else {
   trackTabFocus(client)
   initializeView(client, storage)
-  startRecording(client, storage)
 }
+
+startRecording(client, storage)

--- a/src/recorder/browser/messaging/types.ts
+++ b/src/recorder/browser/messaging/types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4'
 
-import { ElementLocatorSchema } from '@/schemas/locator'
+import { ElementLocatorSchema, LocatorOptionsSchema } from '@/schemas/locator'
 import { BrowserEventSchema } from '@/schemas/recording'
 
 export const InBrowserSettingsSchema = z.object({
@@ -37,6 +37,9 @@ export const EventsRecordedSchema = z.object({
 export const HighlightElementsSchema = z.object({
   type: z.literal('highlight-elements'),
   locator: ElementLocatorSchema.nullable(),
+  // Chain of iframe locators the element lives in, so highlighting can resolve
+  // into nested frames. Absent for top-frame elements.
+  frames: LocatorOptionsSchema.array().optional(),
 })
 
 export const NavigateSchema = z.object({

--- a/src/recorder/browser/recording.ts
+++ b/src/recorder/browser/recording.ts
@@ -12,6 +12,7 @@ import {
 } from '../../utils/dom/dom'
 import { getElementDetails } from '../../utils/dom/selectors'
 
+import { getFramePath, withFrames } from './frames'
 import { eventManager } from './manager'
 import { BrowserExtensionClient } from './messaging'
 import { getTabId } from './utils'
@@ -55,9 +56,15 @@ export function startRecording(
   }
 
   function recordEvents(events: BrowserEvent[] | BrowserEvent) {
+    const list = Array.isArray(events) ? events : [events]
+
+    // All events captured in this listener happened in the current frame, so
+    // they share the same frame path.
+    const frames = getFramePath()
+
     client.send({
       type: 'record-events',
-      events: Array.isArray(events) ? events : [events],
+      events: list.map((event) => withFrames(event, frames)),
     })
   }
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Bounds, Position } from '@/components/Browser/types'
+import { isHTMLIFrameElement } from '@/utils/dom/realm'
 
+import { toTopFramePosition } from '../frameGeometry'
 import { useGlobalClass } from '../GlobalStyles'
 import { useHighlightDebounce } from '../hooks/useHighlightDebounce'
 import { usePreventClick } from '../hooks/usePreventClick'
@@ -46,6 +48,33 @@ export function useInspectedElement() {
 
   useGlobalClass('inspecting')
 
+  const reset = useCallback(() => {
+    setMousePosition({
+      top: 0,
+      left: 0,
+    })
+
+    unpin()
+  }, [unpin])
+
+  const pinElement = useCallback(
+    (element: Element, position: Position) => {
+      const tracked = toTrackedElement(element)
+
+      // In certain cases the mouse position is outside the bounds of the hovered
+      // element, e.g. when the last hovered element was the `body` element.
+      // Showing the menu when clicking outside the bounds is very confusing
+      // because you have no idea what element the menu is for.
+      if (!isInsideBounds(position, tracked.bounds)) {
+        return
+      }
+
+      setMousePosition(position)
+      pin(tracked)
+    },
+    [pin]
+  )
+
   useEffect(() => {
     const handleMouseOver = (ev: MouseEvent) => {
       const [target] = ev.composedPath()
@@ -68,6 +97,13 @@ export function useInspectedElement() {
         return
       }
 
+      // The inspector running inside the iframe reports the element under the
+      // cursor, so don't highlight the iframe element itself (and skip the
+      // expensive selector computation it would require).
+      if (isHTMLIFrameElement(target)) {
+        return
+      }
+
       setHoveredEl(toTrackedElement(target))
     }
 
@@ -77,15 +113,6 @@ export function useInspectedElement() {
       window.removeEventListener('mouseover', handleMouseOver)
     }
   }, [])
-
-  const reset = useCallback(() => {
-    setMousePosition({
-      top: 0,
-      left: 0,
-    })
-
-    unpin()
-  }, [unpin])
 
   usePreventClick({
     callback: (ev) => {
@@ -99,25 +126,51 @@ export function useInspectedElement() {
         return
       }
 
-      const position = {
+      pinElement(hoveredEl.element, {
         top: ev.clientY + window.scrollY,
         left: ev.clientX + window.scrollX,
-      }
-
-      // In certain cases the mouse position is outside the bounds of
-      // the hovered element, e.g. when the last hovered element was
-      // the `body` element. Showing the menu when clicking outside
-      // the bounds is very confusing because you have no idea what
-      // element the menu is for.
-      if (!isInsideBounds(position, hoveredEl.bounds)) {
-        return
-      }
-
-      setMousePosition(position)
-      pin(hoveredEl)
+      })
     },
-    dependencies: [pinned, hoveredEl, unpin],
+    dependencies: [pinned, hoveredEl, reset, pinElement],
   })
+
+  // Detection inside iframes runs in the child frames (see
+  // attachInspectionDetection) and reports back through this bridge with the
+  // live element reference. We delegate through refs so the bridge object stays
+  // stable while still seeing the latest state.
+  const hoverRef = useRef<(element: Element) => void>(() => {})
+  const pickRef = useRef<
+    (element: Element, clientX: number, clientY: number) => void
+  >(() => {})
+
+  hoverRef.current = (element) => {
+    setHoveredEl(toTrackedElement(element))
+  }
+
+  pickRef.current = (element, clientX, clientY) => {
+    if (pinned !== null) {
+      reset()
+
+      return
+    }
+
+    pinElement(
+      element,
+      toTopFramePosition(element.ownerDocument.defaultView, clientX, clientY)
+    )
+  }
+
+  useEffect(() => {
+    window.__K6_STUDIO_INSPECTION__ = {
+      hover: (element) => hoverRef.current(element),
+      pick: (element, clientX, clientY) =>
+        pickRef.current(element, clientX, clientY),
+    }
+
+    return () => {
+      delete window.__K6_STUDIO_INSPECTION__
+    }
+  }, [])
 
   const highlightedEl = useHighlightDebounce(hoveredEl)
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
@@ -141,13 +141,13 @@ export function useInspectedElement() {
   // attachInspectionDetection) and reports back through this bridge with the
   // live element reference. We delegate through refs so the bridge object stays
   // stable while still seeing the latest state.
-  const hoverRef = useRef<(element: Element) => void>(() => {})
+  const hoverRef = useRef<(element: Element | null) => void>(() => {})
   const pickRef = useRef<
     (element: Element, clientX: number, clientY: number) => void
   >(() => {})
 
   hoverRef.current = (element) => {
-    setHoveredEl(toTrackedElement(element))
+    setHoveredEl(element ? toTrackedElement(element) : null)
   }
 
   pickRef.current = (element, clientX, clientY) => {

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
@@ -99,8 +99,11 @@ export function useInspectedElement() {
 
       // The inspector running inside the iframe reports the element under the
       // cursor, so don't highlight the iframe element itself (and skip the
-      // expensive selector computation it would require).
+      // expensive selector computation it would require). Clear the hover so a
+      // prior in-frame highlight can't linger over the iframe's own surface.
       if (isHTMLIFrameElement(target)) {
+        setHoveredEl(null)
+
         return
       }
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.tsx
@@ -7,6 +7,7 @@ import { Overlay } from '@/components/Browser/Overlay'
 import { Tooltip } from '@/components/primitives/Tooltip'
 import { ElementRole } from '@/utils/dom/aria'
 
+import { getFramePathForElement, withFrames } from '../../frames'
 import { getTabId } from '../../utils'
 import { Anchor } from '../Anchor'
 import { useEscape } from '../hooks/useEscape'
@@ -87,17 +88,22 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
   }
 
   const handleAssertionSubmit = (assertion: AssertionData) => {
+    const frames = element ? getFramePathForElement(element.element) : []
+
     client.send({
       type: 'record-events',
       events: [
-        {
-          type: 'assert',
-          eventId: nanoid(),
-          timestamp: Date.now(),
-          tab: getTabId(),
-          target: assertion.target,
-          assertion: toAssertion(assertion),
-        },
+        withFrames(
+          {
+            type: 'assert',
+            eventId: nanoid(),
+            timestamp: Date.now(),
+            tab: getTabId(),
+            target: assertion.target,
+            assertion: toAssertion(assertion),
+          },
+          frames
+        ),
       ],
     })
 
@@ -109,17 +115,22 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
   }
 
   const handleAddWaitFor = (data: WaitForData) => {
+    const frames = element ? getFramePathForElement(element.element) : []
+
     client.send({
       type: 'record-events',
       events: [
-        {
-          type: 'wait-for',
-          eventId: nanoid(),
-          timestamp: Date.now(),
-          tab: getTabId(),
-          target: data.target,
-          options: data.options,
-        },
+        withFrames(
+          {
+            type: 'wait-for',
+            eventId: nanoid(),
+            timestamp: Date.now(),
+            tab: getTabId(),
+            target: data.target,
+            options: data.options,
+          },
+          frames
+        ),
       ],
     })
 

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
@@ -11,6 +11,7 @@ import { ComponentProps, ReactNode } from 'react'
 
 import { Toolbar } from '@/components/primitives/Toolbar'
 import { ElementRole } from '@/utils/dom/aria'
+import { isHTMLTextAreaElement } from '@/utils/dom/realm'
 
 import { AssertionData, CheckAssertionData } from './assertions/types'
 import {
@@ -120,7 +121,7 @@ function TextInputAssertion({
       type: 'text-input',
       target: input.target,
       multiline:
-        input.element instanceof HTMLTextAreaElement ||
+        isHTMLTextAreaElement(input.element) ||
         input.element.getAttribute('aria-multiline') === 'true',
       expected: getTextBoxValue(input.element),
     })

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
@@ -1,6 +1,13 @@
 import { BrowserEventTarget } from '@/schemas/recording'
 import { ElementRole, getElementRoles } from '@/utils/dom/aria'
 import { findAssociatedElement } from '@/utils/dom/dom'
+import {
+  isHTMLButtonElement,
+  isHTMLInputElement,
+  isHTMLLabelElement,
+  isHTMLSelectElement,
+  isHTMLTextAreaElement,
+} from '@/utils/dom/realm'
 import { getElementDetails } from '@/utils/dom/selectors'
 
 import { CheckAssertionData } from './assertions/types'
@@ -29,10 +36,10 @@ export function findAssociatedControl({
 }: TrackedElement): LabeledControl | null {
   // If the target is already a control, then we don't need to do a search.
   if (
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLButtonElement ||
-    element instanceof HTMLSelectElement ||
-    element instanceof HTMLTextAreaElement
+    isHTMLInputElement(element) ||
+    isHTMLButtonElement(element) ||
+    isHTMLSelectElement(element) ||
+    isHTMLTextAreaElement(element)
   ) {
     return {
       element,
@@ -41,8 +48,8 @@ export function findAssociatedControl({
     }
   }
 
-  const label = [...getAncestors(element)].find(
-    (ancestor) => ancestor instanceof HTMLLabelElement
+  const label = [...getAncestors(element)].find((ancestor) =>
+    isHTMLLabelElement(ancestor)
   )
 
   if (label === undefined) {
@@ -65,7 +72,7 @@ export function findAssociatedControl({
 export function getCheckedState(
   element: Element
 ): CheckAssertionData['expected'] {
-  if (element instanceof HTMLInputElement) {
+  if (isHTMLInputElement(element)) {
     if (element.indeterminate) {
       return 'indeterminate'
     }
@@ -89,10 +96,7 @@ export function getCheckedState(
 }
 
 export function getTextBoxValue(element: Element): string {
-  if (
-    element instanceof HTMLInputElement ||
-    element instanceof HTMLTextAreaElement
-  ) {
+  if (isHTMLInputElement(element) || isHTMLTextAreaElement(element)) {
     return element.value
   }
 
@@ -106,7 +110,7 @@ export function isNative(role: ElementRole, element: Element) {
   // `.toHaveAttribute()`.
   if (
     role.role === 'switch' &&
-    element instanceof HTMLInputElement &&
+    isHTMLInputElement(element) &&
     element.type === 'checkbox'
   ) {
     return true

--- a/src/recorder/browser/view/ElementInspector/hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/hooks.ts
@@ -1,6 +1,9 @@
 import { last } from 'lodash-es'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { emptyToUndefined } from '@/utils/list'
+
+import { getCssFramePathForElement } from '../../frames'
 import { useStudioClient } from '../StudioClientProvider'
 
 import { toTrackedElement, TrackedElement } from './utils'
@@ -27,7 +30,9 @@ export function usePinnedElement(element?: TrackedElement) {
 
     const parent = head.element.parentElement
 
-    if (parent === null || parent === document.documentElement) {
+    // Use the element's own document so expansion stops correctly for elements
+    // inside iframes, not just the top document.
+    if (parent === null || parent === parent.ownerDocument.documentElement) {
       return undefined
     }
 
@@ -66,6 +71,22 @@ export function usePinnedElement(element?: TrackedElement) {
 export function useElementHighlight(element: TrackedElement | null) {
   const client = useStudioClient()
 
+  // The frame chain is the same for every element in a given document, and
+  // computing it runs an expensive selector generation on each ancestor iframe,
+  // so memoize it per owner document. Any element in the document yields the
+  // same chain, so it is computed from the document element. The chain of iframe
+  // CSS selectors lets the highlight resolve into the right frame.
+  const ownerDocument = element?.element.ownerDocument ?? null
+  const frames = useMemo(
+    () =>
+      ownerDocument === null
+        ? undefined
+        : emptyToUndefined(
+            getCssFramePathForElement(ownerDocument.documentElement)
+          ),
+    [ownerDocument]
+  )
+
   useEffect(() => {
     client.send({
       type: 'highlight-elements',
@@ -73,8 +94,9 @@ export function useElementHighlight(element: TrackedElement | null) {
         type: 'css',
         selector: element.target.selectors.css,
       },
+      frames,
     })
-  }, [client, element])
+  }, [client, element, frames])
 
   useEffect(() => {
     return () => {

--- a/src/recorder/browser/view/ElementInspector/utils.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.ts
@@ -1,10 +1,11 @@
 import { nanoid } from 'nanoid'
 
 import { Bounds } from '@/components/Browser/types'
-import { getElementBounds } from '@/components/Browser/utils'
 import { BrowserEventTarget } from '@/schemas/recording'
 import { ElementRole, getElementRoles } from '@/utils/dom/aria'
 import { getElementDetails } from '@/utils/dom/selectors'
+
+import { getElementBoundsInTopFrame } from '../frameGeometry'
 
 export interface TrackedElement {
   id: string
@@ -22,6 +23,6 @@ export function toTrackedElement(element: Element): TrackedElement {
     roles: [...roles],
     target: getElementDetails(element),
     element: element,
-    bounds: getElementBounds(element),
+    bounds: getElementBoundsInTopFrame(element),
   }
 }

--- a/src/recorder/browser/view/EventDrawer.tsx
+++ b/src/recorder/browser/view/EventDrawer.tsx
@@ -4,7 +4,7 @@ import { XIcon } from 'lucide-react'
 
 import { BrowserEventList } from '@/components/BrowserEventList'
 import { useContainerElement } from '@/components/primitives/ContainerProvider'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent } from '@/schemas/recording'
 import { RecordingContext } from '@/views/Recorder/RecordingContext'
 
@@ -42,10 +42,14 @@ export function EventDrawer({ open, events, onOpenChange }: EventDrawerProps) {
   const container = useContainerElement()
   const [settings, setSettings] = useInBrowserSettings()
 
-  const handleHighlight = (locator: ElementLocator | null) => {
+  const handleHighlight = (
+    locator: ElementLocator | null,
+    frames?: LocatorOptions[]
+  ) => {
     client.send({
       type: 'highlight-elements',
       locator,
+      frames,
     })
   }
 

--- a/src/recorder/browser/view/RemoteHighlights.tsx
+++ b/src/recorder/browser/view/RemoteHighlights.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 import { ElementHighlights } from '@/components/Browser/ElementHighlights'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 
 import { useStudioClient } from './StudioClientProvider'
 
@@ -12,12 +12,16 @@ export function RemoteHighlights() {
   const client = useStudioClient()
 
   const [locator, setLocator] = useState<ElementLocator | null>(null)
+  const [frames, setFrames] = useState<LocatorOptions[] | undefined>(undefined)
 
   useEffect(() => {
     return client.on('highlight-elements', ({ data }) => {
       setLocator(data.locator)
+      setFrames(data.frames)
     })
   }, [client])
 
-  return <ElementHighlights root={document.body} target={locator} />
+  return (
+    <ElementHighlights root={document.body} target={locator} frames={frames} />
+  )
 }

--- a/src/recorder/browser/view/TextSelectionPopover.hooks.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.hooks.ts
@@ -1,7 +1,10 @@
 import { useCallback, useRef, useState, useEffect } from 'react'
 
 import { useContainerElement } from '@/components/primitives/ContainerProvider'
-import { observeWindowsForLayoutShift } from '@/utils/dom/layout'
+import {
+  collectLayoutShiftWindows,
+  observeWindowsForLayoutShift,
+} from '@/utils/dom/layout'
 
 import { toTrackedElement } from './ElementInspector/utils'
 import { toTopFrameBounds } from './frameGeometry'
@@ -118,13 +121,9 @@ export function useTextSelection() {
     }
 
     // The selected range may live inside an iframe that scrolls independently
-    // of the top document, so recompute on a shift in either frame.
+    // of the top document, so recompute on a shift in any frame on the path.
     const frameWindow = selectionRange.startContainer.ownerDocument?.defaultView
-    const windows = new Set<Window>([window])
-
-    if (frameWindow != null) {
-      windows.add(frameWindow)
-    }
+    const windows = collectLayoutShiftWindows(window, frameWindow)
 
     return observeWindowsForLayoutShift(windows, recompute)
   }, [selectionRange])

--- a/src/recorder/browser/view/TextSelectionPopover.hooks.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.hooks.ts
@@ -1,15 +1,23 @@
-import { useRef, useState, useEffect } from 'react'
+import { useCallback, useRef, useState, useEffect } from 'react'
 
-import { getElementBounds, toBounds } from '@/components/Browser/utils'
 import { useContainerElement } from '@/components/primitives/ContainerProvider'
+import { observeWindowsForLayoutShift } from '@/utils/dom/layout'
 
 import { toTrackedElement } from './ElementInspector/utils'
+import { toTopFrameBounds } from './frameGeometry'
+import { readSelection } from './inspection'
 import { TextSelection } from './TextSelectionPopover.types'
 
 function measureRange(range: Range) {
+  // The range may live inside an iframe; translate its rects into the top
+  // frame's coordinates so the highlights line up.
+  const frameWindow = range.startContainer.ownerDocument?.defaultView ?? null
+
   return {
-    highlights: Array.from(range.getClientRects()).map(toBounds),
-    bounds: getElementBounds(range),
+    highlights: Array.from(range.getClientRects()).map((rect) =>
+      toTopFrameBounds(rect, frameWindow)
+    ),
+    bounds: toTopFrameBounds(range.getBoundingClientRect(), frameWindow),
   }
 }
 
@@ -19,6 +27,18 @@ export function useTextSelection() {
   const container = useContainerElement()
 
   const [selection, setSelection] = useState<TextSelection | null>(null)
+
+  const buildSelection = useCallback(
+    (range: Range, commonAncestor: Element) => {
+      setSelection({
+        text: range.toString(),
+        element: toTrackedElement(commonAncestor),
+        range,
+        ...measureRange(range),
+      })
+    },
+    []
+  )
 
   useEffect(() => {
     const handleStart = (ev: Event) => {
@@ -52,37 +72,15 @@ export function useTextSelection() {
 
       isSelecting.current = false
 
-      const selection = document.getSelection()
+      const result = readSelection(document)
 
-      if (
-        selection === null ||
-        selection.rangeCount === 0 ||
-        selection.isCollapsed
-      ) {
+      if (result === null) {
         setSelection(null)
 
         return
       }
 
-      const range = selection.getRangeAt(0)
-
-      const commonAncestor =
-        range.commonAncestorContainer instanceof Element
-          ? range.commonAncestorContainer
-          : range.commonAncestorContainer.parentElement
-
-      if (commonAncestor === null) {
-        setSelection(null)
-
-        return
-      }
-
-      setSelection({
-        text: range.toString(),
-        element: toTrackedElement(commonAncestor),
-        range,
-        ...measureRange(range),
-      })
+      buildSelection(result.range, result.commonAncestor)
     }
 
     document.addEventListener('mouseup', handleMouseUp)
@@ -90,28 +88,46 @@ export function useTextSelection() {
     return () => {
       document.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [])
+  }, [buildSelection])
 
+  // Selections made inside iframes are detected in the child frames (see
+  // attachTextSelectionDetection) and reported here with the live range.
   useEffect(() => {
-    const observer = new ResizeObserver(() => {
-      setSelection((selection) => {
-        if (selection === null) {
-          return null
-        }
-
-        return {
-          ...selection,
-          ...measureRange(selection.range),
-        }
-      })
-    })
-
-    observer.observe(document.body)
+    window.__K6_STUDIO_TEXT_SELECTION__ = {
+      select: (range, commonAncestor) => buildSelection(range, commonAncestor),
+    }
 
     return () => {
-      observer.disconnect()
+      delete window.__K6_STUDIO_TEXT_SELECTION__
     }
-  }, [])
+  }, [buildSelection])
+
+  const selectionRange = selection?.range ?? null
+
+  useEffect(() => {
+    if (selectionRange === null) {
+      return
+    }
+
+    const recompute = () => {
+      setSelection((selection) =>
+        selection === null
+          ? null
+          : { ...selection, ...measureRange(selection.range) }
+      )
+    }
+
+    // The selected range may live inside an iframe that scrolls independently
+    // of the top document, so recompute on a shift in either frame.
+    const frameWindow = selectionRange.startContainer.ownerDocument?.defaultView
+    const windows = new Set<Window>([window])
+
+    if (frameWindow != null) {
+      windows.add(frameWindow)
+    }
+
+    return observeWindowsForLayoutShift(windows, recompute)
+  }, [selectionRange])
 
   useEffect(() => {
     if (selection !== null) {

--- a/src/recorder/browser/view/TextSelectionPopover.tsx
+++ b/src/recorder/browser/view/TextSelectionPopover.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 
 import { Overlay } from '@/components/Browser/Overlay'
 
+import { getFramePathForElement, withFrames } from '../frames'
 import { getTabId } from '../utils'
 
 import { TextAssertionEditor } from './ElementInspector/assertions/TextAssertionEditor'
@@ -91,23 +92,32 @@ export function TextSelectionPopover({ onClose }: TextSelectionPopoverProps) {
   })
 
   const handleAdd = (assertion: TextAssertionData) => {
+    // Expansion stays within the same frame, so the selection's element gives
+    // the right frame chain.
+    const frames = selection
+      ? getFramePathForElement(selection.element.element)
+      : []
+
     client.send({
       type: 'record-events',
       events: [
-        {
-          eventId: nanoid(),
-          timestamp: Date.now(),
-          type: 'assert',
-          tab: getTabId(),
-          target: assertion.target,
-          assertion: {
-            type: 'text',
-            operation: {
-              type: 'contains',
-              value: assertion.text,
+        withFrames(
+          {
+            eventId: nanoid(),
+            timestamp: Date.now(),
+            type: 'assert',
+            tab: getTabId(),
+            target: assertion.target,
+            assertion: {
+              type: 'text',
+              operation: {
+                type: 'contains',
+                value: assertion.text,
+              },
             },
           },
-        },
+          frames
+        ),
       ],
     })
 

--- a/src/recorder/browser/view/frameGeometry.ts
+++ b/src/recorder/browser/view/frameGeometry.ts
@@ -1,0 +1,51 @@
+import { Bounds, Position } from '@/components/Browser/types'
+import { composeBounds } from '@/components/Browser/utils'
+import { getFrameOffset } from '@/utils/dom/layout'
+
+function getTopScroll(): { x: number; y: number } {
+  const top = window.top ?? window
+
+  return { x: top.scrollX, y: top.scrollY }
+}
+
+/**
+ * Bounds of an element in the top frame's document coordinates, accounting for
+ * any iframes it lives in. For a top-frame element this is just its rect plus
+ * the page scroll.
+ */
+export function getElementBoundsInTopFrame(element: Element): Bounds {
+  return toTopFrameBounds(
+    element.getBoundingClientRect(),
+    element.ownerDocument.defaultView
+  )
+}
+
+/**
+ * Translates a viewport rect measured inside `frameWindow` into the top frame's
+ * document coordinates. Used for element and text-range highlights that may
+ * originate inside iframes.
+ */
+export function toTopFrameBounds(
+  rect: DOMRect,
+  frameWindow: Window | null
+): Bounds {
+  return composeBounds(rect, getFrameOffset(frameWindow), getTopScroll())
+}
+
+/**
+ * Maps a client point inside `frameWindow` to the top frame's document
+ * coordinates.
+ */
+export function toTopFramePosition(
+  frameWindow: Window | null,
+  clientX: number,
+  clientY: number
+): Position {
+  const offset = getFrameOffset(frameWindow)
+  const scroll = getTopScroll()
+
+  return {
+    left: clientX + offset.left + scroll.x,
+    top: clientY + offset.top + scroll.y,
+  }
+}

--- a/src/recorder/browser/view/hooks/useRecordedEvents.ts
+++ b/src/recorder/browser/view/hooks/useRecordedEvents.ts
@@ -11,7 +11,7 @@ export function useRecordedEvents() {
 
   useEffect(() => {
     return client.on('events-recorded', (event) => {
-      setEvents((prev) => [...prev, ...event.data.events])
+      setEvents(event.data.events)
     })
   }, [client])
 

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -1,0 +1,78 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+import { attachInspectionDetection } from './inspection'
+
+const hover = vi.fn()
+const pick = vi.fn()
+
+beforeAll(() => {
+  attachInspectionDetection()
+})
+
+beforeEach(() => {
+  window.__K6_STUDIO_INSPECTION__ = { hover, pick }
+})
+
+afterEach(() => {
+  hover.mockClear()
+  pick.mockClear()
+  delete window.__K6_STUDIO_INSPECTION__
+  document.body.innerHTML = ''
+})
+
+afterAll(() => {
+  delete window.__K6_STUDIO_INSPECTION__
+})
+
+function dispatch(type: string, target: Element, init: MouseEventInit = {}) {
+  target.dispatchEvent(
+    new MouseEvent(type, { bubbles: true, composed: true, ...init })
+  )
+}
+
+describe('attachInspectionDetection', () => {
+  it('reports a hovered element to the top frame', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('mouseover', button)
+
+    expect(hover).toHaveBeenCalledWith(button)
+  })
+
+  it('clears the hover when the cursor is over an iframe', () => {
+    const iframe = document.createElement('iframe')
+    document.body.append(iframe)
+
+    dispatch('mouseover', iframe)
+
+    expect(hover).toHaveBeenCalledWith(null)
+  })
+
+  it('picks a clicked element', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('click', button, { clientX: 5, clientY: 6 })
+
+    expect(pick).toHaveBeenCalledWith(button, 5, 6)
+  })
+
+  it('does not pick an iframe element', () => {
+    const iframe = document.createElement('iframe')
+    document.body.append(iframe)
+
+    dispatch('click', iframe, { clientX: 5, clientY: 6 })
+
+    expect(pick).not.toHaveBeenCalled()
+  })
+})

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -6,7 +6,7 @@ import { isElement, isHTMLIFrameElement } from '@/utils/dom/realm'
  * while the inspector tool is active.
  */
 export interface InspectionBridge {
-  hover(element: Element): void
+  hover(element: Element | null): void
   pick(element: Element, clientX: number, clientY: number): void
 }
 
@@ -100,12 +100,15 @@ export function attachInspectionDetection() {
 
     const [target] = event.composedPath()
 
-    // Skip iframe elements: the inspector running inside the iframe reports the
-    // actual element under the cursor, which also avoids an expensive selector
-    // computation on the (often deeply nested) iframe element here.
-    if (isElement(target) && !isHTMLIFrameElement(target)) {
-      bridge.hover(target)
+    if (!isElement(target)) {
+      return
     }
+
+    // The inspector running inside the iframe reports the actual element under
+    // the cursor, so don't highlight the iframe element itself; clear the hover
+    // instead so a prior highlight can't linger over it (this also avoids an
+    // expensive selector computation on the often deeply nested iframe element).
+    bridge.hover(isHTMLIFrameElement(target) ? null : target)
   })
 
   document.addEventListener(
@@ -126,6 +129,12 @@ export function attachInspectionDetection() {
       // The inspector is active, so swallow the page click and pick instead.
       event.preventDefault()
       event.stopPropagation()
+
+      // Don't pick the iframe element itself; the inspector inside it picks the
+      // real element under the cursor.
+      if (isHTMLIFrameElement(target)) {
+        return
+      }
 
       bridge.pick(target, event.clientX, event.clientY)
     },

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -1,0 +1,159 @@
+import { isElement, isHTMLIFrameElement } from '@/utils/dom/realm'
+
+/**
+ * Bridge the top-frame element inspector exposes so that detection running in
+ * child frames can report hovered/picked elements to it. It is only present
+ * while the inspector tool is active.
+ */
+export interface InspectionBridge {
+  hover(element: Element): void
+  pick(element: Element, clientX: number, clientY: number): void
+}
+
+/**
+ * Bridge the top-frame text-selection tool exposes so child frames can report a
+ * selection made inside them. Present only while the tool is active.
+ */
+export interface TextSelectionBridge {
+  select(range: Range, commonAncestor: Element): void
+}
+
+declare global {
+  interface Window {
+    __K6_STUDIO_INSPECTION__?: InspectionBridge
+    __K6_STUDIO_TEXT_SELECTION__?: TextSelectionBridge
+  }
+}
+
+// The bridges live on the top window. Reading `window.top` can throw on a
+// cross-origin frame, so guard the access and fall back to undefined.
+function getTopFrameBridge<T>(read: (top: Window) => T): T | undefined {
+  try {
+    return window.top ? read(window.top) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function getBridge(): InspectionBridge | undefined {
+  return getTopFrameBridge((top) => top.__K6_STUDIO_INSPECTION__)
+}
+
+function getTextSelectionBridge(): TextSelectionBridge | undefined {
+  return getTopFrameBridge((top) => top.__K6_STUDIO_TEXT_SELECTION__)
+}
+
+/**
+ * Reads the current selection from `document`, returning the range and the
+ * element it lives in. Shared by the top frame and child-frame detection.
+ */
+export function readSelection(
+  doc: Document
+): { range: Range; commonAncestor: Element } | null {
+  const selection = doc.getSelection()
+
+  if (
+    selection === null ||
+    selection.rangeCount === 0 ||
+    selection.isCollapsed
+  ) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0)
+
+  const commonAncestor = isElement(range.commonAncestorContainer)
+    ? range.commonAncestorContainer
+    : range.commonAncestorContainer.parentElement
+
+  if (commonAncestor === null) {
+    return null
+  }
+
+  return { range, commonAncestor }
+}
+
+/**
+ * Runs in child frames so the top-frame inspector can pick elements inside
+ * iframes. Detection has to happen in each frame because DOM events don't cross
+ * iframe boundaries; matched elements are forwarded to the top frame with a
+ * direct call (frames are same-process with web security disabled, so the live
+ * element reference passes across the boundary).
+ */
+export function attachInspectionDetection() {
+  document.addEventListener('mouseover', (event) => {
+    const bridge = getBridge()
+
+    if (bridge === undefined) {
+      return
+    }
+
+    const [target] = event.composedPath()
+
+    // Skip iframe elements: the inspector running inside the iframe reports the
+    // actual element under the cursor, which also avoids an expensive selector
+    // computation on the (often deeply nested) iframe element here.
+    if (isElement(target) && !isHTMLIFrameElement(target)) {
+      bridge.hover(target)
+    }
+  })
+
+  document.addEventListener(
+    'click',
+    (event) => {
+      const bridge = getBridge()
+
+      if (bridge === undefined) {
+        return
+      }
+
+      const [target] = event.composedPath()
+
+      if (!isElement(target)) {
+        return
+      }
+
+      // The inspector is active, so swallow the page click and pick instead.
+      event.preventDefault()
+      event.stopPropagation()
+
+      bridge.pick(target, event.clientX, event.clientY)
+    },
+    { capture: true }
+  )
+}
+
+/**
+ * Runs in child frames so the top-frame text-selection tool can assert on text
+ * selected inside an iframe. Selection state is per-document, so the selection
+ * is read here and forwarded to the top frame.
+ */
+export function attachTextSelectionDetection() {
+  let isSelecting = false
+
+  document.addEventListener('selectstart', () => {
+    if (getTextSelectionBridge() !== undefined) {
+      isSelecting = true
+    }
+  })
+
+  document.addEventListener('mouseup', () => {
+    if (!isSelecting) {
+      return
+    }
+
+    isSelecting = false
+
+    const bridge = getTextSelectionBridge()
+
+    if (bridge === undefined) {
+      return
+    }
+
+    const selection = readSelection(document)
+
+    if (selection !== null) {
+      bridge.select(selection.range, selection.commonAncestor)
+    }
+  })
+}

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -44,6 +44,16 @@ function getTextSelectionBridge(): TextSelectionBridge | undefined {
 }
 
 /**
+ * True when the top frame has an inspector or text-selection tool active. Child
+ * frames keep their own UI store where `tool` is never set, so they detect an
+ * active tool through the top frame's bridge to avoid recording inspector picks
+ * and text selections as real interactions.
+ */
+export function isTopFrameToolActive(): boolean {
+  return getBridge() !== undefined || getTextSelectionBridge() !== undefined
+}
+
+/**
  * Reads the current selection from `document`, returning the range and the
  * element it lives in. Shared by the top frame and child-frame detection.
  */

--- a/src/recorder/browser/view/utils.test.ts
+++ b/src/recorder/browser/view/utils.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useInBrowserUIStore } from './store'
+import { shouldSkipEvent } from './utils'
+
+afterEach(() => {
+  delete window.__K6_STUDIO_INSPECTION__
+  delete window.__K6_STUDIO_TEXT_SELECTION__
+  useInBrowserUIStore.getState().selectTool(null)
+})
+
+describe('shouldSkipEvent', () => {
+  it('does not skip events when no tool is active', () => {
+    expect(shouldSkipEvent(new Event('click'))).toBe(false)
+  })
+
+  it('skips events while the top frame has the inspector active', () => {
+    // A child frame has its own store where `tool` stays null, so it must look
+    // at the top frame's inspector bridge instead of its local store.
+    window.__K6_STUDIO_INSPECTION__ = { hover: () => {}, pick: () => {} }
+
+    expect(useInBrowserUIStore.getState().tool).toBeNull()
+    expect(shouldSkipEvent(new Event('click'))).toBe(true)
+  })
+
+  it('skips events while the top frame has text selection active', () => {
+    window.__K6_STUDIO_TEXT_SELECTION__ = { select: () => {} }
+
+    expect(shouldSkipEvent(new Event('click'))).toBe(true)
+  })
+})

--- a/src/recorder/browser/view/utils.ts
+++ b/src/recorder/browser/view/utils.ts
@@ -1,3 +1,4 @@
+import { isTopFrameToolActive } from './inspection'
 import { useInBrowserUIStore } from './store'
 
 export function isUsingTool(): boolean {
@@ -9,7 +10,7 @@ export function isUsingTool(): boolean {
 export function shouldSkipEvent(event: Event): boolean {
   const store = useInBrowserUIStore.getState()
 
-  if (store.tool !== null || store.isCaptureBlocked) {
+  if (store.tool !== null || store.isCaptureBlocked || isTopFrameToolActive()) {
     return true
   }
 

--- a/src/recorder/launchers/cdp/events.test.ts
+++ b/src/recorder/launchers/cdp/events.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { BrowserEvent } from '@/schemas/recording'
+
+import { mergeRecordedEvents } from './events'
+
+function nav(eventId: string, timestamp: number): BrowserEvent {
+  return {
+    type: 'navigate-to-page',
+    eventId,
+    timestamp,
+    tab: 'tab-1',
+    url: 'http://example.test',
+    source: 'address-bar',
+  }
+}
+
+describe('mergeRecordedEvents', () => {
+  it('orders late-arriving events from another frame by timestamp', () => {
+    const existing = [nav('a', 100), nav('b', 300)]
+    // An iframe's socket flushes a buffered event with an earlier timestamp.
+    const incoming = [nav('c', 200)]
+
+    const merged = mergeRecordedEvents(existing, incoming)
+
+    expect(merged.map((event) => event.eventId)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('keeps arrival order for events sharing a timestamp', () => {
+    const merged = mergeRecordedEvents(
+      [nav('a', 100)],
+      [nav('b', 100), nav('c', 100)]
+    )
+
+    expect(merged.map((event) => event.eventId)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('handles an empty buffer', () => {
+    const merged = mergeRecordedEvents([], [nav('a', 5)])
+
+    expect(merged.map((event) => event.eventId)).toEqual(['a'])
+  })
+})

--- a/src/recorder/launchers/cdp/events.ts
+++ b/src/recorder/launchers/cdp/events.ts
@@ -1,0 +1,17 @@
+import { BrowserEvent } from '@/schemas/recording'
+
+/**
+ * Appends newly recorded events to the buffer and returns it ordered by
+ * timestamp. Each frame records over its own WebSocket connection, so events
+ * from different frames can arrive out of order (e.g. an iframe socket that
+ * connects late flushes its buffer in a burst). Keeping the buffer sorted
+ * preserves the order in which the user actually interacted, which is what
+ * codegen turns into test steps. The sort is stable, so events sharing a
+ * timestamp keep their arrival order.
+ */
+export function mergeRecordedEvents(
+  existing: BrowserEvent[],
+  incoming: BrowserEvent[]
+): BrowserEvent[] {
+  return [...existing, ...incoming].sort((a, b) => a.timestamp - b.timestamp)
+}

--- a/src/recorder/launchers/cdp/index.ts
+++ b/src/recorder/launchers/cdp/index.ts
@@ -2,7 +2,7 @@ import { ChildProcess, spawn } from 'child_process'
 import logger from 'electron-log/main'
 
 import { BrowserServer } from '@/recorder/server'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent } from '@/schemas/recording'
 import { ChromeDevToolsClient, Transport } from '@/utils/cdp/client'
 import { PipeTransport } from '@/utils/cdp/transports/pipe'
@@ -20,6 +20,7 @@ import {
 import { getBrowserLaunchArgs } from '../utils'
 
 import { BrowserSession } from './browser'
+import { mergeRecordedEvents } from './events'
 import { Script } from './script'
 
 type InitState = 'init' | 'spawned' | 'ready'
@@ -31,6 +32,12 @@ const BROWSER_CDP_ARGS = [
   // Disable web security to allow our script to be executed in sandboxed iframes.
   '--disable-web-security',
   '--allow-running-insecure-content',
+  // Keep cross-origin iframes in the parent's process so the injected recording
+  // script runs inside them and can walk up to the top frame. Disabling the
+  // IsolateOrigins/site-per-process features (see FEATURES_TO_DISABLE) is not
+  // enough on its own in current Chrome; the site-isolation trials must also be
+  // turned off.
+  '--disable-site-isolation-trials',
 ]
 
 const BROWSER_CDP_WEBSOCKET_ARGS = [
@@ -100,8 +107,11 @@ class CDPRecordingSession
     })
   }
 
-  highlightElement(locator: ElementLocator | null): void {
-    this.#server.send({ type: 'highlight-elements', locator })
+  highlightElement(
+    locator: ElementLocator | null,
+    frames?: LocatorOptions[]
+  ): void {
+    this.#server.send({ type: 'highlight-elements', locator, frames })
   }
 
   navigateTo(url: string): void {
@@ -124,7 +134,10 @@ class CDPRecordingSession
   }
 
   #record(events: BrowserEvent[]) {
-    this.#events.push(...events)
+    // Frames record over separate WebSocket connections, so events can arrive
+    // out of order. Keep the buffer sorted by timestamp so the saved recording
+    // and generated test reflect the real interaction order.
+    this.#events = mergeRecordedEvents(this.#events, events)
 
     this.#server.send({ type: 'events-recorded', events })
 

--- a/src/recorder/launchers/cdp/index.ts
+++ b/src/recorder/launchers/cdp/index.ts
@@ -139,9 +139,9 @@ class CDPRecordingSession
     // and generated test reflect the real interaction order.
     this.#events = mergeRecordedEvents(this.#events, events)
 
-    this.#server.send({ type: 'events-recorded', events })
+    this.#server.send({ type: 'events-recorded', events: this.#events })
 
-    this.emit('record', { events })
+    this.emit('record', { events: this.#events })
   }
 }
 

--- a/src/recorder/launchers/types.ts
+++ b/src/recorder/launchers/types.ts
@@ -1,5 +1,5 @@
 import { LaunchBrowserErrorReason } from '@/recorder/types'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent } from '@/schemas/recording'
 import { EventEmitter } from '@/utils/events'
 
@@ -10,7 +10,10 @@ export interface RecordingSessionEventMap {
 }
 
 export interface RecordingSession extends EventEmitter<RecordingSessionEventMap> {
-  highlightElement(locator: ElementLocator | null): void
+  highlightElement(
+    locator: ElementLocator | null,
+    frames?: LocatorOptions[]
+  ): void
   navigateTo(url: string): void
   stop(): void
 }

--- a/src/recorder/launchers/utils.ts
+++ b/src/recorder/launchers/utils.ts
@@ -49,6 +49,12 @@ const FEATURES_TO_DISABLE = [
   'OptimizationHintsFetching',
   'OptimizationTargetPrediction',
   'OptimizationHints',
+  // Keep cross-origin iframes in the same process as their parent so that the
+  // recording script (injected via CDP) runs inside them and can walk up to the
+  // top frame. Combined with --disable-web-security this lets us record events
+  // and compute frame paths across origins.
+  'IsolateOrigins',
+  'site-per-process',
 ]
 
 interface GetBrowserLaunchArgsOptions {

--- a/src/schemas/recording/browser/v2/index.test.ts
+++ b/src/schemas/recording/browser/v2/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+
+import { BrowserEventSchema } from './index'
+
+describe('BrowserEventSchema frame path', () => {
+  test('retains the frame chain on a click event', () => {
+    const event = {
+      type: 'click',
+      eventId: '1',
+      timestamp: 0,
+      tab: 'tab1',
+      target: { selectors: { css: 'button' } },
+      button: 'left',
+      modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+      frames: [
+        { selectors: { css: 'iframe#outer' } },
+        { selectors: { css: 'iframe#inner' } },
+      ],
+    }
+
+    const result = BrowserEventSchema.parse(event)
+
+    expect(result).toMatchObject({
+      type: 'click',
+      frames: [
+        { selectors: { css: 'iframe#outer' } },
+        { selectors: { css: 'iframe#inner' } },
+      ],
+    })
+  })
+
+  test('omits frame for top-frame events', () => {
+    const event = {
+      type: 'click',
+      eventId: '1',
+      timestamp: 0,
+      tab: 'tab1',
+      target: { selectors: { css: 'button' } },
+      button: 'left',
+      modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+    }
+
+    const result = BrowserEventSchema.parse(event)
+
+    if (result.type !== 'click') {
+      throw new Error('expected a click event')
+    }
+
+    expect(result.frames).toBeUndefined()
+  })
+
+  test('does not carry a frame chain on page-level events', () => {
+    const event = {
+      type: 'navigate-to-page',
+      eventId: '1',
+      timestamp: 0,
+      tab: 'tab1',
+      url: 'http://example.test',
+      source: 'address-bar',
+      // A navigation has no element target, so it has no frame scope. The schema
+      // should not retain frames here even if some upstream code attaches them.
+      frames: [{ selectors: { css: 'iframe#outer' } }],
+    }
+
+    const result = BrowserEventSchema.parse(event)
+
+    expect(result).not.toHaveProperty('frames')
+  })
+})

--- a/src/schemas/recording/browser/v2/index.ts
+++ b/src/schemas/recording/browser/v2/index.ts
@@ -31,6 +31,14 @@ const BrowserEventBaseSchema = z.object({
   timestamp: z.number(),
 })
 
+// Events that target an element also record the chain of iframe elements from
+// the top frame down to the frame the element lives in, outermost first. Absent
+// or empty means the top frame. Page-level events (navigation, reload) have no
+// element target and so no frame scope; they extend the base directly.
+const TargetedEventBaseSchema = BrowserEventBaseSchema.extend({
+  frames: BrowserEventTargetSchema.array().optional(),
+})
+
 const NavigateToPageEventSchema = BrowserEventBaseSchema.extend({
   type: z.literal('navigate-to-page'),
   tab: z.string(),
@@ -48,7 +56,7 @@ const ReloadPageEventSchema = BrowserEventBaseSchema.extend({
   url: z.string(),
 })
 
-const ClickEventSchema = BrowserEventBaseSchema.extend({
+const ClickEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('click'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
@@ -61,7 +69,7 @@ const ClickEventSchema = BrowserEventBaseSchema.extend({
   }),
 })
 
-const InputChangeEventSchema = BrowserEventBaseSchema.extend({
+const InputChangeEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('input-change'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
@@ -69,14 +77,14 @@ const InputChangeEventSchema = BrowserEventBaseSchema.extend({
   sensitive: z.boolean(),
 })
 
-const CheckChangeEventSchema = BrowserEventBaseSchema.extend({
+const CheckChangeEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('check-change'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
   checked: z.boolean(),
 })
 
-const RadioChangeEventSchema = BrowserEventBaseSchema.extend({
+const RadioChangeEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('radio-change'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
@@ -84,7 +92,7 @@ const RadioChangeEventSchema = BrowserEventBaseSchema.extend({
   value: z.string(),
 })
 
-const SelectChangeEventSchema = BrowserEventBaseSchema.extend({
+const SelectChangeEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('select-change'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
@@ -92,7 +100,7 @@ const SelectChangeEventSchema = BrowserEventBaseSchema.extend({
   multiple: z.boolean(),
 })
 
-const SubmitFormEventSchema = BrowserEventBaseSchema.extend({
+const SubmitFormEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('submit-form'),
   tab: z.string(),
   form: BrowserEventTargetSchema,
@@ -136,14 +144,14 @@ const AssertionSchema = z.discriminatedUnion('type', [
   TextInputAssertionSchema,
 ])
 
-const AssertEventSchema = BrowserEventBaseSchema.extend({
+const AssertEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('assert'),
   tab: z.string(),
   target: BrowserEventTargetSchema,
   assertion: AssertionSchema,
 })
 
-const WaitForEventSchema = BrowserEventBaseSchema.extend({
+const WaitForEventSchema = TargetedEventBaseSchema.extend({
   type: z.literal('wait-for'),
   tab: z.string(),
   target: BrowserEventTargetSchema,

--- a/src/utils/dom/layout.test.ts
+++ b/src/utils/dom/layout.test.ts
@@ -1,6 +1,50 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { observeWindowsForLayoutShift } from './layout'
+import {
+  collectLayoutShiftWindows,
+  observeWindowsForLayoutShift,
+} from './layout'
+
+interface FakeWindow {
+  parent: FakeWindow
+}
+
+function fakeWindow(): FakeWindow {
+  const win = {} as FakeWindow
+  win.parent = win
+  return win
+}
+
+describe('collectLayoutShiftWindows', () => {
+  it('includes every frame on the path from content to root', () => {
+    const top = fakeWindow()
+    const middle = fakeWindow()
+    const leaf = fakeWindow()
+
+    middle.parent = top
+    leaf.parent = middle
+
+    const windows = collectLayoutShiftWindows(
+      top as unknown as Window,
+      leaf as unknown as Window
+    )
+
+    expect(windows).toEqual(
+      new Set([top, middle, leaf].map((win) => win as unknown as Window))
+    )
+  })
+
+  it('returns only the root when content is already in the root frame', () => {
+    const top = fakeWindow()
+
+    const windows = collectLayoutShiftWindows(
+      top as unknown as Window,
+      top as unknown as Window
+    )
+
+    expect(windows).toEqual(new Set([top as unknown as Window]))
+  })
+})
 
 describe('observeWindowsForLayoutShift', () => {
   afterEach(() => {

--- a/src/utils/dom/layout.ts
+++ b/src/utils/dom/layout.ts
@@ -39,6 +39,38 @@ export function getFrameOffset(
 }
 
 /**
+ * Every window from each content window up through its parent chain, plus
+ * `rootWindow`. Intermediate frames are included so scroll listeners cover the
+ * full path from a nested element to the overlay root, not just the endpoints.
+ */
+export function collectLayoutShiftWindows(
+  rootWindow: Window | null,
+  ...contentWindows: Array<Window | null | undefined>
+): Set<Window> {
+  const windows = new Set<Window>()
+
+  if (rootWindow !== null) {
+    windows.add(rootWindow)
+  }
+
+  for (const contentWindow of contentWindows) {
+    let win = contentWindow ?? null
+
+    while (win !== null && win !== rootWindow) {
+      windows.add(win)
+
+      if (win === win.parent) {
+        break
+      }
+
+      win = win.parent
+    }
+  }
+
+  return windows
+}
+
+/**
  * Recomputes layout-derived state (e.g. a highlight overlay) when any of the
  * given windows scrolls or its document resizes. Scroll neither fires a
  * ResizeObserver nor bubbles across iframe boundaries, so each window is

--- a/src/utils/locator.ts
+++ b/src/utils/locator.ts
@@ -9,7 +9,7 @@ import {
   TestIdLocator,
   TitleLocator,
 } from '@/schemas/locator'
-import { ElementSelector } from '@/schemas/recording'
+import { BrowserEventTarget, ElementSelector } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 
 function hasNonEmptyString(value: string | undefined): value is string {
@@ -187,4 +187,11 @@ export function toLocatorOptions(selector: ElementSelector): LocatorOptions {
       title: getTitleLocator(selector) ?? undefined,
     },
   }
+}
+
+// Converts a recorded event's iframe chain into locator options for each frame.
+export function toFrameOptions(
+  frames: BrowserEventTarget[] | undefined
+): LocatorOptions[] | undefined {
+  return frames?.map((frame) => toLocatorOptions(frame.selectors))
 }

--- a/src/utils/proxyDataToHar.test.ts
+++ b/src/utils/proxyDataToHar.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { BrowserEvent } from '@/schemas/recording'
+
+import { proxyDataToHar } from './proxyDataToHar'
+
+function clickAt(timestamp: number, id: string): BrowserEvent {
+  return {
+    type: 'click',
+    eventId: id,
+    timestamp,
+    tab: 'tab-1',
+    target: { selectors: { css: `#${id}` } },
+    button: 'left',
+    modifiers: { ctrl: false, shift: false, alt: false, meta: false },
+  }
+}
+
+function eventIds(recording: ReturnType<typeof proxyDataToHar>): string[] {
+  return (recording.log._browserEvents?.events ?? []).map(
+    (event) => event.eventId
+  )
+}
+
+describe('proxyDataToHar browser events', () => {
+  it('sorts recorded events by timestamp', () => {
+    // Events arrive over separate per-frame sockets, so they can be appended
+    // out of order.
+    const events = [clickAt(30, 'c'), clickAt(10, 'a'), clickAt(20, 'b')]
+
+    expect(eventIds(proxyDataToHar([], events))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('keeps insertion order for events with equal timestamps', () => {
+    const events = [clickAt(10, 'a'), clickAt(10, 'b'), clickAt(10, 'c')]
+
+    expect(eventIds(proxyDataToHar([], events))).toEqual(['a', 'b', 'c'])
+  })
+
+  it('does not mutate the input array', () => {
+    const events = [clickAt(30, 'c'), clickAt(10, 'a')]
+
+    proxyDataToHar([], events)
+
+    expect(events.map((event) => event.eventId)).toEqual(['c', 'a'])
+  })
+})

--- a/src/utils/proxyDataToHar.ts
+++ b/src/utils/proxyDataToHar.ts
@@ -30,7 +30,12 @@ function createLog(
     entries,
     _browserEvents: {
       version: '2',
-      events,
+      // Events arrive over separate per-frame sockets and are appended in
+      // arrival order, so sort by timestamp here, the point where the recording
+      // is persisted, so the saved file and the generated test reflect the real
+      // interaction order. Array.prototype.sort is stable, preserving the order
+      // of events sharing a timestamp.
+      events: [...events].sort((a, b) => a.timestamp - b.timestamp),
     },
   }
 }

--- a/src/views/Recorder/BrowserEventLog.tsx
+++ b/src/views/Recorder/BrowserEventLog.tsx
@@ -1,7 +1,7 @@
 import { Flex, ScrollArea } from '@radix-ui/themes'
 
 import { BrowserEventList } from '@/components/BrowserEventList'
-import { ElementLocator } from '@/schemas/locator'
+import { ElementLocator, LocatorOptions } from '@/schemas/locator'
 import { BrowserEvent } from '@/schemas/recording'
 
 interface BrowserEventLogProps {
@@ -13,8 +13,11 @@ export function BrowserEventLog({ events }: BrowserEventLogProps) {
     window.studio.browserRemote.navigateTo(url)
   }
 
-  const handleHighlight = (locator: ElementLocator | null) => {
-    window.studio.browserRemote.highlightElement(locator)
+  const handleHighlight = (
+    locator: ElementLocator | null,
+    frames?: LocatorOptions[]
+  ) => {
+    window.studio.browserRemote.highlightElement(locator, frames)
   }
 
   return (


### PR DESCRIPTION
## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

Records DOM interactions that happen inside iframes, including nested and cross-origin ones. The recorder previously captured only the top frame and dropped everything inside iframes, which is a real gap since apps put auth, payment, and embedded widgets in cross-origin iframes.

Each recorded event is now tagged with the chain of iframe locators it happened in, and the event list shows that chain inside the element's selector badge so an interaction inside an iframe is recognizable. To reach cross-origin iframes, the recorder browser forces them into the parent process so the injected script runs in them (it already runs with web security disabled; this browser is authoring-only).

Second PR in the iframe-support stack, building on #1274. Generating `frameLocator` code from these recordings and replaying them come in later PRs.

<img width="1280" height="760" alt="screencapture 2026-06-04 at 12 42 46@2x" src="https://github.com/user-attachments/assets/bbb8b7ee-de96-4b8b-9b68-c4a204e3f093" />

## How to Test

<!--- Please describe in detail how you tested your changes -->

1. Record a page with form in an iframe, you can use this codepen example: https://codepen.io/BaylorRae/full/oNxeBQJ
2. Interact inside the iframe: type inputs, use element picker to add conditions, add assertions by selecting text
3. Stop recording and verify iframe events are recorded

Each interaction captured inside the iframe shows the frame chain in its selector badge (an "in iframe" marker plus the iframe locator), top-frame events look the same as before.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Builds on https://github.com/grafana/k6-studio/pull/1274


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core recording, CDP browser launch flags, and event ordering across frames; mis-framed paths or sort regressions would corrupt saved recordings, though behavior is heavily tested.
> 
> **Overview**
> **Iframe-aware recording** extends the recorder so interactions inside nested (including cross-origin) iframes are captured, not only the top frame. Each element-targeted event can carry an optional **`frames`** chain (outermost iframe first); the v2 schema adds this on targeted events only. Chrome is launched with **`--disable-site-isolation-trials`** plus existing **`IsolateOrigins` / `site-per-process`** disables so the injected script runs in child frames and can walk **`frameElement`** for paths. **`startRecording`** now runs in every frame; child frames forward inspection/text-selection via **`__K6_STUDIO_*`** bridges while the top frame keeps the UI.
> 
> **Ordering and live lists** stop appending event batches: CDP **`mergeRecordedEvents`**, HAR export, and **`useListenBrowserEvent` / `useRecordedEvents`** replace state with the full timestamp-sorted buffer so late iframe sockets do not scramble the timeline.
> 
> **Highlighting and bounds** thread optional frame locators through IPC/messaging into **`findElementsByFrameChain`**, use cross-realm **`isElement`**, and recompute overlay bounds with iframe offsets and **`collectLayoutShiftWindows`**. Locator badges show **"in &lt;frame&gt;"** (collapsed to **"in N frames"** when deep) and pass frame options on hover.
> 
> **Inspector tools** pick elements and text inside iframes (child-frame detection, top-frame coordinates via **`frameGeometry`**), attach **`frames`** on manual assert/wait-for/text assertions, and skip recording while the top-frame inspector/selection bridge is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdeac39a971e1cde1fe4be97e71cc9aa33d87c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->