### PR TITLE
refactor: Move proxy data parsing to main process

### DIFF
--- a/src/handlers/fs/serialization.ts
+++ b/src/handlers/fs/serialization.ts
@@ -10,6 +10,7 @@ import { RecordingSchema } from '@/schemas/recording'
 import { StudioFileType } from '@/types'
 import { DataFilePreview } from '@/types/testData'
 import { parseDataFile } from '@/utils/dataFile'
+import { harToProxyData } from '@/utils/harToProxyData'
 import { K6Client } from '@/utils/k6/client'
 import * as path from '@/utils/path'
 import {
@@ -63,12 +64,16 @@ export async function deserializeContent(
         isExternal: isExternalBrowserTest(filePath),
       }
 
-    case 'recording':
+    case 'recording': {
+      const recording = RecordingSchema.parse(JSON.parse(raw))
+
       return {
         type: 'recording',
-        data: RecordingSchema.parse(JSON.parse(raw)),
+        data: harToProxyData(recording),
+        browserEvents: recording.log._browserEvents?.events ?? [],
         isExternal: isExternalRecording(filePath),
       }
+    }
 
     case 'script': {
       const options = await new K6Client()

--- a/src/handlers/fs/types.ts
+++ b/src/handlers/fs/types.ts
@@ -1,5 +1,6 @@
 import { BrowserTestFile } from '@/schemas/browserTest'
-import { Recording } from '@/schemas/recording'
+import { BrowserEvent } from '@/schemas/recording'
+import { ProxyData } from '@/types'
 import { GeneratorFileData } from '@/types/generator'
 import { DataFilePreview } from '@/types/testData'
 import { K6TestOptions } from '@/utils/k6/schema'
@@ -37,7 +38,8 @@ export interface BrowserTestContent {
 
 export interface RecordingContent {
   type: 'recording'
-  data: Recording
+  data: ProxyData[]
+  browserEvents: BrowserEvent[]
 
   // Temporary until we support referencing external recordings in HTTP tests.
   isExternal: boolean

--- a/src/utils/harToProxyData.ts
+++ b/src/utils/harToProxyData.ts
@@ -11,7 +11,7 @@ export function harToProxyData(har: Recording): ProxyData[] {
     const response = harEntryToResponse(entry)
 
     return {
-      id: self.crypto.randomUUID(),
+      id: crypto.randomUUID(),
       request,
       response,
       group: entry.pageref || DEFAULT_GROUP_NAME,

--- a/src/views/Generator/Generator.utils.ts
+++ b/src/views/Generator/Generator.utils.ts
@@ -6,7 +6,6 @@ import {
 } from '@/store/generator'
 import { ProxyData } from '@/types'
 import { GeneratorFileData } from '@/types/generator'
-import { harToProxyData } from '@/utils/harToProxyData'
 import { prettify } from '@/utils/prettify'
 
 export async function generateScriptPreview(
@@ -53,5 +52,5 @@ export const loadHarFile = async (fileName: string) => {
     throw new Error(`Expected recording content, got ${content.type}`)
   }
 
-  return harToProxyData(content.data)
+  return content.data
 }

--- a/src/views/Generator/RecordingSelector.tsx
+++ b/src/views/Generator/RecordingSelector.tsx
@@ -6,7 +6,6 @@ import { AlertTriangleIcon, PlusIcon } from 'lucide-react'
 import { useGeneratorStore } from '@/store/generator'
 import { useStudioUIStore } from '@/store/ui'
 import { useToast } from '@/store/ui/useToast'
-import { harToProxyData } from '@/utils/harToProxyData'
 import * as path from '@/utils/path'
 
 export function RecordingSelector({
@@ -34,8 +33,7 @@ export function RecordingSelector({
         throw new Error(`Expected recording content, got ${content.type}`)
       }
 
-      const proxyData = harToProxyData(content.data)
-      setRecording(proxyData, filePath)
+      setRecording(content.data, filePath)
       onChangeRecording?.()
     } catch (error) {
       showToast({

--- a/src/views/RecordingPreviewer/RecordingPreviewer.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewer.tsx
@@ -7,7 +7,6 @@ import { useCurrentFile } from '@/hooks/useCurrentFile'
 import { useProxyDataGroups } from '@/hooks/useProxyDataGroups'
 import { BrowserEvent } from '@/schemas/recording'
 import { ProxyData } from '@/types'
-import { harToProxyData } from '@/utils/harToProxyData'
 
 import { RecordingInspector } from '../Recorder/RecordingInspector'
 
@@ -34,8 +33,8 @@ export function RecordingPreviewer() {
       }
 
       setIsExternal(content.isExternal)
-      setProxyData(harToProxyData(content.data))
-      setBrowserEvents(content.data.log._browserEvents?.events ?? [])
+      setProxyData(content.data)
+      setBrowserEvents(content.browserEvents)
     })()
 
     return () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR moves the conversion from HAR to ProxyData to the main process. I was hoping that it'd improve the performance of loading large recordings (and to some degree it has) but it didn't have as much impact as I hoped.

The changes make sense though. There's no point in doing this processing in the renderer and if we can unblock the renderer even a few ms that's a win.

The big culprit is the full-text search indexing where we parse the body of all requests and then throw them into Fuse.js. My proposed solution to this would be to:

1. Do the parsing of bodies once when loading the file.
2. Use [`FuseWorker`](https://www.fusejs.io/web-workers.html) for indexing and search

So this PR could be seen as one step closer to doing that.

## How to Test

Open recordings in both the previewer and a generator. Both should work fine.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the IPC contract for recording files and shifts parsing to the main process; regressions would affect every recording load in generator and previewer, though scope is localized to deserialization and consumers.
> 
> **Overview**
> **Recording open path** now parses HAR into **`ProxyData[]`** in the main process (`deserializeContent`) instead of in the renderer. **`RecordingContent`** returns **`data: ProxyData[]`** plus a top-level **`browserEvents`** array, rather than the raw **`Recording`** schema.
> 
> The **Generator** (`loadHarFile`, **`RecordingSelector`**) and **Recording previewer** no longer call **`harToProxyData`**; they use **`content.data`** and **`content.browserEvents`** from **`openFile`**. **`harToProxyData`** switches from **`self.crypto`** to **`crypto`** for UUID generation where it still runs on the main side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023ae74d0933320710d93d1af90f96185fa4af55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->