### PR TITLE
fix: Use local time zone for default file name date prefix

### DIFF
--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { formatLocalDate } from './date'
+
+const originalTimeZone = process.env.TZ
+
+afterEach(() => {
+  if (originalTimeZone === undefined) {
+    delete process.env.TZ
+  } else {
+    process.env.TZ = originalTimeZone
+  }
+})
+
+describe('formatLocalDate', () => {
+  it('formats a date as YYYY-MM-DD', () => {
+    process.env.TZ = 'UTC'
+
+    expect(formatLocalDate(new Date('2026-06-05T12:00:00Z'))).toBe('2026-06-05')
+  })
+
+  it('uses local time, not UTC, when the instant falls on a different UTC day', () => {
+    // 01:30 UTC on June 5 is still June 4 in America/New_York (UTC-4 in June).
+    process.env.TZ = 'America/New_York'
+
+    expect(formatLocalDate(new Date('2026-06-05T01:30:00Z'))).toBe('2026-06-04')
+  })
+
+  it('zero-pads single-digit months and days', () => {
+    process.env.TZ = 'UTC'
+
+    expect(formatLocalDate(new Date('2026-01-09T10:00:00Z'))).toBe('2026-01-09')
+  })
+})

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,14 @@
+/**
+ * Formats a date as `YYYY-MM-DD` using the local time zone.
+ *
+ * Unlike `Date.prototype.toISOString`, which always uses UTC, this reflects the
+ * user's calendar day. Using UTC caused recording file names to be prefixed
+ * with the wrong date for users whose local day differs from the UTC day.
+ */
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+
+  return `${year}-${month}-${day}`
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -8,6 +8,7 @@ import { PathLike } from 'fs'
 import { access, writeFile } from 'fs/promises'
 import * as fs from 'fs/promises'
 
+import { formatLocalDate } from './date'
 import { EventEmitter } from './events'
 import * as path from './path'
 import { normalize } from './path'
@@ -70,7 +71,7 @@ export async function createFileWithUniqueName({
   prefix: string
   ext: string
 }): Promise<string> {
-  const timestamp = new Date().toISOString().split('T')[0] ?? ''
+  const timestamp = formatLocalDate(new Date())
   const template = `${prefix ? `${prefix} - ` : ''}${timestamp}${ext}`
 
   // Start from 2 as it follows the the OS behavior for duplicate files


### PR DESCRIPTION
## Description

The default date prefix on recording, browser test, and generator file names is generated with `new Date().toISOString()`, which always formats in UTC. For users whose local date differs from the UTC date (for example, west of UTC in the evening), the file name shows the wrong day. This switches the prefix to a local-time formatter so the name matches the user's calendar day.

## How to Test

Bug reproduced with unit tests.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small utility change with unit tests; only affects default filename date prefixes, not file content or security paths.
> 
> **Overview**
> Fixes wrong calendar day in auto-generated file names when the user’s local date differs from UTC (e.g. late evening west of UTC).
> 
> Adds **`formatLocalDate`** in `src/utils/date.ts` to produce `YYYY-MM-DD` from the system local time instead of **`toISOString()`** (UTC). **`createFileWithUniqueName`** in `fs.ts` now uses that helper for the date segment, so recording, browser test, and generator default names align with the user’s day.
> 
> Includes Vitest coverage for UTC formatting, zero-padding, and a timezone case where UTC and local dates diverge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d486172522a7ff4b816d630606c53d701d5ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->