### PR TITLE
ci: Fix windows release workflow failing due to broken pnpm action

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -36,17 +36,15 @@ jobs:
         run: python update_version.py
 
       - name: setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
         with:
-          dest: ~/pnpm
+          version: 11.5.2
 
       - name: setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24.11
-
-      - name: setup pnpm
-        run: npm install -g pnpm@11.5.2
+          cache: "pnpm"
 
       # appdmg (used for DMG builds) depends on native modules compiled via node-gyp,
       # which requires Python setuptools. macOS runners ship with Python 3.12+ where

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          dest: ${HOME}/setup-pnpm
 
       - name: setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -35,13 +35,10 @@ jobs:
           PACKAGE_VERSION: ${{ inputs.version-suffix }}
         run: python update_version.py
 
-      - name: "Echo home directory for debugging"
-        run: echo ${HOME}
-
       - name: setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
-          dest: ${HOME}/setup-pnpm
+          dest: ~/pnpm
 
       - name: setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24.11
-          cache: "pnpm"
 
       - name: setup pnpm
         run: npm install -g pnpm@11.5.2

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -36,7 +36,7 @@ jobs:
         run: python update_version.py
 
       - name: setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           version: 11.5.2
 

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -36,7 +36,7 @@ jobs:
         run: python update_version.py
 
       - name: setup pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11.5.2
 

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -35,8 +35,11 @@ jobs:
           PACKAGE_VERSION: ${{ inputs.version-suffix }}
         run: python update_version.py
 
-      # - name: setup pnpm
-      #   uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: "Echo home directory for debugging"
+        run: echo ${HOME}
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -44,6 +44,9 @@ jobs:
           node-version: 24.11
           cache: "pnpm"
 
+      - name: setup pnpm
+        run: npm install -g pnpm@11.5.2
+
       # appdmg (used for DMG builds) depends on native modules compiled via node-gyp,
       # which requires Python setuptools. macOS runners ship with Python 3.12+ where
       # setuptools was removed. See https://github.com/electron/forge/issues/3371

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -35,8 +35,8 @@ jobs:
           PACKAGE_VERSION: ${{ inputs.version-suffix }}
         run: python update_version.py
 
-      - name: setup pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      # - name: setup pnpm
+      #   uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.0.0-rc.5 <12.0.0",
+      "version": ">=11.0.0 <12.0.0",
       "onFail": "error"
     }
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "version": ">=11.0.0 <12.0.0",
+      "version": ">=11.0.0-rc.5 <12.0.0",
       "onFail": "error"
     }
   },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The latest version of pnpm/action-setup that I upgraded to in the last PR broke the Windows build. For some reason it doesn't seem able to resolve versions automatically on Windows specifically, so we have to specify the pnpm version explicitly.

## How to Test

<!--- Please describe in detail how you tested your changes -->

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI configuration change with no application or runtime impact; only risk is drift if the repo later standardizes on a different pnpm version elsewhere.
> 
> **Overview**
> Fixes **Windows release builds** failing after upgrading `pnpm/action-setup` by **pinning pnpm to `11.5.2`** on the shared release workflow step (macOS, Windows, Linux matrix).
> 
> Without an explicit version, the action no longer resolves pnpm reliably on Windows runners; specifying the version restores a consistent install before `pnpm install --frozen-lockfile` and publish steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c77773dddead9dccd479e6b545aedd70b856dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->