### PR TITLE
internal(autocorrelation): Reduce tokens in validation result sent to Assistant

### DIFF
--- a/src/views/Generator/AutoCorrelation/useGenerateRules.ts
+++ b/src/views/Generator/AutoCorrelation/useGenerateRules.ts
@@ -30,6 +30,7 @@ import {
   searchRequests,
 } from './utils/searchTools'
 import { prepareRequestsForAI } from './utils/stripRequestData'
+import { summarizeValidationForAI } from './utils/summarizeValidationForAI'
 import { validationMatchesRecording } from './utils/validationMatchesRecording'
 
 const outcomeEvents = {
@@ -241,10 +242,12 @@ export const useGenerateRules = ({
       false
     )
 
-    return validationMatchesRecording(
+    const comparison = validationMatchesRecording(
       prepareRequestsForAI(recording),
       prepareRequestsForAI(validationResult)
     )
+
+    return summarizeValidationForAI(comparison)
   }
 
   const removeRule = useCallback((ruleId: string) => {
@@ -270,10 +273,10 @@ export const useGenerateRules = ({
     actionsLog.setValidationEntryId(initialEntry.id)
 
     try {
-      const validationResult = await runValidation()
+      const validationSummary = await runValidation()
       actionsLog.completeValidationProgress()
 
-      if (validationResult.success) {
+      if (validationSummary.success) {
         setCorrelationStatusAndRef('correlation-not-needed')
         actionsLog.addEntry({
           type: 'info',
@@ -289,7 +292,7 @@ export const useGenerateRules = ({
       })
 
       return await sendMessage({
-        text: `${systemPrompt} \n\n Validation result: ${JSON.stringify(validationResult)}`,
+        text: `${systemPrompt} \n\n Validation result: ${JSON.stringify(validationSummary)}`,
       })
     } catch (error) {
       if (error instanceof Error && error.name === 'AbortError') {

--- a/src/views/Generator/AutoCorrelation/utils/compareValues.test.ts
+++ b/src/views/Generator/AutoCorrelation/utils/compareValues.test.ts
@@ -90,6 +90,17 @@ describe('compareResponseValues', () => {
       expect(result.mismatches).toHaveLength(0)
     })
 
+    it('should still report Location header changes (redirect targets are correlation candidates)', () => {
+      const expected = createMockData([['Location', '/dashboard?id=1']])
+      const actual = createMockData([['Location', '/dashboard?id=2']])
+
+      const result = compareResponseValues(expected, actual)
+
+      expect(result.mismatches).toMatchObject([
+        { path: 'response.headers.location', location: 'header' },
+      ])
+    })
+
     it('should match headers case-insensitively', () => {
       const expected = createMockData([['X-Custom-Header', 'value1']])
       const actual = createMockData([['x-custom-header', 'value1']])

--- a/src/views/Generator/AutoCorrelation/utils/compareValues.ts
+++ b/src/views/Generator/AutoCorrelation/utils/compareValues.ts
@@ -1,7 +1,7 @@
 import { Header } from '@/types'
 import { safeJsonParse } from '@/utils/json'
 
-import { shouldSkipCookie } from './skipCookies'
+import { shouldSkipHeader } from './skipHeaders'
 import { StrippedProxyData } from './stripRequestData'
 
 const MAX_RECURSION_DEPTH = 5
@@ -9,25 +9,6 @@ const MAX_MISMATCHES = 20
 const MAX_CONTENT_LENGTH = 1000
 const MAX_ARRAY_LENGTH = 10
 const CONTENT_PREVIEW_LENGTH = 500
-
-const SKIP_HEADERS = [
-  'date',
-  'age',
-  'expires',
-  'last-modified',
-  'etag',
-  'x-request-id',
-  'x-correlation-id',
-  'x-trace-id',
-  'x-span-id',
-  'x-amzn-requestid',
-  'x-amzn-trace-id',
-  'cf-ray',
-  'content-length',
-  'transfer-encoding',
-  'content-type',
-  'user-agent',
-]
 
 const MAX_MISMATCH_VALUE_LENGTH = 80
 
@@ -159,22 +140,6 @@ function normalizeHeaders(headers: Header[]) {
 
 function parseCookieName(value: string) {
   return value.split(';')[0]?.split('=')[0]?.trim()
-}
-
-function shouldSkipHeader(key: string) {
-  const lowerKey = key.toLowerCase()
-
-  if (SKIP_HEADERS.includes(lowerKey)) {
-    return true
-  }
-
-  // Check if this is a set-cookie header with a skippable cookie name
-  if (lowerKey.startsWith('set-cookie.')) {
-    const cookieName = lowerKey.slice('set-cookie.'.length)
-    return shouldSkipCookie(cookieName)
-  }
-
-  return false
 }
 
 function normalizeValue(value: string) {

--- a/src/views/Generator/AutoCorrelation/utils/skipHeaders.test.ts
+++ b/src/views/Generator/AutoCorrelation/utils/skipHeaders.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+
+import { shouldSkipHeader } from './skipHeaders'
+
+describe('shouldSkipHeader', () => {
+  it('skips standard server-generated headers', () => {
+    const skipped = [
+      'date',
+      'server-timing',
+      'alt-svc',
+      'vary',
+      'via',
+      'server',
+      'accept-ranges',
+      'retry-after',
+      'keep-alive',
+    ]
+
+    skipped.forEach((name) => expect(shouldSkipHeader(name)).toBe(true))
+  })
+
+  it('skips diagnostic id and rate-limit headers by pattern, regardless of vendor prefix', () => {
+    const skipped = [
+      'grafana-trace-id',
+      'x-datadog-trace-id',
+      'x-amzn-requestid',
+      'my-request-id',
+      'x-correlation-id',
+      'b3-span-id',
+      'audit-id',
+      'x-ratelimit-remaining',
+      'x-rate-limit-limit',
+    ]
+
+    skipped.forEach((name) => expect(shouldSkipHeader(name)).toBe(true))
+  })
+
+  it('is case-insensitive', () => {
+    expect(shouldSkipHeader('Server-Timing')).toBe(true)
+  })
+
+  it('does not skip correlation candidates like Location', () => {
+    expect(shouldSkipHeader('location')).toBe(false)
+    expect(shouldSkipHeader('x-custom-header')).toBe(false)
+  })
+
+  it('defers set-cookie headers to the cookie skip rules', () => {
+    expect(shouldSkipHeader('set-cookie.awsalb')).toBe(true)
+    expect(shouldSkipHeader('set-cookie.csrf_token')).toBe(false)
+  })
+
+  it('defers set-cookie to cookie rules even when the cookie name contains a header pattern', () => {
+    // A functional cookie whose name happens to contain a diagnostic-id
+    // substring must not be dropped by the header patterns.
+    expect(shouldSkipHeader('set-cookie.session-trace-id')).toBe(false)
+  })
+})

--- a/src/views/Generator/AutoCorrelation/utils/skipHeaders.ts
+++ b/src/views/Generator/AutoCorrelation/utils/skipHeaders.ts
@@ -1,0 +1,61 @@
+import { shouldSkipCookie } from './skipCookies'
+
+// Standard, server-generated response headers that a client never extracts
+// and replays, so they can never be correlation sources or targets.
+const SKIP_HEADERS = [
+  'date',
+  'age',
+  'expires',
+  'last-modified',
+  'etag',
+  'cf-ray',
+  'content-length',
+  'transfer-encoding',
+  'content-type',
+  'user-agent',
+  'server-timing',
+  'alt-svc',
+  'vary',
+  'via',
+  'server',
+  'accept-ranges',
+  'retry-after',
+  'keep-alive',
+]
+
+// Substring patterns covering server-issued diagnostic id and rate-limit
+// header families across vendors (e.g. grafana-trace-id, x-datadog-trace-id,
+// x-amzn-requestid, audit-id, x-ratelimit-remaining). Kept generic so new
+// vendor prefixes are filtered without enumerating each one.
+const SKIP_HEADER_PATTERNS = [
+  'trace-id',
+  'request-id',
+  'requestid',
+  'correlation-id',
+  'span-id',
+  'audit-id',
+  'ratelimit',
+  'rate-limit',
+]
+
+export function shouldSkipHeader(key: string) {
+  const lowerKey = key.toLowerCase()
+
+  // A set-cookie header is normalized to `set-cookie.<name>`; the cookie skip
+  // rules own the functional-vs-noise decision, so consult them before the
+  // header-name patterns (a cookie name may incidentally contain a pattern).
+  if (lowerKey.startsWith('set-cookie.')) {
+    const cookieName = lowerKey.slice('set-cookie.'.length)
+    return shouldSkipCookie(cookieName)
+  }
+
+  if (SKIP_HEADERS.includes(lowerKey)) {
+    return true
+  }
+
+  if (SKIP_HEADER_PATTERNS.some((pattern) => lowerKey.includes(pattern))) {
+    return true
+  }
+
+  return false
+}

--- a/src/views/Generator/AutoCorrelation/utils/summarizeValidationForAI.test.ts
+++ b/src/views/Generator/AutoCorrelation/utils/summarizeValidationForAI.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+
+import { summarizeValidationForAI } from './summarizeValidationForAI'
+import type { ValidationResult } from './validationMatchesRecording'
+
+const statusOnly = (url: string, expected: number, actual: number) => ({
+  request: { method: 'GET', url },
+  statusCodeMismatch: { expected, actual },
+})
+
+describe('summarizeValidationForAI', () => {
+  it('groups status-only mismatches by delta, keeping every url (lossless)', () => {
+    const result: ValidationResult = {
+      success: false,
+      details: {
+        mismatches: [
+          statusOnly('http://a.com/1', 200, 401),
+          statusOnly('http://a.com/2', 200, 401),
+          statusOnly('http://a.com/3', 200, 401),
+          statusOnly('http://a.com/4', 200, 503),
+        ],
+      },
+    }
+
+    const summary = summarizeValidationForAI(result)
+
+    expect(summary.statusMismatches).toEqual([
+      {
+        expected: 200,
+        actual: 401,
+        requests: [
+          'GET http://a.com/1',
+          'GET http://a.com/2',
+          'GET http://a.com/3',
+        ],
+      },
+      { expected: 200, actual: 503, requests: ['GET http://a.com/4'] },
+    ])
+  })
+
+  it('keeps method so same-path different-method requests stay distinct', () => {
+    const result: ValidationResult = {
+      success: false,
+      details: {
+        mismatches: [
+          {
+            request: { method: 'GET', url: 'http://a.com/x' },
+            statusCodeMismatch: { expected: 200, actual: 401 },
+          },
+          {
+            request: { method: 'POST', url: 'http://a.com/x' },
+            statusCodeMismatch: { expected: 200, actual: 401 },
+          },
+        ],
+      },
+    }
+
+    const summary = summarizeValidationForAI(result)
+
+    expect(summary.statusMismatches[0]?.requests).toEqual([
+      'GET http://a.com/x',
+      'POST http://a.com/x',
+    ])
+  })
+
+  it('keeps value mismatches in full as correlation targets', () => {
+    const result: ValidationResult = {
+      success: false,
+      details: {
+        mismatches: [
+          {
+            request: { method: 'POST', url: 'http://a.com/login' },
+            valueMismatches: [
+              {
+                path: 'response.headers.set-cookie.session',
+                expected: 'a',
+                actual: 'b',
+                location: 'header',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const summary = summarizeValidationForAI(result)
+
+    expect(summary.valueMismatches).toHaveLength(1)
+    expect(summary.statusMismatches).toHaveLength(0)
+    expect(summary.valueMismatches[0]?.valueMismatches?.[0]?.path).toBe(
+      'response.headers.set-cookie.session'
+    )
+  })
+
+  it('treats an entry with both status and value mismatch as a value target, not a cascade', () => {
+    const result: ValidationResult = {
+      success: false,
+      details: {
+        mismatches: [
+          {
+            request: { method: 'POST', url: 'http://a.com/x' },
+            statusCodeMismatch: { expected: 200, actual: 401 },
+            valueMismatches: [
+              {
+                path: 'response.body.token',
+                expected: 'a',
+                actual: 'b',
+                location: 'body',
+              },
+            ],
+          },
+        ],
+      },
+    }
+
+    const summary = summarizeValidationForAI(result)
+
+    expect(summary.valueMismatches).toHaveLength(1)
+    expect(summary.statusMismatches).toHaveLength(0)
+  })
+
+  it('passes through success with empty buckets', () => {
+    const summary = summarizeValidationForAI({ success: true })
+
+    expect(summary).toEqual({
+      success: true,
+      valueMismatches: [],
+      statusMismatches: [],
+    })
+  })
+
+  it('is smaller than the raw result for a large status cascade', () => {
+    const mismatches = Array.from({ length: 90 }, (_, index) =>
+      statusOnly(`http://a.com/path/${index}`, 200, 401)
+    )
+    const result: ValidationResult = {
+      success: false,
+      details: { mismatches },
+    }
+
+    const rawSize = JSON.stringify(result).length
+    const summarySize = JSON.stringify(summarizeValidationForAI(result)).length
+
+    expect(summarySize).toBeLessThan(rawSize)
+  })
+})

--- a/src/views/Generator/AutoCorrelation/utils/summarizeValidationForAI.ts
+++ b/src/views/Generator/AutoCorrelation/utils/summarizeValidationForAI.ts
@@ -1,0 +1,75 @@
+import type {
+  ValidationMismatch,
+  ValidationResult,
+} from './validationMatchesRecording'
+
+interface StatusMismatchGroup {
+  expected: number
+  actual: number
+  // Each entry is "METHOD url" so method survives the grouping.
+  requests: string[]
+}
+
+export interface ValidationSummaryForAI {
+  success: boolean
+  // Entries with value-level diffs are real correlation targets, kept in full.
+  valueMismatches: ValidationMismatch[]
+  // Status-only mismatches grouped by delta: every request (method + url) is
+  // retained, only the repeated per-entry scaffolding is dropped. A missing
+  // auth correlation produces one cascade group rather than N entries.
+  statusMismatches: StatusMismatchGroup[]
+}
+
+function hasValueMismatch(mismatch: ValidationMismatch): boolean {
+  return (mismatch.valueMismatches?.length ?? 0) > 0
+}
+
+function groupStatusMismatches(
+  mismatches: ValidationMismatch[]
+): StatusMismatchGroup[] {
+  const groups = new Map<string, StatusMismatchGroup>()
+
+  for (const mismatch of mismatches) {
+    const { statusCodeMismatch, request } = mismatch
+    if (!statusCodeMismatch) {
+      continue
+    }
+
+    const key = `${statusCodeMismatch.expected}->${statusCodeMismatch.actual}`
+    let group = groups.get(key)
+    if (!group) {
+      group = {
+        expected: statusCodeMismatch.expected,
+        actual: statusCodeMismatch.actual,
+        requests: [],
+      }
+      groups.set(key, group)
+    }
+    group.requests.push(`${request.method} ${request.url}`)
+  }
+
+  return [...groups.values()]
+}
+
+/**
+ * Collapses a validation result into the compact form sent to the AI. Real
+ * correlation targets (value mismatches) are preserved verbatim; status-only
+ * mismatches are grouped by delta so a downstream failure cascade does not
+ * dominate the payload with repeated entries.
+ */
+export function summarizeValidationForAI(
+  result: ValidationResult
+): ValidationSummaryForAI {
+  const mismatches = result.details?.mismatches ?? []
+
+  const valueMismatches = mismatches.filter(hasValueMismatch)
+  const statusOnly = mismatches.filter(
+    (mismatch) => !hasValueMismatch(mismatch)
+  )
+
+  return {
+    success: result.success,
+    valueMismatches,
+    statusMismatches: groupStatusMismatches(statusOnly),
+  }
+}

--- a/src/views/Generator/AutoCorrelation/utils/validationMatchesRecording.ts
+++ b/src/views/Generator/AutoCorrelation/utils/validationMatchesRecording.ts
@@ -1,7 +1,7 @@
 import { compareResponseValues, ValueMismatch } from './compareValues'
 import { StrippedProxyData } from './stripRequestData'
 
-interface ValidationMismatch {
+export interface ValidationMismatch {
   request: {
     method: string
     url: string
@@ -13,10 +13,9 @@ interface ValidationMismatch {
   valueMismatches?: ValueMismatch[]
 }
 
-interface ValidationResult {
+export interface ValidationResult {
   success: boolean
   details?: {
-    reason: string
     mismatches?: ValidationMismatch[]
   }
 }
@@ -76,21 +75,9 @@ export function validationMatchesRecording(
     (m) => m.statusCodeMismatch === undefined
   )
 
-  const statusCodeMismatches = allMismatches.filter(
-    (m) => m.statusCodeMismatch !== undefined
-  )
-
-  const reasons = statusCodeMismatches
-    .slice(0, 10)
-    .map(
-      (m) =>
-        `Expected ${m.statusCodeMismatch?.expected} but got ${m.statusCodeMismatch?.actual} for ${m.request.method} ${m.request.url}`
-    )
-
   return {
     success: allResponseCodesMatch,
     details: {
-      reason: reasons.join('\n'),
       mismatches: allMismatches,
     },
   }


### PR DESCRIPTION
## Description

During autocorrelation the Assistant receives the validation result to decide which values need correlation rules. On larger recordings this payload was dominated by noise: mismatches for volatile response headers (server timing, trace ids, rate limits) and one entry per request for a downstream status-code cascade.

This improves header filtering by removing headers unrelated to correlation, and collapses status-only mismatches into one group per status delta, keeping every URL and every value-level mismatch. On a 119-request recording the payload dropped from ~14.9k to ~4.2k tokens (72%) with no loss of correlation targets.

Header filtering uses generic substring patterns for diagnostic-id and rate-limit families rather than a fixed list tied to a specific backend.

### Before

```json
{
  "success": false,
  "details": {
    "reason": "Expected 200 but got 401 for GET .../api/ratings\n...",
    "mismatches": [
      {
        "request": { "method": "POST", "url": ".../api/csrf-token" },
        "valueMismatches": [
          { "path": "response.headers.set-cookie.csrf_token", "expected": "a1b2", "actual": "c3d4", "location": "header" },
          { "path": "response.headers.server-timing", "expected": "db;dur=12", "actual": "db;dur=31", "location": "header" },
          { "path": "response.headers.grafana-trace-id", "expected": "abc", "actual": "xyz", "location": "header" }
        ]
      },
      { "request": { "method": "POST", "url": ".../api/login" }, "statusCodeMismatch": { "expected": 200, "actual": 401 } },
      { "request": { "method": "GET", "url": ".../api/ratings" }, "statusCodeMismatch": { "expected": 200, "actual": 401 } },
      { "request": { "method": "GET", "url": ".../api/tools" }, "statusCodeMismatch": { "expected": 200, "actual": 401 } }
    ]
  }
}
```

### After

```json
{
  "success": false,
  "valueMismatches": [
    {
      "request": { "method": "POST", "url": ".../api/csrf-token" },
      "valueMismatches": [
        { "path": "response.headers.set-cookie.csrf_token", "expected": "a1b2", "actual": "c3d4", "location": "header" }
      ]
    }
  ],
  "statusMismatches": [
    {
      "expected": 200,
      "actual": 401,
      "requests": ["POST .../api/login", "GET .../api/ratings", "GET .../api/tools"]
    }
  ]
}
```

## How to Test

1. Open a generator with a recording that has an auth flow. I used a Grafana instance login through grafana.com. Without this fix the run hit the context limit.
2. Run autocorrelation.
3. Confirm it creates the expected correlation rules and reaches a success outcome.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what the Assistant sees during rule generation (new JSON shape and fewer header diffs); wrong filtering could hide real correlation targets, though behavior is covered by new unit tests.
> 
> **Overview**
> Shrinks the **validation result JSON** sent to the autocorrelation Assistant on start and from **`runValidation`**, so large recordings are less likely to hit context limits.
> 
> **Header comparison** moves skip logic into **`shouldSkipHeader`**: more server-generated headers are ignored, trace/request/rate-limit families are dropped via **substring patterns** (not a fixed vendor list), **`Location`** stays visible, and **`set-cookie.*`** is judged by cookie rules before header patterns.
> 
> **`summarizeValidationForAI`** replaces the raw **`validationMatchesRecording`** output for the AI: **value mismatches** stay complete; **status-only** failures group by expected→actual while keeping every `METHOD url`; entries with both status and value diffs count as value targets. **`details.reason`** is removed from **`ValidationResult`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c938b763e249e2c68a82e82c04a0935fe83e6ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->