### PR TITLE
internal: Add cross-OS E2E smoke tests

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,63 @@
+name: E2E Smoke
+
+# Packages the real artifact and launches it on every supported OS to catch
+# build/startup regressions release builds would miss.
+on:
+  workflow_dispatch:
+  # TEMPORARY: runs the 4-OS matrix on this PR for first-time verification.
+  # Remove this trigger before merging -- workflow_dispatch is the intended
+  # long-term entry point.
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  smoke:
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Native arch per runner covers all four targets: macos-latest=Apple
+        # Silicon, macos-15-intel=Intel, windows-latest=x64, ubuntu-latest=Linux.
+        platform: [macos-latest, macos-15-intel, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 11.5.2
+
+      - name: setup node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: 24.11
+          cache: 'pnpm'
+
+      # postinstall downloads the k6 binary; the proxy binary is committed.
+      - name: install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No signing credentials are set, so forge.config.ts ad-hoc signs on macOS
+      # (required for the arm64 app to launch) and skips notarization/Windows
+      # signing. `package` does not run makers, so no DMG/setuptools is needed.
+      - name: package app
+        env:
+          NODE_OPTIONS: '--max_old_space_size=8192'
+        run: pnpm package
+
+      # Linux runners are headless, so the app needs a virtual display.
+      - name: run smoke test (Linux)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a pnpm test:e2e
+
+      - name: run smoke test (macOS/Windows)
+        if: runner.os != 'Linux'
+        run: pnpm test:e2e

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,14 +4,38 @@ name: E2E Smoke
 # build/startup regressions release builds would miss.
 on:
   workflow_dispatch:
-  # TEMPORARY: runs the 4-OS matrix on this PR for first-time verification.
-  # Remove this trigger before merging -- workflow_dispatch is the intended
-  # long-term entry point.
+  # Run on PRs that touch packaging, startup, native deps, or the test harness
+  # itself -- the changes that can break a packaged build, which unit tests and
+  # `pnpm start` never exercise. Most PRs (UI, codegen) skip it. release-please
+  # release PRs bump package.json (releaseType: node), so they always match and
+  # the full matrix runs as the pre-release gate.
   pull_request:
     branches:
       - main
+    paths:
+      - 'forge.config.ts'
+      - 'windowsSign*.ts'
+      - 'entitlements.plist'
+      - 'vite.*.config.*'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'src/main.ts'
+      - 'src/main/**'
+      - 'src/preload.ts'
+      - 'scripts/install-k6.js'
+      - 'k6-versions.json'
+      - 'resources/**'
+      - 'playwright.config.ts'
+      - 'e2e/**'
+      - '.github/workflows/smoke.yml'
 
 permissions: {}
+
+# Supersede an in-flight run when a PR is updated, so rapid pushes (and the
+# frequently-updated release-please PR) don't stack redundant 4-OS matrices.
+concurrency:
+  group: smoke-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   smoke:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,6 +17,7 @@ jobs:
   smoke:
     permissions:
       contents: read
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,10 @@ resources/entrypoint.js
 resources/replay.js
 resources/k6-testing.js
 
+# Playwright e2e output
+test-results
+playwright-report
+
 # Local claude settings
 .claude/settings.local.json
 .claude/CLAUDE.local.md

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -168,6 +168,15 @@
       "rules": {
         "no-restricted-imports": "off"
       }
+    },
+    {
+      "files": ["e2e/**"],
+      "rules": {
+        "no-restricted-imports": "off",
+        "no-empty-pattern": "off",
+        "react/rules-of-hooks": "off",
+        "react-hooks/rules-of-hooks": "off"
+      }
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -174,8 +174,7 @@
       "rules": {
         "no-restricted-imports": "off",
         "no-empty-pattern": "off",
-        "react/rules-of-hooks": "off",
-        "react-hooks/rules-of-hooks": "off"
+        "react/rules-of-hooks": "off"
       }
     }
   ]

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -56,7 +56,10 @@ function resolvePackagedExecutable() {
   return path.join(baseDir, EXECUTABLE_NAME)
 }
 
