### PR TITLE
internal: Remove feature preview labels from autocorrelation

### DIFF
--- a/src/views/Generator/AutoCorrelation/IntroductionMessage.tsx
+++ b/src/views/Generator/AutoCorrelation/IntroductionMessage.tsx
@@ -1,13 +1,5 @@
 import { css } from '@emotion/react'
-import {
-  Badge,
-  Button,
-  Callout,
-  Flex,
-  Spinner,
-  Text,
-  Tooltip,
-} from '@radix-ui/themes'
+import { Button, Callout, Flex, Spinner, Text, Tooltip } from '@radix-ui/themes'
 import {
   AlertTriangleIcon,
   CheckCircleIcon,
@@ -106,9 +98,6 @@ export function IntroductionMessage({ onStart }: IntroductionMessageProps) {
         onStart={onStart}
         connectError={signIn.error}
       />
-      <Text size="1" color="gray" mt="1">
-        This feature is in public preview and subject to change.
-      </Text>
     </IntroLayout>
   )
 }
@@ -233,9 +222,6 @@ function IntroLayout({
         maxWidth="600px"
         css={{ textAlign: 'center' }}
       >
-        <Badge color="orange" variant="soft">
-          Feature Preview
-        </Badge>
         <Text size="3" weight="bold">
           Automatically correlate dynamic values
         </Text>


### PR DESCRIPTION
## Description

<!-- A short (or detailed) description of what this PR does and why these changes are needed -->
<!-- Include screenshots if applicable -->

Removes the "Feature Preview" badge and the "This feature is in public preview and subject to change." disclaimer from the autocorrelation introduction screen, since the feature is no longer in preview.

## How to Test

<!--- Please describe in detail how you tested your changes -->

1. Open a test generator and click "Autocorrelate" in the rules panel.
2. The introduction screen shows neither the orange "Feature Preview" badge nor the public preview disclaimer.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->