### PR TITLE
refactor: Replace allotment with react-resizable-panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "@typescript-eslint/typescript-estree": "8.59.2",
     "@vitejs/plugin-react": "4.7.0",
     "ai": "5.0.185",
-    "allotment": "1.20.5",
     "aria-query": "5.3.2",
     "astring": "1.9.0",
     "chokidar": "4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
       ai:
         specifier: 5.0.185
         version: 5.0.185(zod@4.4.3)
-      allotment:
-        specifier: 1.20.5
-        version: 1.20.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       aria-query:
         specifier: 5.3.2
         version: 5.3.2
@@ -3203,12 +3200,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  allotment@1.20.5:
-    resolution: {integrity: sha512-7i4NT7ieXEyAd5lBrXmE7WHz/e7hRuo97+j+TwrPE85ha6kyFURoc76nom0dWSZ1pTKVEAMJy/+f3/Isfu/41A==}
-    peerDependencies:
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -4708,12 +4699,6 @@ packages:
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
-
-  lodash.clamp@4.0.3:
-    resolution: {integrity: sha512-HvzRFWjtcguTW7yd8NJBshuNaCa8aqNFtnswdT7f/cMd/1YKy5Zzoq4W/Oxvnx9l7aeY258uSdDfM793+eLsVg==}
-
-  lodash.debounce@4.0.8:
-    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
@@ -6330,12 +6315,6 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  usehooks-ts@3.1.1:
-    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
-    engines: {node: '>=16.15.0'}
-    peerDependencies:
-      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   username@5.1.0:
     resolution: {integrity: sha512-PCKbdWw85JsYMvmCv5GH3kXmM66rCd9m1hBEDutPNv94b/pqCMT4NtcKyeWYvLFiE8b+ha1Jdl8XAaUdPn5QTg==}
@@ -9795,17 +9774,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  allotment@1.20.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      classnames: 2.5.1
-      eventemitter3: 5.0.4
-      fast-deep-equal: 3.1.3
-      lodash.clamp: 4.0.3
-      lodash.debounce: 4.0.8
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      usehooks-ts: 3.1.1(react@19.2.5)
-
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -11430,10 +11398,6 @@ snapshots:
       p-locate: 5.0.0
 
   lodash-es@4.18.1: {}
-
-  lodash.clamp@4.0.3: {}
-
-  lodash.debounce@4.0.8: {}
 
   lodash.get@4.4.2: {}
 
@@ -13298,11 +13262,6 @@ snapshots:
 
   use-sync-external-store@1.6.0(react@19.2.5):
     dependencies:
