### PR TITLE
internal(browser): Remove public preview notices and feature flags for browser functionality

### DIFF
--- a/src/components/Layout/ActivityBar/CreateNewPopover.test.tsx
+++ b/src/components/Layout/ActivityBar/CreateNewPopover.test.tsx
@@ -7,7 +7,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { useCreateBrowserTest } from '@/hooks/useCreateBrowserTest'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
-import { useFeaturesStore } from '@/store/features'
 
 import { CreateNewPopover } from './CreateNewPopover'
 
@@ -16,17 +15,9 @@ vi.mock('@/hooks/useCreateGenerator', () => ({ useCreateGenerator: vi.fn() }))
 vi.mock('@/hooks/useCreateBrowserTest', () => ({
   useCreateBrowserTest: vi.fn(),
 }))
-vi.mock('@/store/features', () => ({ useFeaturesStore: vi.fn() }))
 
 function renderWithTheme(ui: ReactElement) {
   return render(<Theme>{ui}</Theme>)
-}
-
-function setupFeatureFlag(isBrowserEditorEnabled: boolean) {
-  const state = {
-    features: { 'browser-test-editor': isBrowserEditorEnabled },
-  } as unknown as Parameters<Parameters<typeof useFeaturesStore>[0]>[0]
-  vi.mocked(useFeaturesStore).mockImplementation((selector) => selector(state))
 }
 
 async function openMenu(user: ReturnType<typeof userEvent.setup>) {
@@ -47,29 +38,17 @@ describe('CreateNewPopover', () => {
     vi.mocked(useCreateBrowserTest).mockReturnValue(createBrowserTest)
   })
 
-  it('hides Browser test entry when feature flag is off', async () => {
-    setupFeatureFlag(false)
-    const user = userEvent.setup()
-    renderWithTheme(<CreateNewPopover />)
-
-    await openMenu(user)
-
-    expect(screen.queryByRole('menuitem', { name: /browser test/i })).toBeNull()
-    expect(screen.getByRole('menuitem', { name: /http test/i })).toBeTruthy()
-  })
-
-  it('shows Browser test entry when feature flag is on', async () => {
-    setupFeatureFlag(true)
+  it('shows Browser test entry', async () => {
     const user = userEvent.setup()
     renderWithTheme(<CreateNewPopover />)
 
     await openMenu(user)
 
     expect(screen.getByRole('menuitem', { name: /browser test/i })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /http test/i })).toBeTruthy()
   })
 
   it('navigates to recorder when Recording is clicked', async () => {
-    setupFeatureFlag(true)
     const user = userEvent.setup()
     renderWithTheme(<CreateNewPopover />)
 
@@ -80,7 +59,6 @@ describe('CreateNewPopover', () => {
   })
 
   it('calls useCreateGenerator when HTTP test is clicked', async () => {
-    setupFeatureFlag(true)
     const user = userEvent.setup()
     renderWithTheme(<CreateNewPopover />)
 
@@ -92,7 +70,6 @@ describe('CreateNewPopover', () => {
   })
 
   it('calls useCreateBrowserTest when Browser test is clicked', async () => {
-    setupFeatureFlag(true)
     const user = userEvent.setup()
     renderWithTheme(<CreateNewPopover />)
 

--- a/src/components/Layout/ActivityBar/CreateNewPopover.tsx
+++ b/src/components/Layout/ActivityBar/CreateNewPopover.tsx
@@ -8,11 +8,8 @@ import { getRoutePath } from '@/routeMap'
 
 export function CreateNewPopover() {
   const navigate = useNavigate()
-  const {
-    handleCreateHTTPTest,
-    handleCreateBrowserTest,
-    isBrowserEditorEnabled,
-  } = useCreateTestActions()
+  const { handleCreateHTTPTest, handleCreateBrowserTest } =
+    useCreateTestActions()
 
   return (
     <DropdownMenu.Root>
@@ -36,14 +33,12 @@ export function CreateNewPopover() {
           description="Create a test from HTTP requests using rules"
           onClick={() => handleCreateHTTPTest()}
         />
-        {isBrowserEditorEnabled && (
-          <RichDropdownMenuItem
-            label="Browser test"
-            icon={<MonitorIcon />}
-            description="Create a test simulating browser interactions"
-            onClick={() => handleCreateBrowserTest()}
-          />
-        )}
+        <RichDropdownMenuItem
+          label="Browser test"
+          icon={<MonitorIcon />}
+          description="Create a test simulating browser interactions"
+          onClick={() => handleCreateBrowserTest()}
+        />
       </DropdownMenu.Content>
     </DropdownMenu.Root>
   )

--- a/src/components/NewTestMenu/CreateTestButton.tsx
+++ b/src/components/NewTestMenu/CreateTestButton.tsx
@@ -4,19 +4,8 @@ import { PlusIcon } from 'lucide-react'
 import { useCreateTestActions } from '@/hooks/useCreateTestActions'
 
 export function CreateTestButton() {
-  const {
-    handleCreateHTTPTest,
-    handleCreateBrowserTest,
-    isBrowserEditorEnabled,
-  } = useCreateTestActions()
-
-  if (!isBrowserEditorEnabled) {
-    return (
-      <Button size="1" variant="soft" onClick={() => handleCreateHTTPTest()}>
-        <PlusIcon /> Create test
-      </Button>
-    )
-  }
+  const { handleCreateHTTPTest, handleCreateBrowserTest } =
+    useCreateTestActions()
 
   return (
     <DropdownMenu.Root>

--- a/src/components/NewTestMenu/NewTestMenu.tsx
+++ b/src/components/NewTestMenu/NewTestMenu.tsx
@@ -4,26 +4,8 @@ import { PlusIcon } from 'lucide-react'
 import { useCreateTestActions } from '@/hooks/useCreateTestActions'
 
 export function NewTestMenu() {
-  const {
-    handleCreateHTTPTest,
-    handleCreateBrowserTest,
-    isBrowserEditorEnabled,
-  } = useCreateTestActions()
-
-  if (!isBrowserEditorEnabled) {
-    return (
-      <Tooltip content="New generator" side="right">
-        <IconButton
-          aria-label="New generator"
-          variant="ghost"
-          size="1"
-          onClick={() => handleCreateHTTPTest()}
-        >
-          <PlusIcon />
-        </IconButton>
-      </Tooltip>
-    )
-  }
+  const { handleCreateHTTPTest, handleCreateBrowserTest } =
+    useCreateTestActions()
 
   return (
     <DropdownMenu.Root>

--- a/src/hooks/useCreateTestActions.ts
+++ b/src/hooks/useCreateTestActions.ts
@@ -1,17 +1,12 @@
 import { useCreateBrowserTest } from '@/hooks/useCreateBrowserTest'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
-import { useFeaturesStore } from '@/store/features'
 
 export function useCreateTestActions() {
   const handleCreateHTTPTest = useCreateGenerator()
   const handleCreateBrowserTest = useCreateBrowserTest()
-  const isBrowserEditorEnabled = useFeaturesStore(
-    (state) => state.features['browser-test-editor']
-  )
 
   return {
     handleCreateHTTPTest,
     handleCreateBrowserTest,
-    isBrowserEditorEnabled,
   }
 }

--- a/src/store/features/useFeaturesStore.ts
+++ b/src/store/features/useFeaturesStore.ts
@@ -11,7 +11,6 @@ interface FeaturesStore {
 export const defaultFeatures: Record<Feature, boolean> = {
   'dummy-feature': false,
   'typeahead-json': false,
-  'browser-test-editor': import.meta.env.DEV,
 }
 
 export const useFeaturesStore = create<FeaturesStore>()(

--- a/src/types/features.ts
+++ b/src/types/features.ts
@@ -1,1 +1,1 @@
-export type Feature = 'dummy-feature' | 'typeahead-json' | 'browser-test-editor'
+export type Feature = 'dummy-feature' | 'typeahead-json'

--- a/src/views/Recorder/EmptyState.tsx
+++ b/src/views/Recorder/EmptyState.tsx
@@ -215,12 +215,7 @@ function BrowserEventsSection({ children }: BrowserEventsSectionProps) {
     <Flex direction="column" gap="1">
       <Text size="2" weight="medium">
         <Flex align="center" gap="1">
-          <span>
-            Browser Events{' '}
-            <Text size="1" weight="light">
-              (Preview)
-            </Text>
-          </span>
+          <span>Browser Events</span>
           <Tooltip
             content={
               <>

--- a/src/views/Recorder/RecordingInspector.tsx
+++ b/src/views/Recorder/RecordingInspector.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react'
 import { Badge, Tabs } from '@radix-ui/themes'
-import { FlaskConical } from 'lucide-react'
 
 import { Flex } from '@/components/primitives/Flex'
 import { BrowserEvent } from '@/schemas/recording'
@@ -59,14 +58,6 @@ export function RecordingInspector({
           disabled={browserEvents.length === 0}
         >
           <Flex align="center" gap="1">
-            <FlaskConical
-              css={css`
-                width: 1em;
-                height: 1em;
-                margin-right: 0.25em;
-              `}
-              strokeWidth={1.5}
-            />
             Browser events
             <Badge
               radius="full"

--- a/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
+++ b/src/views/RecordingPreviewer/RecordingPreviewerControls.tsx
@@ -7,17 +7,13 @@ import {
 } from 'lucide-react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 
-import { emitScript } from '@/codegen/browser'
 import { convertEventsToActions } from '@/codegen/browser/convertEventsToActions'
-import { convertEventsToTest } from '@/codegen/browser/test'
 import { RichDropdownMenuItem } from '@/components/RichDropdownMenuItem'
 import { useCreateBrowserTest } from '@/hooks/useCreateBrowserTest'
 import { useCreateGenerator } from '@/hooks/useCreateGenerator'
 import { useDeleteFile } from '@/hooks/useDeleteFile'
-import { useExportScript } from '@/hooks/useExportScript'
 import { getRoutePath } from '@/routeMap'
 import { BrowserEvent } from '@/schemas/recording'
-import { useFeaturesStore } from '@/store/features'
 import { ProxyData, StudioFile } from '@/types'
 
 interface RecordingPreviewControlsProps {
@@ -41,9 +37,6 @@ export function RecordingPreviewControls({
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const isDiscardable = Boolean(state?.discardable)
 
-  const isBrowserEditorEnabled = useFeaturesStore(
-    (state) => state.features['browser-test-editor']
-  )
   const createBrowserTest = useCreateBrowserTest()
 
   const handleCreateGenerator = () => createTestGenerator(file.path)
@@ -52,10 +45,6 @@ export function RecordingPreviewControls({
     const actions = convertEventsToActions(browserEvents)
     void createBrowserTest(actions)
   }
-
-  const browserTestDescription = isBrowserEditorEnabled
-    ? 'Create a browser test from recorded interactions'
-    : 'Export a k6 script simulating browser interactions'
 
   const handleDelete = useDeleteFile({
     file,
@@ -71,27 +60,6 @@ export function RecordingPreviewControls({
     handleDelete()
     navigate(getRoutePath('home'))
   }
-
-  const exportScript = useExportScript({
-    enableMenuItem: browserEvents.length > 0,
-    openOnSave: true,
-    fileName: 'my-browser-script.js',
-    content: async () => {
-      const test = convertEventsToTest({
-        browserEvents,
-      })
-
-      return await emitScript(test)
-    },
-  })
-
-  const handleExportBrowserScript = () => {
-    void exportScript()
-  }
-
-  const handleBrowserTest = isBrowserEditorEnabled
-    ? handleCreateBrowserTest
-    : handleExportBrowserScript
 
   return (
     <>
@@ -121,9 +89,9 @@ export function RecordingPreviewControls({
           <RichDropdownMenuItem
             icon={<MonitorIcon />}
             label="Browser test"
-            description={browserTestDescription}
+            description="Create a browser test from recorded interactions"
             disabled={browserEvents.length === 0}
-            onSelect={handleBrowserTest}
+            onSelect={handleCreateBrowserTest}
           />
         </DropdownMenu.Content>
       </DropdownMenu.Root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I think it's time that we removed the public preview and feature flags for browser test authoring.

## How to Test

* Check that all menus create browser tests instead of exports browser scripts
* No mention of public preview should be made
* The experimental icon on the browser events tab should be removed

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and feature-flag cleanup only; behavior change is enabling browser test flows that were previously gated, with no auth or data-layer changes.
> 
> **Overview**
> **Browser test authoring is no longer behind the `browser-test-editor` feature flag.** Create menus always show HTTP and browser test options, and recording preview always creates a browser test from events instead of optionally exporting a k6 script.
> 
> The **`browser-test-editor`** entry is removed from the features store and `Feature` type. **`useCreateTestActions`** no longer exposes `isBrowserEditorEnabled`. **Preview UI** drops the “(Preview)” label on browser events in the recorder empty state and the experimental icon on the browser events tab. **Tests** drop feature-flag setup and assert the browser test menu item is always present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f812c48d9a5c4add0dc3321a2ed2e58d2c3234af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->