### PR TITLE
internal: Show branch name in window title during development

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
       type="font/woff2"
       crossorigin
     />
-    <title>Grafana k6 Studio</title>
   </head>
   <body>
     <div id="root">

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,9 @@ const createWindow = async () => {
     minHeight: 600,
     show: false,
     icon,
-    title: 'Grafana k6 Studio',
+    title: DEV_GIT_BRANCH
+      ? `Grafana k6 Studio [${DEV_GIT_BRANCH}]`
+      : 'Grafana k6 Studio',
     backgroundColor: nativeTheme.themeSource === 'light' ? '#fff' : '#111110',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,3 +7,5 @@ declare const GRAFANA_COM_URL: string
 declare const K6_TESTING_OVERRIDE: string
 
 declare const TARGET_PLATFORM: NodeJS.Platform
+
+declare const DEV_GIT_BRANCH: string | undefined

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
+import { execSync } from 'node:child_process'
 import {
   defineConfig,
   mergeConfig,
@@ -15,10 +16,26 @@ import {
   pluginHotRestart,
 } from './vite.base.config'
 
+function getGitBranch(): string | null {
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: import.meta.dirname,
+    })
+
+    return branch.toString().trim()
+  } catch (error) {
+    console.log("Couldn't get git branch:", error)
+
+    return null
+  }
+}
+
 // https://vitejs.dev/config
 export default defineConfig((env) => {
   const forgeEnv = env as ConfigEnv<'build'>
   const { forgeConfigSelf } = forgeEnv
+
+  const gitBranch = forgeEnv.command === 'serve' ? getGitBranch() : null
 
   const define = {
     ...getBuildDefine(forgeEnv),
@@ -29,6 +46,7 @@ export default defineConfig((env) => {
       GRAFANA_COM_URL: 'https://grafana.com',
       K6_TESTING_OVERRIDE: '',
     }),
+    DEV_GIT_BRANCH: JSON.stringify(gitBranch),
   }
 
   const config: UserConfig = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When working with a lot of agents in different branches it is sometimes difficult to remember which version of k6 Studio you have open. This PR adds the branch name from which the app was started to the window title, giving you a quick way of knowing which version you are looking at.

The branch name is only shown during development. All code related to setting the title will be removed as dead code during builds.

## How to Test

Start the app. It should display the branch name in the window title.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only window title and build-time git lookup; production builds explicitly skip branch resolution.
> 
> **Overview**
> During **local dev serve**, the Electron main window title becomes **`Grafana k6 Studio [<branch>]`** when the current git branch can be resolved, so multiple local builds are easier to tell apart.
> 
> **`vite.main.config.ts`** runs `git rev-parse --abbrev-ref HEAD` only when Vite’s command is **`serve`**, injects the result as compile-time **`DEV_GIT_BRANCH`**, and leaves it **`null` on production builds** so release titles stay unchanged. **`src/main.ts`** uses that constant for **`BrowserWindow`’s `title`**; **`src/vite-env.d.ts`** adds the type declaration.
> 
> The static **`<title>`** was removed from **`index.html`** (the window title is driven from the main process instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5ce78242737bf8d65f3d74480593add7c6a35ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->