-async function waitForDebugEndpoint(timeoutMs: number) {
+async function waitForDebugEndpoint(
+  timeoutMs: number,
+  getStderr: () => string
+) {
   const deadline = Date.now() + timeoutMs
 
   while (Date.now() < deadline) {
@@ -73,7 +76,9 @@ async function waitForDebugEndpoint(timeoutMs: number) {
     await new Promise((resolve) => setTimeout(resolve, 500))
   }
 
-  throw new Error(`CDP endpoint never came up on port ${DEBUG_PORT}`)
+  throw new Error(
+    `CDP endpoint never came up on port ${DEBUG_PORT}. App stderr:\n${getStderr()}`
+  )
 }
 
 // Launches the packaged app and exposes its renderer window as a Page.
@@ -95,17 +100,28 @@ export const test = base.extend<{ appWindow: Page }>({
     let app: ChildProcess | undefined
     let browser: Browser | undefined
 
-    try {
-      app = spawn(
-        executablePath,
-        [
-          `--remote-debugging-port=${DEBUG_PORT}`,
-          `--user-data-dir=${userDataDir}`,
-        ],
-        { stdio: 'ignore' }
-      )
+    const args = [
+      `--remote-debugging-port=${DEBUG_PORT}`,
+      `--user-data-dir=${userDataDir}`,
+    ]
+    // Ubuntu CI runners restrict unprivileged user namespaces (AppArmor), so
+    // Electron's Chromium sandbox fails to start and the app never exposes the
+    // debugging port. The smoke test only launches a throwaway packaged build,
+    // so disabling the sandbox on Linux is safe.
+    if (process.platform === 'linux') {
+      args.push('--no-sandbox')
+    }
 
-      await waitForDebugEndpoint(30_000)
+    try {
+      app = spawn(executablePath, args, {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      })
+      let stderr = ''
+      app.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString()
+      })
+
+      await waitForDebugEndpoint(30_000, () => stderr)
 
       browser = await chromium.connectOverCDP(`http://127.0.0.1:${DEBUG_PORT}`)
       const context = browser.contexts()[0]
@@ -118,8 +134,14 @@ export const test = base.extend<{ appWindow: Page }>({
 
       await use(window)
     } finally {
-      await browser?.close()
-      app?.kill('SIGKILL')
+      // Kill the app even if browser.close() rejects (e.g. the packaged app
+      // already exited) -- otherwise an orphaned Electron keeps CDP bound to the
+      // port and breaks the next run.
+      try {
+        await browser?.close()
+      } finally {
+        app?.kill('SIGKILL')
+      }
     }
   },
 })

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -3,6 +3,7 @@ import {
   expect,
   chromium,
   type Browser,
+  type BrowserContext,
   type Page,
 } from '@playwright/test'
 import { type ChildProcess, spawn } from 'node:child_process'
@@ -101,6 +102,26 @@ async function waitForDebugPort(
   throw new Error(`CDP port never came up. App stderr:\n${probes.getStderr()}`)
 }
 
+// DevToolsActivePort is written when Chromium's CDP server binds, which happens
+// before the main process creates the window and loads the renderer. So at
+// connect time context.pages() may not yet list the Home window -- poll until it
+// appears rather than throwing immediately.
+async function waitForRendererPage(context: BrowserContext, timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    const page = context
+      .pages()
+      .find((candidate) => !candidate.url().startsWith('devtools://'))
+    if (page) {
+      return page
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
+
+  throw new Error('No renderer page exposed over CDP within timeout')
+}
+
 // Launches the packaged app and exposes its renderer window as a Page.
 //
 // The production fuses disable the Node inspector, so Playwright's
@@ -162,12 +183,7 @@ export const test = base.extend<{ appWindow: Page }>({
       if (!context) {
         throw new Error('No browser context exposed over CDP')
       }
-      const window = context
-        .pages()
-        .find((page) => !page.url().startsWith('devtools://'))
-      if (!window) {
-        throw new Error('No renderer page exposed over CDP')
-      }
+      const window = await waitForRendererPage(context, 20_000)
 
       await use(window)
     } finally {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,127 @@
+import {
+  test as base,
+  expect,
+  chromium,
+  type Browser,
+  type Page,
+} from '@playwright/test'
+import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+const EXECUTABLE_NAME = 'k6-studio'
+// Distinct from the recorder's CDP port (9222) and the dev server's (9223).
+const DEBUG_PORT = 9789
+
+// `electron-forge package` writes to `out/<productName>-<platform>-<arch>/`.
+// Resolve the executable for the current platform so tests run unchanged on
+// every runner in the matrix.
+function resolvePackagedExecutable() {
+  const outDir = path.resolve(__dirname, '..', 'out')
+
+  if (!fs.existsSync(outDir)) {
+    throw new Error(
+      `Packaged output not found at ${outDir}. Run "pnpm package" first.`
+    )
+  }
+
+  const suffix = `-${process.platform}-${process.arch}`
+  const packageDir = fs
+    .readdirSync(outDir)
+    .find((entry) => entry.endsWith(suffix))
+
+  if (!packageDir) {
+    throw new Error(`No packaged app for ${suffix} in ${outDir}`)
+  }
+
+  const baseDir = path.join(outDir, packageDir)
+
+  if (process.platform === 'darwin') {
+    const appBundle = fs
+      .readdirSync(baseDir)
+      .find((entry) => entry.endsWith('.app'))
+
+    if (!appBundle) {
+      throw new Error(`No .app bundle in ${baseDir}`)
+    }
+
+    return path.join(baseDir, appBundle, 'Contents', 'MacOS', EXECUTABLE_NAME)
+  }
+
+  if (process.platform === 'win32') {
+    return path.join(baseDir, `${EXECUTABLE_NAME}.exe`)
+  }
+
+  return path.join(baseDir, EXECUTABLE_NAME)
+}
+
+async function waitForDebugEndpoint(timeoutMs: number) {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${DEBUG_PORT}/json/version`
+      )
+      if (response.ok) {
+        return
+      }
+    } catch {
+      // endpoint not up yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
+
+  throw new Error(`CDP endpoint never came up on port ${DEBUG_PORT}`)
+}
+
+// Launches the packaged app and exposes its renderer window as a Page.
+//
+// The production fuses disable the Node inspector, so Playwright's
+// `_electron.launch` (which attaches to it) cannot drive the packaged app.
+// Instead launch the real artifact with Chromium's remote debugging port -- a
+// switch fuses do not affect -- and connect over CDP. An isolated user-data dir
+// gives the app its own single-instance lock and a clean profile, otherwise the
+// lock collides with a running k6 Studio (e.g. a dev `pnpm start`) and the
+// second instance immediately quits.
+export const test = base.extend<{ appWindow: Page }>({
+  appWindow: async ({}, use) => {
+    const executablePath = resolvePackagedExecutable()
+    const userDataDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'k6-studio-smoke-')
+    )
+
+    let app: ChildProcess | undefined
+    let browser: Browser | undefined
+
+    try {
+      app = spawn(
+        executablePath,
+        [
+          `--remote-debugging-port=${DEBUG_PORT}`,
+          `--user-data-dir=${userDataDir}`,
+        ],
+        { stdio: 'ignore' }
+      )
+
+      await waitForDebugEndpoint(30_000)
+
+      browser = await chromium.connectOverCDP(`http://127.0.0.1:${DEBUG_PORT}`)
+      const context = browser.contexts()[0]
+      if (!context) {
+        throw new Error('No browser context exposed over CDP')
+      }
+      const window =
+        context.pages().find((page) => !page.url().startsWith('devtools://')) ??
+        (await context.waitForEvent('page'))
+
+      await use(window)
+    } finally {
+      await browser?.close()
+      app?.kill('SIGKILL')
+    }
+  },
+})
+
+export { expect }

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -11,8 +11,6 @@ import os from 'node:os'
 import path from 'node:path'
 
 const EXECUTABLE_NAME = 'k6-studio'
-// Distinct from the recorder's CDP port (9222) and the dev server's (9223).
-const DEBUG_PORT = 9789
 
 // `electron-forge package` writes to `out/<productName>-<platform>-<arch>/`.
 // Resolve the executable for the current platform so tests run unchanged on
@@ -56,29 +54,51 @@ function resolvePackagedExecutable() {
   return path.join(baseDir, EXECUTABLE_NAME)
 }
 
-async function waitForDebugEndpoint(
-  timeoutMs: number,
+// Electron writes the actual remote-debugging port to DevToolsActivePort in the
+// user-data dir once the CDP server is listening. Reading it (rather than a
+// fixed port) ties the connection to the instance we spawned and avoids
+// colliding with any other Electron on the machine.
+function readDebugPort(userDataDir: string) {
+  const portFile = path.join(userDataDir, 'DevToolsActivePort')
+  if (!fs.existsSync(portFile)) {
+    return undefined
+  }
+  const port = Number(fs.readFileSync(portFile, 'utf8').split('\n')[0])
+  return Number.isInteger(port) && port > 0 ? port : undefined
+}
+
+interface DebugPortProbes {
   getStderr: () => string
+  getExit: () => string | undefined
+  getError: () => Error | undefined
+}
+
+async function waitForDebugPort(
+  userDataDir: string,
+  timeoutMs: number,
+  probes: DebugPortProbes
 ) {
   const deadline = Date.now() + timeoutMs
 
   while (Date.now() < deadline) {
-    try {
-      const response = await fetch(
-        `http://127.0.0.1:${DEBUG_PORT}/json/version`
-      )
-      if (response.ok) {
-        return
-      }
-    } catch {
-      // endpoint not up yet
+    const error = probes.getError()
+    if (error) {
+      throw new Error(`App failed to launch: ${error.message}`)
     }
-    await new Promise((resolve) => setTimeout(resolve, 500))
+    const exit = probes.getExit()
+    if (exit) {
+      throw new Error(
+        `App exited before exposing CDP (${exit}). App stderr:\n${probes.getStderr()}`
+      )
+    }
+    const port = readDebugPort(userDataDir)
+    if (port !== undefined) {
+      return port
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250))
   }
 
-  throw new Error(
-    `CDP endpoint never came up on port ${DEBUG_PORT}. App stderr:\n${getStderr()}`
-  )
+  throw new Error(`CDP port never came up. App stderr:\n${probes.getStderr()}`)
 }
 
 // Launches the packaged app and exposes its renderer window as a Page.
@@ -87,9 +107,10 @@ async function waitForDebugEndpoint(
 // `_electron.launch` (which attaches to it) cannot drive the packaged app.
 // Instead launch the real artifact with Chromium's remote debugging port -- a
 // switch fuses do not affect -- and connect over CDP. An isolated user-data dir
-// gives the app its own single-instance lock and a clean profile, otherwise the
-// lock collides with a running k6 Studio (e.g. a dev `pnpm start`) and the
-// second instance immediately quits.
+// is required for two reasons: it gives the app its own single-instance lock so
+// it does not collide with a running k6 Studio (e.g. a dev `pnpm start`, which
+// would make the second instance immediately quit), and it gives a known path
+// to read the chosen port from (<userDataDir>/DevToolsActivePort).
 export const test = base.extend<{ appWindow: Page }>({
   appWindow: async ({}, use) => {
     const executablePath = resolvePackagedExecutable()
@@ -100,10 +121,8 @@ export const test = base.extend<{ appWindow: Page }>({
     let app: ChildProcess | undefined
     let browser: Browser | undefined
 
-    const args = [
-      `--remote-debugging-port=${DEBUG_PORT}`,
-      `--user-data-dir=${userDataDir}`,
-    ]
+    // Port 0 lets Electron pick a free port, reported via DevToolsActivePort.
+    const args = ['--remote-debugging-port=0', `--user-data-dir=${userDataDir}`]
     // Ubuntu CI runners restrict unprivileged user namespaces (AppArmor), so
     // Electron's Chromium sandbox fails to start and the app never exposes the
     // debugging port. The smoke test only launches a throwaway packaged build,
@@ -116,32 +135,53 @@ export const test = base.extend<{ appWindow: Page }>({
       app = spawn(executablePath, args, {
         stdio: ['ignore', 'ignore', 'pipe'],
       })
+
       let stderr = ''
       app.stderr?.on('data', (chunk: Buffer) => {
         stderr += chunk.toString()
       })
+      // Capturing 'error' both surfaces spawn failures (missing/non-executable
+      // binary) and stops the unhandled event from crashing the test worker.
+      let spawnError: Error | undefined
+      app.on('error', (error) => {
+        spawnError = error
+      })
+      let exitInfo: string | undefined
+      app.on('exit', (code, signal) => {
+        exitInfo = `code=${code} signal=${signal ?? 'none'}`
+      })
 
-      await waitForDebugEndpoint(30_000, () => stderr)
+      const port = await waitForDebugPort(userDataDir, 30_000, {
+        getStderr: () => stderr,
+        getExit: () => exitInfo,
+        getError: () => spawnError,
+      })
 
-      browser = await chromium.connectOverCDP(`http://127.0.0.1:${DEBUG_PORT}`)
+      browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`)
       const context = browser.contexts()[0]
       if (!context) {
         throw new Error('No browser context exposed over CDP')
       }
-      const window =
-        context.pages().find((page) => !page.url().startsWith('devtools://')) ??
-        (await context.waitForEvent('page'))
+      const window = context
+        .pages()
+        .find((page) => !page.url().startsWith('devtools://'))
+      if (!window) {
+        throw new Error('No renderer page exposed over CDP')
+      }
 
       await use(window)
     } finally {
       // Kill the app even if browser.close() rejects (e.g. the packaged app
-      // already exited) -- otherwise an orphaned Electron keeps CDP bound to the
-      // port and breaks the next run.
+      // already exited), then remove the throwaway profile.
       try {
         await browser?.close()
       } finally {
         app?.kill('SIGKILL')
       }
+      // The profile dir is a throwaway under os.tmpdir() (OS-reaped; CI runners
+      // are ephemeral). We deliberately do not rmSync it -- SIGKILL is async and
+      // the dying helper processes keep writing to it, which races rmSync into
+      // ENOTEMPTY.
     }
   },
 })

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from './fixtures'
+
+test('packaged app launches and renders the Home view', async ({
+  appWindow,
+}) => {
+  // Home renders unconditionally (no auth gate), so these markers prove the app
+  // booted past the main process, preload, and renderer without crashing. The
+  // card descriptions are unique to Home -- the short labels (Recorder, etc.)
+  // also appear in the app shell nav and would match multiple elements.
+  await expect(
+    appWindow.getByText('Discover what you can do with Grafana k6 Studio')
+  ).toBeVisible({ timeout: 20_000 })
+  await expect(
+    appWindow.getByText('Use our built-in proxy to record a user flow')
+  ).toBeVisible()
+  await expect(
+    appWindow.getByText('Transform a recorded flow into a k6 test script')
+  ).toBeVisible()
+  await expect(
+    appWindow.getByText('Debug and validate your k6 script')
+  ).toBeVisible()
+})

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -16,6 +16,11 @@ import { getPlatform, getArch } from './src/utils/electron'
 import { windowsSign } from './windowsSign'
 import { spawnSignFile } from './windowsSignHook'
 
+// Apple signing credentials are present only in release. Their absence marks a
+// creds-free build (e.g. the smoke-test workflow), which skips osxSign/notarize
+// and instead gets a deep ad-hoc signature from the postPackage hook.
+const hasAppleSigningCreds = Boolean(process.env.APPLE_API_KEY)
+
 function getPlatformSpecificResources() {
   // on mac we are using a single image to build both architectures so we
   // will need to include both binaries in the final package for it to work.
@@ -37,7 +42,7 @@ function getPostPackageHook() {
   // the binary after packaging, invalidating any earlier signature, so apply a
   // deep ad-hoc signature as the final step. Config hooks run after plugin hooks,
   // so this lands after the fuse flip. No-op off macOS or when releasing.
-  if (getPlatform() !== 'mac' || process.env.APPLE_API_KEY) {
+  if (getPlatform() !== 'mac' || hasAppleSigningCreds) {
     return undefined
   }
 
@@ -116,7 +121,7 @@ const config: ForgeConfig = {
     // builds skip this and get a deep ad-hoc signature from the postPackage hook
     // instead -- signing here as well would race the fuse flip and leave an
     // invalid signature the OS refuses to launch.
-    osxSign: process.env.APPLE_API_KEY
+    osxSign: hasAppleSigningCreds
       ? {
           optionsForFile: () => {
             return {
@@ -127,9 +132,9 @@ const config: ForgeConfig = {
       : undefined,
     // Notarization uploads to Apple and requires real credentials, so only run
     // it when they are present. Smoke builds skip it.
-    osxNotarize: process.env.APPLE_API_KEY
+    osxNotarize: hasAppleSigningCreds
       ? {
-          appleApiKey: process.env.APPLE_API_KEY,
+          appleApiKey: process.env.APPLE_API_KEY ?? '',
           appleApiKeyId: process.env.APPLE_API_KEY_ID ?? '',
           appleApiIssuer: process.env.APPLE_API_ISSUER ?? '',
         }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -7,6 +7,8 @@ import { FusesPlugin } from '@electron-forge/plugin-fuses'
 import { VitePlugin } from '@electron-forge/plugin-vite'
 import type { ForgeConfig, ForgeMakeResult } from '@electron-forge/shared-types'
 import { FuseV1Options, FuseVersion } from '@electron/fuses'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
 import path from 'path'
 
 import { CUSTOM_APP_PROTOCOL } from './src/main/deepLinks.constants'
@@ -25,6 +27,42 @@ function getPlatformSpecificResources() {
   }
 
   return [path.join('./resources/', getPlatform(), getArch())]
+}
+
+function getPostPackageHook() {
+  // Release signs with a real Developer ID via osxSign and notarizes, producing
+  // a valid signature. Creds-free builds (smoke tests) need a valid signature
+  // too: on Apple Silicon an app with an invalid signature is killed on launch,
+  // and the integrity fuse enforces a signed asar hash. The fuses plugin rewrites
+  // the binary after packaging, invalidating any earlier signature, so apply a
+  // deep ad-hoc signature as the final step. Config hooks run after plugin hooks,
+  // so this lands after the fuse flip. No-op off macOS or when releasing.
+  if (getPlatform() !== 'mac' || process.env.APPLE_API_KEY) {
+    return undefined
+  }
+
+  return (
+    _forgeConfig: ForgeConfig,
+    { outputPaths }: { outputPaths: string[] }
+  ) => {
+    for (const outputPath of outputPaths) {
+      const appBundle = fs
+        .readdirSync(outputPath)
+        .find((entry) => entry.endsWith('.app'))
+
+      if (appBundle) {
+        execFileSync('codesign', [
+          '--force',
+          '--deep',
+          '--sign',
+          '-',
+          path.join(outputPath, appBundle),
+        ])
+      }
+    }
+
+    return Promise.resolve()
+  }
 }
 
 function getPostMakeHook() {
@@ -55,6 +93,7 @@ function getPostMakeHook() {
 const config: ForgeConfig = {
   // this is an hack for signing windows binaries: https://github.com/grafana/k6-studio/pull/869#discussion_r2454584477
   hooks: {
+    postPackage: getPostPackageHook(),
     postMake: getPostMakeHook(),
   },
   packagerConfig: {
@@ -69,19 +108,32 @@ const config: ForgeConfig = {
       './resources/k6-testing.js',
       ...getPlatformSpecificResources(),
     ],
-    windowsSign,
-    osxSign: {
-      optionsForFile: () => {
-        return {
-          entitlements: './entitlements.plist',
+    // Windows signing relies on the Azure Trusted Signing tool. Only enable it
+    // when SIGNTOOL_PATH is present (release), otherwise the hook rejects and a
+    // creds-free `package` (smoke builds) would fail.
+    windowsSign: process.env.SIGNTOOL_PATH ? windowsSign : undefined,
+    // Sign with the keychain Developer ID only in release. Creds-free smoke
+    // builds skip this and get a deep ad-hoc signature from the postPackage hook
+    // instead -- signing here as well would race the fuse flip and leave an
+    // invalid signature the OS refuses to launch.
+    osxSign: process.env.APPLE_API_KEY
+      ? {
+          optionsForFile: () => {
+            return {
+              entitlements: './entitlements.plist',
+            }
+          },
         }
-      },
-    },
-    osxNotarize: {
-      appleApiKey: process.env.APPLE_API_KEY ?? '',
-      appleApiKeyId: process.env.APPLE_API_KEY_ID ?? '',
-      appleApiIssuer: process.env.APPLE_API_ISSUER ?? '',
-    },
+      : undefined,
+    // Notarization uploads to Apple and requires real credentials, so only run
+    // it when they are present. Smoke builds skip it.
+    osxNotarize: process.env.APPLE_API_KEY
+      ? {
+          appleApiKey: process.env.APPLE_API_KEY,
+          appleApiKeyId: process.env.APPLE_API_KEY_ID ?? '',
+          appleApiIssuer: process.env.APPLE_API_ISSUER ?? '',
+        }
+      : undefined,
     protocols: [
       {
         name: CUSTOM_APP_PROTOCOL,

--- a/forge.env.d.ts
+++ b/forge.env.d.ts
@@ -8,6 +8,7 @@ declare global {
   // whether you're running in development or production).
   const MAIN_WINDOW_VITE_DEV_SERVER_URL: string
   const MAIN_WINDOW_VITE_NAME: string
+  // Empty string in builds compiled without Sentry credentials (e.g. smoke builds)
   const SENTRY_DSN: string
 
   namespace NodeJS {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "test:watch": "vitest watch",
+    "test:e2e": "playwright test",
     "format": "oxfmt",
     "prepare": "husky && husky install",
     "gen:cdp": "ts-node --transpileOnly scripts/cdp/generateCdpClient.ts > src/utils/cdp/client.ts"
@@ -44,6 +45,7 @@
     "@electron-forge/plugin-vite": "7.11.2",
     "@electron-forge/publisher-github": "7.11.2",
     "@electron/fuses": "1.8.0",
+    "@playwright/test": "1.60.0",
     "@tanstack/eslint-plugin-query": "5.100.9",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
   fullyParallel: false,
   workers: 1,
   reporter: 'list',
-  timeout: 60_000,
+  // Per-test timeout covers fixture setup AND the test body. The appWindow
+  // fixture can wait up to 30s for the CDP port + 20s for the renderer, then the
+  // spec allows 20s for the first assertion (~70s worst case), so keep this
+  // comfortably above that ceiling to avoid cutting off a slow CI startup.
+  timeout: 120_000,
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test'
+
+// E2E smoke tests launch the packaged Electron app, so they cannot run in
+// parallel against a shared `out/` build and have no use for browser projects.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  workers: 1,
+  reporter: 'list',
+  timeout: 60_000,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       '@electron/fuses':
         specifier: 1.8.0
         version: 1.8.0
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@tanstack/eslint-plugin-query':
         specifier: 5.100.9
         version: 5.100.9(@typescript/typescript6@6.0.1)(eslint@8.57.1)
@@ -1874,6 +1877,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
@@ -4405,6 +4413,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -5536,6 +5549,16 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   plist@3.1.1:
     resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
@@ -8340,6 +8363,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.67.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@prisma/instrumentation@5.22.0':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -11067,6 +11094,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -12350,6 +12380,14 @@ snapshots:
   pidtree@0.6.0: {}
 
   pify@2.3.0: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plist@3.1.1:
     dependencies:

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -103,11 +103,11 @@ export function getBuildDefine(env: ConfigEnv<'build'>) {
             ? JSON.stringify(process.env[VITE_DEV_SERVER_URL])
             : undefined,
         [VITE_NAME]: JSON.stringify(name),
-        // Fall back to null (not undefined) so the define is always emitted --
+        // Fall back to '' (not undefined) so the define is always emitted --
         // vite drops defines whose value is undefined, which would leave the
         // bare SENTRY_DSN identifier in the bundle and crash creds-free builds.
-        // A null dsn simply disables Sentry.
-        [SENTRY_DSN]: JSON.stringify(process.env.SENTRY_DSN ?? null),
+        // An empty dsn simply disables Sentry.
+        [SENTRY_DSN]: JSON.stringify(process.env.SENTRY_DSN ?? ''),
       }
       return { ...acc, ...def }
     },

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -103,7 +103,11 @@ export function getBuildDefine(env: ConfigEnv<'build'>) {
             ? JSON.stringify(process.env[VITE_DEV_SERVER_URL])
             : undefined,
         [VITE_NAME]: JSON.stringify(name),
-        [SENTRY_DSN]: JSON.stringify(process.env.SENTRY_DSN),
+        // Fall back to null (not undefined) so the define is always emitted --
+        // vite drops defines whose value is undefined, which would leave the
+        // bare SENTRY_DSN identifier in the bundle and crash creds-free builds.
+        // A null dsn simply disables Sentry.
+        [SENTRY_DSN]: JSON.stringify(process.env.SENTRY_DSN ?? null),
       }
       return { ...acc, ...def }
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,12 @@
 import viteTsconfigPaths from 'vite-tsconfig-paths'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, configDefaults } from 'vitest/config'
 
 export default defineConfig({
   plugins: [viteTsconfigPaths()],
   test: {
     includeSource: ['src/**/*.{js,ts}'],
+    // e2e/ holds Playwright specs run via `pnpm test:e2e`, not vitest.
+    exclude: [...configDefaults.exclude, 'e2e/**'],
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
   },


### PR DESCRIPTION
## Description

Adds E2E smoke tests that package the real app with `electron-forge package` and launch it on macOS (Apple Silicon + Intel), Windows, and Linux, asserting the Home view renders. Nothing in CI currently builds the packaged app, so per-OS packaging, startup, and signing regressions only surface at release. The tests run via a new `smoke.yml` workflow, one native-arch leg per runner, triggered manually (`workflow_dispatch`), on PRs that touch packaging/startup/native files, and on release-please PRs.

Getting a creds-free build to launch needed a few changes: signing and notarization are gated to release, and creds-free macOS builds get a deep ad-hoc signature in a `postPackage` hook (Apple Silicon kills an invalidly-signed app on launch, and the fuses plugin re-signs the binary after packaging). This also fixes a latent crash where `SENTRY_DSN` was left undefined in the bundle when built without Sentry credentials.

Playwright drives the packaged app over Chromium's remote debugging port rather than `_electron.launch`, since the production fuses disable the Node inspector.

## How to Test

Locally, against your runner's native arch:

1. `pnpm package`
2. `pnpm test:e2e`

The app should package, launch, and the test pass. In CI, all four legs run automatically on this PR (it touches `forge.config.ts`, `e2e/**`, and the workflow); verify they go green.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)