-      react: 19.2.5
-
-  usehooks-ts@3.1.1(react@19.2.5):
-    dependencies:
-      lodash.debounce: 4.0.8
       react: 19.2.5
 
   username@5.1.0:

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -67,13 +67,7 @@ export function Layout() {
 
   return (
     <Flex height="100dvh">
-      <Group
-        {...layout}
-        id="sidebar-layout"
-        css={css`
-          --focus-border: var(--accent-9);
-        `}
-      >
+      <Group {...layout} id="sidebar-layout">
         <Box
           flexShrink="0"
           css={{

--- a/src/components/primitives/ResizablePanel.tsx
+++ b/src/components/primitives/ResizablePanel.tsx
@@ -23,7 +23,7 @@ export const Separator = styled(SeparatorPrimitive)`
   &[data-separator='hover']:not([data-disabled])::before,
   &[data-separator='active']:not([data-disabled])::before {
     --separator-size: 2px;
-    background-color: var(--focus-border);
+    background-color: var(--accent-9);
   }
 
   &[aria-orientation='vertical']::before {

--- a/src/globalStyles.ts
+++ b/src/globalStyles.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react'
 import '@radix-ui/themes/styles.css'
-import 'allotment/dist/style.css'
 
 import InterVariable from '@/assets/fonts/Inter/InterVariable.woff2'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import { createRoot } from 'react-dom/client'
 import { App } from './App'
 
 // Must register before electron-log to suppress benign ResizeObserver
-// warnings triggered by Radix UI and Allotment during layout shifts.
+// warnings triggered by Radix UI during layout shifts.
 window.addEventListener('error', (event) => {
   if (event.message?.includes('ResizeObserver loop')) {
     event.stopImmediatePropagation()

--- a/src/views/BrowserTestEditor/BrowserTestEditor.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.tsx
@@ -163,7 +163,7 @@ function BrowserTestEditorView({
                     />
                   </Panel>
                   <Separator />
-                  <Panel id="actions" minSize={400}>
+                  <Panel id="actions" defaultSize="30%" minSize={400}>
                     <EditableBrowserActionList
                       actions={test.actions}
                       onAddAction={test.addAction}
@@ -192,7 +192,13 @@ function BrowserTestEditorView({
                 </Tabs.Trigger>
               </Tabs.List>
               <Separator data-disabled />
-              <Panel id="drawer" panelRef={setDrawer} collapsible minSize={100}>
+              <Panel
+                id="drawer"
+                panelRef={setDrawer}
+                collapsible
+                defaultSize="30%"
+                minSize={100}
+              >
                 <Flex height="100%" direction="column" overflow="hidden">
                   <Tabs.Content
                     css={css`

--- a/src/views/Generator/Generator.tsx
+++ b/src/views/Generator/Generator.tsx
@@ -211,7 +211,7 @@ export function Generator() {
         {selectedRequest && (
           <>
             <Separator />
-            <Panel id="request-details" minSize={300}>
+            <Panel id="request-details" defaultSize="40%" minSize={300}>
               <HttpRequestDetails
                 layout={detailsLayout}
                 selectedRequest={selectedRequest}

--- a/src/views/Generator/ValidatorResult.tsx
+++ b/src/views/Generator/ValidatorResult.tsx
@@ -67,7 +67,7 @@ export function ValidatorResult({
       {selectedRequest && (
         <>
           <Separator />
-          <Panel id="details" minSize={300}>
+          <Panel id="details" defaultSize="40%" minSize={300}>
             <HttpRequestDetails
               selectedRequest={selectedRequest}
               onSelectRequest={setSelectedRequest}

--- a/src/views/Recorder/RequestLog.tsx
+++ b/src/views/Recorder/RequestLog.tsx
@@ -1,12 +1,12 @@
 import { Flex, Box } from '@radix-ui/themes'
-import { Allotment } from 'allotment'
 import { CirclePlusIcon } from 'lucide-react'
 import { useMemo, useState } from 'react'
 
 import { ButtonWithTooltip } from '@/components/ButtonWithTooltip'
 import { EmptyMessage } from '@/components/EmptyMessage'
+import { Group, Panel, Separator } from '@/components/primitives/ResizablePanel'
 import { HttpRequestDetails } from '@/components/WebLogView/HttpRequestDetails'
-import { ProxyData, Group } from '@/types'
+import { ProxyData, Group as GroupType } from '@/types'
 
 import { RequestsSection } from './RequestsSection'
 import { RecorderState } from './types'
@@ -14,8 +14,8 @@ import { RecorderState } from './types'
 interface RequestLogProps {
   recorderState?: RecorderState | undefined
   requests: ProxyData[]
-  groups: Group[]
-  onUpdateGroup?: (group: Group) => void
+  groups: GroupType[]
+  onUpdateGroup?: (group: GroupType) => void
   onCreateGroup?: (name: string) => void
   onResetRecording?: () => void
 }
@@ -41,8 +41,8 @@ export function RequestLog({
   }, [recorderState])
 
   return (
-    <Allotment defaultSizes={[1, 1]}>
-      <Allotment.Pane minSize={200}>
+    <Group>
+      <Panel id="requests" minSize={200}>
         <Flex direction="column" height="100%">
           <div css={{ flexGrow: 0, minHeight: 0 }}>
             <RequestsSection
@@ -71,15 +71,18 @@ export function RequestLog({
             </Box>
           )}
         </Flex>
-      </Allotment.Pane>
+      </Panel>
       {selectedRequest && (
-        <Allotment.Pane minSize={300}>
-          <HttpRequestDetails
-            selectedRequest={selectedRequest}
-            onSelectRequest={setSelectedRequest}
-          />
-        </Allotment.Pane>
+        <>
+          <Separator />
+          <Panel id="details" minSize={300}>
+            <HttpRequestDetails
+              selectedRequest={selectedRequest}
+              onSelectRequest={setSelectedRequest}
+            />
+          </Panel>
+        </>
       )}
-    </Allotment>
+    </Group>
   )
 }

--- a/src/views/Recorder/RequestLog.tsx
+++ b/src/views/Recorder/RequestLog.tsx
@@ -75,7 +75,7 @@ export function RequestLog({
       {selectedRequest && (
         <>
           <Separator />
-          <Panel id="details" minSize={300}>
+          <Panel id="details" defaultSize="40%" minSize={300}>
             <HttpRequestDetails
               selectedRequest={selectedRequest}
               onSelectRequest={setSelectedRequest}

--- a/src/views/Validator/Browser/BrowserDebugger.tsx
+++ b/src/views/Validator/Browser/BrowserDebugger.tsx
@@ -92,7 +92,7 @@ export function BrowserDebuggerContent({
                 />
               </Panel>
               <Separator />
-              <Panel id="actions" minSize={400}>
+              <Panel id="actions" defaultSize="30%" minSize={400}>
                 <BrowserActionsPanel
                   session={session}
                   onDebugScript={onDebugScript}
@@ -110,7 +110,13 @@ export function BrowserDebuggerContent({
             </Tabs.Trigger>
           </Tabs.List>
           <Separator data-disabled />
-          <Panel id="drawer" panelRef={setDrawer} collapsible minSize={100}>
+          <Panel
+            id="drawer"
+            panelRef={setDrawer}
+            collapsible
+            defaultSize="30%"
+            minSize={100}
+          >
             <Flex height="100%" direction="column" overflow="hidden">
               <Tabs.Content
                 css={css`

--- a/src/views/Validator/Browser/NetworkInspector.tsx
+++ b/src/views/Validator/Browser/NetworkInspector.tsx
@@ -35,7 +35,7 @@ export function NetworkInspector({ actions, session }: NetworkInspectorProps) {
       {selectedRequest !== null && (
         <>
           <Separator />
-          <Panel id="details">
+          <Panel id="details" defaultSize="40%" minSize={300}>
             <HttpRequestDetails
               selectedRequest={selectedRequest}
               onSelectRequest={setSelectedRequest}

--- a/src/views/Validator/Browser/NetworkInspector.tsx
+++ b/src/views/Validator/Browser/NetworkInspector.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@radix-ui/themes'
-import { Allotment } from 'allotment'
 import { ReactNode, useState } from 'react'
 
+import { Group, Panel, Separator } from '@/components/primitives/ResizablePanel'
 import { HttpRequestDetails } from '@/components/WebLogView/HttpRequestDetails'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
 import { ProxyData } from '@/types'
@@ -19,8 +19,8 @@ export function NetworkInspector({ actions, session }: NetworkInspectorProps) {
   const groups = useProxyDataGroups(session.requests)
 
   return (
-    <Allotment>
-      <Allotment.Pane minSize={250}>
+    <Group>
+      <Panel id="requests" minSize={250}>
         <Box height="100%">
           <RequestsSection
             proxyData={session.requests}
@@ -31,15 +31,18 @@ export function NetworkInspector({ actions, session }: NetworkInspectorProps) {
             onSelectRequest={setSelectedRequest}
           />
         </Box>
-      </Allotment.Pane>
+      </Panel>
       {selectedRequest !== null && (
-        <Allotment.Pane>
-          <HttpRequestDetails
-            selectedRequest={selectedRequest}
-            onSelectRequest={setSelectedRequest}
-          />
-        </Allotment.Pane>
+        <>
+          <Separator />
+          <Panel id="details">
+            <HttpRequestDetails
+              selectedRequest={selectedRequest}
+              onSelectRequest={setSelectedRequest}
+            />
+          </Panel>
+        </>
       )}
-    </Allotment>
+    </Group>
   )
 }

--- a/src/views/Validator/HTTP/HttpDebugger.tsx
+++ b/src/views/Validator/HTTP/HttpDebugger.tsx
@@ -1,10 +1,15 @@
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Box, Flex, Tabs } from '@radix-ui/themes'
-import { Allotment } from 'allotment'
 import { useEffect, useState } from 'react'
 
 import { ReadOnlyEditor } from '@/components/Monaco/ReadOnlyEditor'
+import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+} from '@/components/primitives/ResizablePanel'
 import { ExecutionDetails } from '@/components/Validator/ExecutionDetails'
 import { HttpRequestDetails } from '@/components/WebLogView/HttpRequestDetails'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
@@ -37,6 +42,9 @@ export function HttpDebugger({
 
   const isRunning = session.state === 'running'
 
+  const mainLayout = useDefaultLayout({ id: 'http-debugger-main' })
+  const innerLayout = useDefaultLayout({ id: 'http-debugger-inner' })
+
   // Clear selected request when starting a new run
   useEffect(() => {
     if (isRunning) {
@@ -46,10 +54,10 @@ export function HttpDebugger({
   }, [isRunning])
 
   return (
-    <Allotment defaultSizes={[3, 2]}>
-      <Allotment.Pane minSize={250}>
-        <Allotment vertical defaultSizes={[2, 1]}>
-          <Allotment.Pane>
+    <Group {...mainLayout}>
+      <Panel id="main" minSize={250}>
+        <Group orientation="vertical" {...innerLayout}>
+          <Panel id="tabs">
             <Tabs.Root asChild value={tab} onValueChange={setTab}>
               <Flex direction="column" height="100%" overflow="hidden">
                 <Tabs.List
@@ -85,8 +93,9 @@ export function HttpDebugger({
                 </TabsContent>
               </Flex>
             </Tabs.Root>
-          </Allotment.Pane>
-          <Allotment.Pane minSize={250}>
+          </Panel>
+          <Separator />
+          <Panel id="execution" minSize={250}>
             <Box height="100%">
               <ExecutionDetails
                 isRunning={isRunning}
@@ -94,17 +103,20 @@ export function HttpDebugger({
                 checks={session.checks}
               />
             </Box>
-          </Allotment.Pane>
-        </Allotment>
-      </Allotment.Pane>
+          </Panel>
+        </Group>
+      </Panel>
       {selectedRequest && (
-        <Allotment.Pane minSize={300}>
-          <HttpRequestDetails
-            selectedRequest={selectedRequest}
-            onSelectRequest={setSelectedRequest}
-          />
-        </Allotment.Pane>
+        <>
+          <Separator />
+          <Panel id="details" minSize={300}>
+            <HttpRequestDetails
+              selectedRequest={selectedRequest}
+              onSelectRequest={setSelectedRequest}
+            />
+          </Panel>
+        </>
       )}
-    </Allotment>
+    </Group>
   )
 }

--- a/src/views/Validator/HTTP/HttpDebugger.tsx
+++ b/src/views/Validator/HTTP/HttpDebugger.tsx
@@ -95,7 +95,7 @@ export function HttpDebugger({
             </Tabs.Root>
           </Panel>
           <Separator />
-          <Panel id="execution" minSize={250}>
+          <Panel id="execution" defaultSize="30%" minSize={250}>
             <Box height="100%">
               <ExecutionDetails
                 isRunning={isRunning}
@@ -109,7 +109,7 @@ export function HttpDebugger({
       {selectedRequest && (
         <>
           <Separator />
-          <Panel id="details" minSize={300}>
+          <Panel id="details" defaultSize="40%" minSize={300}>
             <HttpRequestDetails
               selectedRequest={selectedRequest}
               onSelectRequest={setSelectedRequest}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This pull request removes the `allotment` dependency and refactors all components that previously used it to instead use custom resizable panel primitives. It also cleans up related unused dependencies and updates styling to remove references to `allotment`. The main goal is to simplify the codebase and reduce external dependencies while maintaining or improving layout functionality.

## How to Test

First clear all the stored layouts:

1. Open DevTools
2. Switch to Application-tab
3. Select Local Storage
4. Remove all `react-resizable-panels:*` keys

Then:

* Resize panels in the recording previewer
* Resize panels in the HTTP debugger
* Resize panels in the browser debugger

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core shell and debugger/recorder layout behavior; regressions would show up as broken resizing, wrong default splits, or missing detail panes, but no auth or data-path changes.
> 
> **Overview**
> Removes the **`allotment`** dependency and its global stylesheet, and wires recorder, HTTP debugger, and browser network inspector layouts through the existing **`ResizablePanel`** wrapper (`Group`, `Panel`, `Separator`) from **`react-resizable-panels`**.
> 
> Split views now use explicit **`Separator`** nodes between panes (including conditional request-detail columns), and **`HttpDebugger`** persists nested horizontal/vertical sizes via **`useDefaultLayout`**. Styling drops allotment’s **`--focus-border`** hook in favor of **`--accent-9`** on separator hover/active; **`Layout`** no longer sets sidebar **`--focus-border`**. **`RequestLog`** aliases the domain **`Group`** type to **`GroupType`** to avoid clashing with the panel **`Group`** component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 943ac6ca17feb8e33a1f8953eb342e7af5a62413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->