### PR TITLE
build: Allow MSI builds when building test versions

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -9,6 +9,12 @@ on:
         required: false
         default: ""
 
+      msi:
+        description: "Whether to build the MSI installer (default: false)"
+        required: false
+        type: boolean
+        default: false
+
 permissions: {}
 
 jobs:
@@ -167,6 +173,8 @@ jobs:
           # sentry vite plugin integration during build
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+          # Whether the build should include the MSI installer
+          BUILD_MSI_INSTALLER: ${{ inputs.msi }}
         run: pnpm run publish
 
       - name: publish Linux

--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -11,7 +11,7 @@ on:
         default: "test-version"
 
       msi:
-        description: "Whether to build the MSI installer (default: false)"
+        description: "Build the MSI installer"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/release-test-version.yml
+++ b/.github/workflows/release-test-version.yml
@@ -1,14 +1,20 @@
-name: 'Manual Release Test Version'
+name: "Manual Release Test Version"
 
 on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Specify a version suffix for the test release (limit to 20
-          characters or windows build will fail)'
+        description: "Specify a version suffix for the test release (limit to 20
+          characters or windows build will fail)"
         required: true
         type: string
-        default: 'test-version'
+        default: "test-version"
+
+      msi:
+        description: "Whether to build the MSI installer (default: false)"
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -33,4 +39,5 @@ jobs:
     uses: ./.github/workflows/release-base.yml
     with:
       version-suffix: ${{ inputs.version }}
+      msi: ${{ inputs.msi }}
     secrets: inherit

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -182,7 +182,6 @@ const config: ForgeConfig = {
     }),
     process.env.BUILD_MSI_INSTALLER === 'true' &&
       new MakerWix({
-        name: 'k6 Studio',
         manufacturer: 'Grafana Labs',
         icon: './resources/icons/logo.ico',
         features: {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -163,6 +163,15 @@ const config: ForgeConfig = {
       ui: {
         chooseDirectory: true,
       },
+      // Use custom WiX template that points shortcuts directly to the real exe
+      // in the versioned subfolder, bypassing the broken stub launcher
+      // (see https://github.com/electron-userland/electron-wix-msi/issues/161)
+      beforeCreate: async (creator) => {
+        creator.wixTemplate = fs.readFileSync(
+          path.join(__dirname, 'resources', 'wix-template.xml'),
+          'utf-8'
+        )
+      },
     }),
     new MakerZIP({}, ['darwin']),
     new MakerDMG(

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -153,26 +153,27 @@ const config: ForgeConfig = {
       iconUrl:
         'https://raw.githubusercontent.com/grafana/k6-studio/refs/heads/main/resources/icons/logo.ico',
     }),
-    new MakerWix({
-      manufacturer: 'Grafana Labs',
-      icon: './resources/icons/logo.ico',
-      features: {
-        autoUpdate: false,
-        autoLaunch: false,
-      },
-      ui: {
-        chooseDirectory: true,
-      },
-      // Use custom WiX template that points shortcuts directly to the real exe
-      // in the versioned subfolder, bypassing the broken stub launcher
-      // (see https://github.com/electron-userland/electron-wix-msi/issues/161)
-      beforeCreate: async (creator) => {
-        creator.wixTemplate = fs.readFileSync(
-          path.join(__dirname, 'resources', 'wix-template.xml'),
-          'utf-8'
-        )
-      },
-    }),
+    process.env.BUILD_MSI_INSTALLER === 'true' &&
+      new MakerWix({
+        manufacturer: 'Grafana Labs',
+        icon: './resources/icons/logo.ico',
+        features: {
+          autoUpdate: false,
+          autoLaunch: false,
+        },
+        ui: {
+          chooseDirectory: true,
+        },
+        // Use custom WiX template that points shortcuts directly to the real exe
+        // in the versioned subfolder, bypassing the broken stub launcher
+        // (see https://github.com/electron-userland/electron-wix-msi/issues/161)
+        beforeCreate: (creator) => {
+          creator.wixTemplate = fs.readFileSync(
+            path.join(__dirname, 'resources', 'wix-template.xml'),
+            'utf-8'
+          )
+        },
+      }),
     new MakerZIP({}, ['darwin']),
     new MakerDMG(
       {
@@ -187,7 +188,7 @@ const config: ForgeConfig = {
         mimeType: [`x-scheme-handler/${CUSTOM_APP_PROTOCOL}`],
       },
     }),
-  ],
+  ].filter((value) => value !== false),
   plugins: [
     new VitePlugin({
       // `build` can specify multiple entry builds, which can be Main process, Preload scripts, Worker process, etc.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -182,6 +182,7 @@ const config: ForgeConfig = {
     }),
     process.env.BUILD_MSI_INSTALLER === 'true' &&
       new MakerWix({
+        name: 'k6 Studio',
         manufacturer: 'Grafana Labs',
         icon: './resources/icons/logo.ico',
         features: {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -92,7 +92,34 @@ function getPostMakeHook() {
       .map((filePath) => spawnSignFile(filePath))
 
     await Promise.all(signingPromises)
-    return makeResults
+
+    return await Promise.all(
+      makeResults.map(async (result) => {
+        const artifacts = await Promise.all(
+          result.artifacts.map(async (artifact) => {
+            const parsed = path.parse(artifact)
+
+            if (parsed.ext.toLowerCase() !== '.msi') {
+              return artifact
+            }
+
+            // Rename the MSI file to follow pattern of other artifacts
+            // oxlint-disable-next-line typescript/no-unsafe-member-access
+            const newArtifact = `k6.Studio-${result.packageJSON.version}-${result.arch}.msi`
+            const newArtifactPath = path.join(parsed.dir, newArtifact)
+
+            await fs.promises.rename(artifact, newArtifactPath)
+
+            return newArtifactPath
+          })
+        )
+
+        return {
+          ...result,
+          artifacts,
+        }
+      })
+    )
   }
 }
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -2,6 +2,7 @@ import { MakerDeb } from '@electron-forge/maker-deb'
 import { MakerDMG } from '@electron-forge/maker-dmg'
 import { MakerRpm } from '@electron-forge/maker-rpm'
 import { MakerSquirrel } from '@electron-forge/maker-squirrel'
+import { MakerWix } from '@electron-forge/maker-wix'
 import { MakerZIP } from '@electron-forge/maker-zip'
 import { FusesPlugin } from '@electron-forge/plugin-fuses'
 import { VitePlugin } from '@electron-forge/plugin-vite'
@@ -151,6 +152,17 @@ const config: ForgeConfig = {
     new MakerSquirrel({
       iconUrl:
         'https://raw.githubusercontent.com/grafana/k6-studio/refs/heads/main/resources/icons/logo.ico',
+    }),
+    new MakerWix({
+      manufacturer: 'Grafana Labs',
+      icon: './resources/icons/logo.ico',
+      features: {
+        autoUpdate: false,
+        autoLaunch: false,
+      },
+      ui: {
+        chooseDirectory: true,
+      },
     }),
     new MakerZIP({}, ['darwin']),
     new MakerDMG(

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@electron-forge/maker-dmg": "7.11.2",
     "@electron-forge/maker-rpm": "7.11.2",
     "@electron-forge/maker-squirrel": "7.11.2",
+    "@electron-forge/maker-wix": "^7.11.2",
     "@electron-forge/maker-zip": "7.11.2",
     "@electron-forge/plugin-auto-unpack-natives": "7.11.2",
     "@electron-forge/plugin-fuses": "7.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,9 @@ importers:
       '@electron-forge/maker-squirrel':
         specifier: 7.11.2
         version: 7.11.2
+      '@electron-forge/maker-wix':
+        specifier: ^7.11.2
+        version: 7.11.2
       '@electron-forge/maker-zip':
         specifier: 7.11.2
         version: 7.11.2
@@ -697,6 +700,9 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@bitdisaster/exe-icon-extractor@1.0.10':
+    resolution: {integrity: sha512-iTZ8cVGZ5dglNRyFdSj8U60mHIrC8XNIuOHN/NkM5/dQP4nsmpyqeQTAADLLQgoFCNJD+DiwQCv8dR2cCeWP4g==}
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -788,6 +794,10 @@ packages:
 
   '@electron-forge/maker-squirrel@7.11.2':
     resolution: {integrity: sha512-4CILo57ZDEQH1mJxjhYCSXuv+WaU7oPq67KqiTLEUOEzmiPg9u9/z7FXE34H/Tn5aKWN3dy+ngAETzv6iERCGg==}
+    engines: {node: '>= 16.4.0'}
+
+  '@electron-forge/maker-wix@7.11.2':
+    resolution: {integrity: sha512-uf+wmWCqTA23m0KabkQT7m+lyEtdB/Hbtn9Rb8KVSK4FPLrcSC/glYLlHKJhg6DikQraZVfD8JcUPKyZ1YTX2A==}
     engines: {node: '>= 16.4.0'}
 
   '@electron-forge/maker-zip@7.11.2':
@@ -3816,6 +3826,10 @@ packages:
   cross-dirname@0.1.0:
     resolution: {integrity: sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==}
 
+  cross-spawn-windows-exe@1.2.0:
+    resolution: {integrity: sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==}
+    engines: {node: '>= 10'}
+
   cross-spawn@6.0.6:
     resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
     engines: {node: '>=4.8'}
@@ -4024,6 +4038,10 @@ packages:
   electron-winstaller@5.4.0:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
+
+  electron-wix-msi@5.1.3:
+    resolution: {integrity: sha512-EYj1cm1nZoVHmIIx3o0aKt784lxdEpJnXbEnyypklUCnglqSb7ni+1xi1Vp/gtrGS/mzIxnWBT+x5fIfuDjhvA==}
+    engines: {node: '>=14.0.0'}
 
   electron@42.3.0:
     resolution: {integrity: sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==}
@@ -4664,6 +4682,11 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -4732,6 +4755,10 @@ packages:
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
 
   isbinaryfile@4.0.10:
     resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
@@ -4828,6 +4855,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  klaw@4.1.0:
+    resolution: {integrity: sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==}
+    engines: {node: '>=14.14.0'}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5687,6 +5718,14 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rcedit@4.0.1:
+    resolution: {integrity: sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==}
+    engines: {node: '>= 14.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  rcinfo@0.1.3:
+    resolution: {integrity: sha512-c2XV2aYgY7x3BscO+/B/nCTtMvnclZ8w5D7R6zgK4sGOQnE0MjlXhOPynno7yp6Iw1RPNSXBwXwB1svZVRfcSw==}
 
   react-base16-styling@0.10.0:
     resolution: {integrity: sha512-H1k2eFB6M45OaiRru3PBXkuCcn2qNmx+gzLb4a9IPMR7tMH8oBRXU5jGbPDYG1Hz+82d88ED0vjR8BmqU3pQdg==}
@@ -6995,6 +7034,9 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@bitdisaster/exe-icon-extractor@1.0.10':
+    optional: true
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -7176,6 +7218,19 @@ snapshots:
       fs-extra: 10.1.0
     optionalDependencies:
       electron-winstaller: 5.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron-forge/maker-wix@7.11.2':
+    dependencies:
+      '@electron-forge/core-utils': 7.11.2
+      '@electron-forge/maker-base': 7.11.2
+      '@electron-forge/shared-types': 7.11.2
+      chalk: 4.1.2
+      electron-wix-msi: 5.1.3
+      log-symbols: 4.1.0
+      parse-author: 2.0.0
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7813,7 +7868,6 @@ snapshots:
   '@malept/cross-spawn-promise@1.1.1':
     dependencies:
       cross-spawn: 7.0.6
-    optional: true
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -10361,6 +10415,12 @@ snapshots:
 
   cross-dirname@0.1.0: {}
 
+  cross-spawn-windows-exe@1.2.0:
+    dependencies:
+      '@malept/cross-spawn-promise': 1.1.1
+      is-wsl: 2.2.0
+      which: 2.0.2
+
   cross-spawn@6.0.6:
     dependencies:
       nice-try: 1.0.5
@@ -10597,6 +10657,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  electron-wix-msi@5.1.3:
+    dependencies:
+      '@electron/windows-sign': 1.2.2
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      klaw: 4.1.0
+      lodash: 4.18.1
+      rcedit: 4.0.1
+      rcinfo: 0.1.3
+      semver: 7.7.4
+    optionalDependencies:
+      '@bitdisaster/exe-icon-extractor': 1.0.10
+    transitivePeerDependencies:
+      - supports-color
 
   electron@42.3.0:
     dependencies:
@@ -11376,6 +11451,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-docker@2.2.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -11426,6 +11503,10 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-url@1.2.4: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
 
   isbinaryfile@4.0.10: {}
 
@@ -11520,6 +11601,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  klaw@4.1.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -12540,6 +12623,12 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rcedit@4.0.1:
+    dependencies:
+      cross-spawn-windows-exe: 1.2.0
+
+  rcinfo@0.1.3: {}
 
   react-base16-styling@0.10.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@
 nodeLinker: hoisted
 
 allowBuilds:
+  '@bitdisaster/exe-icon-extractor': true
   '@sentry/cli': true
   electron: true
   electron-winstaller: true

--- a/resources/wix-template.xml
+++ b/resources/wix-template.xml
@@ -1,0 +1,116 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <Product Id="{{ProductCode}}"
+           UpgradeCode="{{UpgradeCode}}"
+           Name = "{{ApplicationName}} (Machine - MSI)"
+           Version="{{Version}}"
+           Manufacturer="{{Manufacturer}}"
+           Language="{{Language}}">
+    <Package InstallerVersion="405"
+             Compressed="yes"
+             Comments="Windows Installer Package"
+             Platform="{{Platform}}"
+             InstallScope="{{PackageScope}}"/>
+    <MajorUpgrade AllowSameVersionUpgrades="yes" DowngradeErrorMessage="A later version of this product is already installed. Setup will now exit."/>
+    <Property Id="ARPSYSTEMCOMPONENT" Value="1" />
+    <Property Id="VisibleProductName" Value="{{ApplicationName}} (Machine)" />
+    <Property Id="MSIINSTALLPERUSER" Secure="yes" Value="{{InstallPerUser}}" />
+    <Property Id="REINSTALLMODE" Value="emus" />
+    <Property Id="REBOOT" Value="{{RebootMode}}" />
+    <Property Id="INSTALLLEVEL" Value="{{InstallLevel}}" />
+    <Property Id="UPDATERUSERGROUP" Value="Users" />
+    <Property Id="AUTOUPDATEENABLED" Value="1" />
+    <Property Id="INSTALLPATH">
+      <RegistrySearch Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{{{ProductCode}}}.msq"
+                      Root="HKCU"
+                      Type="raw"
+                      Id="INSTALLPATH_REGSEARCH_HKCU"
+                      Name="InstallPath"
+                      Win64="{{Win64YesNo}}"/>
+      <RegistrySearch Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{{{ProductCode}}}.msq"
+                      Root="HKLM"
+                      Type="raw"
+                      Id="INSTALLPATH_REGSEARCH_HKLM"
+                      Name="InstallPath"
+                      Win64="{{Win64YesNo}}"/>
+    </Property>
+    <SetProperty Action="SetVisibleProductName" Id="VisibleProductName" Sequence="both" Before="AppSearch"  Value="{{ApplicationName}} (User)">
+      <![CDATA[MSIINSTALLPERUSER = "1"]]>
+    </SetProperty>
+    <SetProperty Action="SetProductName" Id="ProductName" Sequence="both" Before="AppSearch"  Value="{{ApplicationName}} (User - MSI)">
+      <![CDATA[MSIINSTALLPERUSER = "1"]]>
+    </SetProperty>
+
+    <Media Id="1" Cabinet="product.cab" EmbedCab="yes"/>
+<!-- {{Icon}}-->
+<!-- {{UI}} -->
+
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="{{ProgramFilesFolder}}">
+<!-- {{Directories}} -->
+      </Directory>
+
+      <Directory Id="DesktopFolder" Name="Desktop" />
+
+      <Directory Id="ProgramMenuFolder">
+        <Directory Id="ApplicationProgramsFolder" Name="{{ShortcutFolderName}}"/>
+      </Directory>
+    </Directory>
+
+    <!-- Start Menu shortcut - targets the real exe in versioned subfolder, bypassing broken stub -->
+    <DirectoryRef Id="ApplicationProgramsFolder">
+      <Component Id="ApplicationShortcut" Guid="{{ApplicationShortcutGuid}}" Win64="{{Win64YesNo}}">
+        <Shortcut Id="ApplicationStartMenuShortcut"
+                  Name="{{ShortcutName}}"
+                  Description="{{ApplicationDescription}}"
+                  Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\{{ApplicationBinary}}.exe"
+                  WorkingDirectory="APPLICATIONROOTDIRECTORY">
+<!-- {{ShortcutProperties}} -->
+        </Shortcut>
+        <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+        <RegistryValue Root="HKCU"
+                       Key="Software\Microsoft\{{ApplicationShortName}}"
+                       Name="installed"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes"/>
+      </Component>
+    </DirectoryRef>
+
+    <!-- Desktop shortcut - targets the real exe in versioned subfolder, bypassing broken stub -->
+    <DirectoryRef Id="DesktopFolder">
+      <Component Id="DesktopShortcut" Guid="{{DesktopShortcutGuid}}" >
+          <Shortcut Id="MyDesktopShortcut"
+                    Name="{{ShortcutName}}"
+                    Description="{{ApplicationDescription}}"
+                    Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\{{ApplicationBinary}}.exe"
+                    WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
+          <RegistryValue Root="HKCU"
+                    Key="Software\Microsoft\{{ApplicationShortName}}"
+                    Name="installed"
+                    Type="integer"
+                    Value="1"
+                    KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <DirectoryRef Id="APPLICATIONROOTDIRECTORY">
+      <Component Id="PurgeOnUninstall" Guid="{{RandomGuid}}" Win64="{{Win64YesNo}}">
+        <CreateFolder/>
+        <util:RemoveFolderEx On="uninstall" Property="INSTALLPATH" />
+      </Component>
+    </DirectoryRef>
+
+    <Feature Id="Complete" Title="{{ApplicationName}} ({{SemanticVersion}})" Description="The complete package." Display="expand" Level="1" {{ConfigurableDirectory}}>
+      <Feature Id="MainApplication" Title="Main Application" Level="1" Description="The main components to run the applications." >
+<!-- {{ComponentRefs}} -->
+        <ComponentRef Id="ApplicationShortcut" />
+        <ComponentRef Id="DesktopShortcut" />
+        <ComponentRef Id="PurgeOnUninstall" />
+      </Feature>
+<!-- {{AutoLaunchFeature}} -->
+<!-- {{AutoUpdateFeature}} -->
+    </Feature>
+<!-- {{AutoRun}} -->
+  </Product>
+</Wix>

--- a/resources/wix-template.xml
+++ b/resources/wix-template.xml
@@ -63,7 +63,7 @@
         <Shortcut Id="ApplicationStartMenuShortcut"
                   Name="{{ShortcutName}}"
                   Description="{{ApplicationDescription}}"
-                  Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\{{ApplicationBinary}}.exe"
+                  Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\k6-studio.exe"
                   WorkingDirectory="APPLICATIONROOTDIRECTORY">
 <!-- {{ShortcutProperties}} -->
         </Shortcut>
@@ -83,7 +83,7 @@
           <Shortcut Id="MyDesktopShortcut"
                     Name="{{ShortcutName}}"
                     Description="{{ApplicationDescription}}"
-                    Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\{{ApplicationBinary}}.exe"
+                    Target="[APPLICATIONROOTDIRECTORY]app-{{SemanticVersion}}\k6-studio.exe"
                     WorkingDirectory="APPLICATIONROOTDIRECTORY"/>
           <RegistryValue Root="HKCU"
                     Key="Software\Microsoft\{{ApplicationShortName}}"

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import { configureSystemProxy } from './services/http'
 import { initEventTracking } from './services/usageTracking'
 import { ProxyStatus } from './types'
 import { getAppIcon, getPlatform } from './utils/electron'
+import { isMsiInstall } from './utils/installationType'
 import { setupProjectStructure } from './utils/workspace'
 
 if (process.env.NODE_ENV !== 'development') {
@@ -42,14 +43,16 @@ if (process.env.NODE_ENV !== 'development') {
     },
   })
 
-  // update-electron-app swallows autoUpdater errors at info level via its
-  // default logger, so we capture them directly to surface silent failures.
-  autoUpdater.on('error', (err) => {
-    Sentry.captureException(err, { tags: { component: 'autoUpdater' } })
-  })
+  if (!isMsiInstall()) {
+    // update-electron-app swallows autoUpdater errors at info level via its
+    // default logger, so we capture them directly to surface silent failures.
+    autoUpdater.on('error', (err) => {
+      Sentry.captureException(err, { tags: { component: 'autoUpdater' } })
+    })
 
-  // handle auto updates
-  updateElectronApp({ logger: log.scope('autoUpdater') })
+    // handle auto updates
+    updateElectronApp({ logger: log.scope('autoUpdater') })
+  }
 }
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/src/utils/installationType.ts
+++ b/src/utils/installationType.ts
@@ -1,0 +1,9 @@
+import { app } from 'electron'
+
+export function isMsiInstall(): boolean {
+  const exePath = app.getPath('exe')
+  return (
+    exePath.includes('\\Program Files') ||
+    exePath.includes('\\Program Files (x86)')
+  )
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for building MSI files for Windows in the "Manual Release Test Version" workflow. The workflow now includes a checkbox to build MSI (turned off by default).

## How to Test

Build a test version from this branch, install on Windows using the MSI files and check that everything works as expected.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
