### PR TITLE
fix: Keep web security enabled in recording and validation browsers

### DIFF
--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -20,6 +20,31 @@ function isTopLevelFrame() {
   }
 }
 
+// Serialization options must match between the top frame and child frames:
+// with `recordCrossOriginIframes`, each frame serializes its own document and
+// rrweb stitches the events together in the top frame's stream.
+const RECORD_OPTIONS = {
+  blockSelector: "link[rel='modulepreload']",
+  inlineImages: true,
+  inlineStylesheet: true,
+  collectFonts: true,
+  slimDOMOptions: true,
+  // The browser runs with web security enabled, so the top frame's serializer
+  // can't reach into cross-origin iframe documents. Instead rrweb records
+  // inside each frame (this script is a context init script, so it runs in
+  // every frame) and forwards child events to the top frame over postMessage.
+  recordCrossOriginIframes: true,
+} as const
+
+if (trackingServerUrl !== null && !isTopLevelFrame()) {
+  // Child frame: serialize locally and let rrweb forward events to the top
+  // frame. The emit callback is required by the API but never called here.
+  record({
+    ...RECORD_OPTIONS,
+    emit() {},
+  })
+}
+
 if (trackingServerUrl !== null && isTopLevelFrame()) {
   let buffer: BrowserReplayEvent[] = [
     {
@@ -66,11 +91,7 @@ if (trackingServerUrl !== null && isTopLevelFrame()) {
   }, 200)
 
   record({
-    blockSelector: "link[rel='modulepreload']",
-    inlineImages: true,
-    inlineStylesheet: true,
-    collectFonts: true,
-    slimDOMOptions: true,
+    ...RECORD_OPTIONS,
     emit(event) {
       buffer.push(event)
     },

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -62,6 +62,31 @@ if (trackingServerUrl !== null && isTopLevelFrame()) {
     },
   ]
 
+  // The periodic sender below loses whatever is still buffered when the
+  // document tears down. That reliably includes cross-origin iframe content:
+  // a child frame's snapshot arrives over postMessage after the parent's own
+  // events, so a test that closes the page right after load drops it every
+  // time. keepalive lets the request outlive the document (best effort, the
+  // browser caps keepalive bodies at 64KB).
+  window.addEventListener('pagehide', () => {
+    if (buffer.length === 0) {
+      return
+    }
+
+    const events = buffer
+
+    buffer = []
+
+    void fetch(`${trackingServerUrl}/session-replay`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ events }),
+      keepalive: true,
+    }).catch(() => {
+      // The events are lost either way once the document is gone.
+    })
+  })
+
   setTimeout(async function send() {
     if (buffer.length > 0) {
       const events = buffer

--- a/src/main/script.ts
+++ b/src/main/script.ts
@@ -25,14 +25,13 @@ import { configureOptions, getDebugTarget } from './runner/utils'
 
 export type K6Process = ChildProcessWithoutNullStreams
 
-// Disable web security and site isolation so cross-origin (and nested) iframes
-// render in the same process, where the generated test's frameLocator chains can
-// reach them. The validator is authoring-only, so this matches the recorder.
+// Disable site isolation so cross-origin (and nested) iframes render in the
+// same process, where the generated test's frameLocator chains can reach them.
+// Web security stays on so SPA IdP logins keep their Origin headers.
 // K6_BROWSER_ARGS is split on every comma by k6, so each flag must be comma-free
 // (hence `disable-features=site-per-process` alone, not the recorder's
 // `IsolateOrigins,site-per-process`).
 const VALIDATOR_BROWSER_SECURITY_ARGS = [
-  'disable-web-security',
   'disable-features=site-per-process',
   'disable-site-isolation-trials',
 ]

--- a/src/recorder/browser/emitQueue.test.ts
+++ b/src/recorder/browser/emitQueue.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
+
+import { createSequentialEmitter } from './emitQueue'
+
+const makeEvent = (eventId: string): BrowserEvent => ({
+  type: 'navigate-to-page',
+  eventId,
+  timestamp: 1,
+  tab: 'tab-1',
+  url: 'http://example.test',
+  source: 'address-bar',
+})
+
+describe('createSequentialEmitter', () => {
+  it('attaches the resolved frame path to every event', async () => {
+    const frames: BrowserEventTarget[] = [
+      { selectors: { css: 'iframe#outer' } },
+    ]
+    const sent: BrowserEvent[][] = []
+
+    const emit = createSequentialEmitter(
+      () => Promise.resolve(frames),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent).toEqual([[{ ...makeEvent('first'), frames }]])
+  })
+
+  it('preserves emission order when earlier paths resolve slower', async () => {
+    const sent: BrowserEvent[][] = []
+    let resolveFirst: (path: BrowserEventTarget[]) => void = () => undefined
+
+    const paths = [
+      new Promise<BrowserEventTarget[]>((resolve) => {
+        resolveFirst = resolve
+      }),
+      Promise.resolve<BrowserEventTarget[]>([]),
+    ]
+
+    const emit = createSequentialEmitter(
+      () => paths.shift() ?? Promise.resolve([]),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+    emit(makeEvent('second'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent).toEqual([])
+
+    resolveFirst([])
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent.flat().map((event) => event.eventId)).toEqual([
+      'first',
+      'second',
+    ])
+  })
+
+  it('keeps emitting after a path lookup rejects', async () => {
+    const sent: BrowserEvent[][] = []
+
+    const paths = [
+      Promise.reject<BrowserEventTarget[]>(new Error('boom')),
+      Promise.resolve<BrowserEventTarget[]>([]),
+    ]
+
+    const emit = createSequentialEmitter(
+      () => paths.shift() ?? Promise.resolve([]),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+    emit(makeEvent('second'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent.flat().map((event) => event.eventId)).toEqual([
+      'first',
+      'second',
+    ])
+  })
+})

--- a/src/recorder/browser/emitQueue.test.ts
+++ b/src/recorder/browser/emitQueue.test.ts
@@ -88,4 +88,28 @@ describe('createSequentialEmitter', () => {
       'second',
     ])
   })
+
+  it('keeps emitting after send throws', async () => {
+    const sent: BrowserEvent[][] = []
+    let shouldThrow = true
+
+    const emit = createSequentialEmitter(
+      () => Promise.resolve([]),
+      (events) => {
+        if (shouldThrow) {
+          shouldThrow = false
+          throw new Error('transport down')
+        }
+
+        sent.push(events)
+      }
+    )
+
+    emit(makeEvent('first'))
+    emit(makeEvent('second'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent.flat().map((event) => event.eventId)).toEqual(['second'])
+  })
 })

--- a/src/recorder/browser/emitQueue.test.ts
+++ b/src/recorder/browser/emitQueue.test.ts
@@ -20,7 +20,7 @@ describe('createSequentialEmitter', () => {
     ]
     const sent: BrowserEvent[][] = []
 
-    const emit = createSequentialEmitter(
+    const { emit } = createSequentialEmitter(
       () => Promise.resolve(frames),
       (events) => sent.push(events)
     )
@@ -43,7 +43,7 @@ describe('createSequentialEmitter', () => {
       Promise.resolve<BrowserEventTarget[]>([]),
     ]
 
-    const emit = createSequentialEmitter(
+    const { emit } = createSequentialEmitter(
       () => paths.shift() ?? Promise.resolve([]),
       (events) => sent.push(events)
     )
@@ -73,7 +73,7 @@ describe('createSequentialEmitter', () => {
       Promise.resolve<BrowserEventTarget[]>([]),
     ]
 
-    const emit = createSequentialEmitter(
+    const { emit } = createSequentialEmitter(
       () => paths.shift() ?? Promise.resolve([]),
       (events) => sent.push(events)
     )
@@ -93,7 +93,7 @@ describe('createSequentialEmitter', () => {
     const sent: BrowserEvent[][] = []
     let shouldThrow = true
 
-    const emit = createSequentialEmitter(
+    const { emit } = createSequentialEmitter(
       () => Promise.resolve([]),
       (events) => {
         if (shouldThrow) {
@@ -111,5 +111,64 @@ describe('createSequentialEmitter', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(sent.flat().map((event) => event.eventId)).toEqual(['second'])
+  })
+
+  it('flushes queued events immediately without waiting for the frame path', () => {
+    const sent: BrowserEvent[][] = []
+
+    const { emit, flush } = createSequentialEmitter(
+      () => new Promise<BrowserEventTarget[]>(() => undefined),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+    emit(makeEvent('second'))
+
+    flush()
+
+    expect(sent.flat()).toEqual([makeEvent('first'), makeEvent('second')])
+  })
+
+  it('does not send a batch again when its delayed path resolves after a flush', async () => {
+    const sent: BrowserEvent[][] = []
+    let resolvePath: (path: BrowserEventTarget[]) => void = () => undefined
+
+    const { emit, flush } = createSequentialEmitter(
+      () =>
+        new Promise<BrowserEventTarget[]>((resolve) => {
+          resolvePath = resolve
+        }),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+
+    flush()
+
+    expect(sent).toEqual([[makeEvent('first')]])
+
+    resolvePath([])
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent).toEqual([[makeEvent('first')]])
+  })
+
+  it('still emits normally after a flush', async () => {
+    const sent: BrowserEvent[][] = []
+
+    const { emit, flush } = createSequentialEmitter(
+      () => Promise.resolve([]),
+      (events) => sent.push(events)
+    )
+
+    emit(makeEvent('first'))
+    flush()
+
+    emit(makeEvent('second'))
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(sent).toEqual([[makeEvent('first')], [makeEvent('second')]])
   })
 })

--- a/src/recorder/browser/emitQueue.test.ts
+++ b/src/recorder/browser/emitQueue.test.ts
@@ -13,6 +13,8 @@ const makeEvent = (eventId: string): BrowserEvent => ({
   source: 'address-bar',
 })
 
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0))
+
 describe('createSequentialEmitter', () => {
   it('attaches the resolved frame path to every event', async () => {
     const frames: BrowserEventTarget[] = [
@@ -27,7 +29,7 @@ describe('createSequentialEmitter', () => {
 
     emit(makeEvent('first'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent).toEqual([[{ ...makeEvent('first'), frames }]])
   })
@@ -51,13 +53,13 @@ describe('createSequentialEmitter', () => {
     emit(makeEvent('first'))
     emit(makeEvent('second'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent).toEqual([])
 
     resolveFirst([])
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent.flat().map((event) => event.eventId)).toEqual([
       'first',
@@ -81,7 +83,7 @@ describe('createSequentialEmitter', () => {
     emit(makeEvent('first'))
     emit(makeEvent('second'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent.flat().map((event) => event.eventId)).toEqual([
       'first',
@@ -108,7 +110,7 @@ describe('createSequentialEmitter', () => {
     emit(makeEvent('first'))
     emit(makeEvent('second'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent.flat().map((event) => event.eventId)).toEqual(['second'])
   })
@@ -149,7 +151,7 @@ describe('createSequentialEmitter', () => {
 
     resolvePath([])
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent).toEqual([[makeEvent('first')]])
   })
@@ -167,7 +169,7 @@ describe('createSequentialEmitter', () => {
 
     emit(makeEvent('second'))
 
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await flushMicrotasks()
 
     expect(sent).toEqual([[makeEvent('first')], [makeEvent('second')]])
   })

--- a/src/recorder/browser/emitQueue.ts
+++ b/src/recorder/browser/emitQueue.ts
@@ -6,7 +6,8 @@ import { withFrames } from './frames'
  * Emits recorded events in capture order even though frame paths resolve
  * asynchronously: each emission awaits the previous one. A failed path lookup
  * falls back to no frame path so a single slow or broken ancestor can't stall
- * the recording.
+ * the recording. If send() throws, the error is logged and the next emission
+ * continues normally, preventing the chain from being poisoned.
  */
 export function createSequentialEmitter(
   getPath: () => Promise<BrowserEventTarget[]>,
@@ -20,7 +21,11 @@ export function createSequentialEmitter(
     pending = pending.then(async () => {
       const frames = await getPath().catch(() => [])
 
-      send(list.map((event) => withFrames(event, frames)))
+      try {
+        send(list.map((event) => withFrames(event, frames)))
+      } catch (error) {
+        console.error('Failed to send events:', error)
+      }
     })
   }
 }

--- a/src/recorder/browser/emitQueue.ts
+++ b/src/recorder/browser/emitQueue.ts
@@ -1,0 +1,26 @@
+import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
+
+import { withFrames } from './frames'
+
+/**
+ * Emits recorded events in capture order even though frame paths resolve
+ * asynchronously: each emission awaits the previous one. A failed path lookup
+ * falls back to no frame path so a single slow or broken ancestor can't stall
+ * the recording.
+ */
+export function createSequentialEmitter(
+  getPath: () => Promise<BrowserEventTarget[]>,
+  send: (events: BrowserEvent[]) => void
+) {
+  let pending: Promise<void> = Promise.resolve()
+
+  return function emit(events: BrowserEvent[] | BrowserEvent) {
+    const list = Array.isArray(events) ? events : [events]
+
+    pending = pending.then(async () => {
+      const frames = await getPath().catch(() => [])
+
+      send(list.map((event) => withFrames(event, frames)))
+    })
+  }
+}

--- a/src/recorder/browser/emitQueue.ts
+++ b/src/recorder/browser/emitQueue.ts
@@ -8,24 +8,55 @@ import { withFrames } from './frames'
  * falls back to no frame path so a single slow or broken ancestor can't stall
  * the recording. If send() throws, the error is logged and the next emission
  * continues normally, preventing the chain from being poisoned.
+ *
+ * Returns `flush` alongside `emit` so callers can synchronously send every
+ * still-unsent batch at document teardown (e.g. on pagehide), before the async
+ * frame-path lookup would otherwise resolve. Flushed batches go out frameless,
+ * and are marked sent so the pending async chain doesn't send them again once
+ * its path lookup later resolves.
  */
 export function createSequentialEmitter(
   getPath: () => Promise<BrowserEventTarget[]>,
   send: (events: BrowserEvent[]) => void
 ) {
   let pending: Promise<void> = Promise.resolve()
+  const unsentBatches = new Set<BrowserEvent[]>()
 
-  return function emit(events: BrowserEvent[] | BrowserEvent) {
+  function sendBatch(batch: BrowserEvent[]) {
+    try {
+      send(batch)
+    } catch (error) {
+      console.error('Failed to send events:', error)
+    }
+  }
+
+  function emit(events: BrowserEvent[] | BrowserEvent) {
     const list = Array.isArray(events) ? events : [events]
+
+    unsentBatches.add(list)
 
     pending = pending.then(async () => {
       const frames = await getPath().catch(() => [])
 
-      try {
-        send(list.map((event) => withFrames(event, frames)))
-      } catch (error) {
-        console.error('Failed to send events:', error)
+      // The batch may have already been flushed synchronously while this
+      // lookup was in flight; don't send it a second time.
+      if (!unsentBatches.delete(list)) {
+        return
       }
+
+      sendBatch(list.map((event) => withFrames(event, frames)))
     })
   }
+
+  function flush() {
+    const batches = [...unsentBatches]
+
+    unsentBatches.clear()
+
+    batches.forEach((batch) => {
+      sendBatch(batch.map((event) => withFrames(event, [])))
+    })
+  }
+
+  return { emit, flush }
 }

--- a/src/recorder/browser/frames.test.ts
+++ b/src/recorder/browser/frames.test.ts
@@ -1,8 +1,16 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
 
-import { buildFramePath, getCssFramePathForElement, withFrames } from './frames'
+import {
+  buildFramePath,
+  getCssFramePathForElement,
+  getFramePathAsync,
+  getOwnFramePath,
+  resolveFramePath,
+  withFrames,
+} from './frames'
+import { FrameAgent, installFrameAgent } from './messaging/frames'
 
 interface FakeWindow {
   parent: FakeWindow
@@ -94,5 +102,56 @@ describe('getCssFramePathForElement', () => {
     }
 
     expect(getCssFramePathForElement(target)).toEqual([])
+  })
+})
+
+describe('getFramePathAsync', () => {
+  afterEach(() => {
+    installFrameAgent(null)
+    vi.restoreAllMocks()
+  })
+
+  it('returns an empty path in the top frame without consulting the agent', async () => {
+    // Under jsdom `window.frameElement` is null and `window.parent` self-references,
+    // so the sync walk succeeds with an empty path.
+    await expect(getFramePathAsync()).resolves.toEqual([])
+  })
+
+  it('falls back to the frame agent when the sync walk throws', async () => {
+    const agent = {
+      requestFramePath: vi
+        .fn()
+        .mockResolvedValue([{ selectors: { css: 'iframe#outer' } }]),
+    } as unknown as FrameAgent
+
+    await expect(
+      resolveFramePath(() => {
+        throw new Error('cross-origin')
+      }, agent)
+    ).resolves.toEqual([{ selectors: { css: 'iframe#outer' } }])
+  })
+
+  it('returns an empty path when the agent cannot resolve one', async () => {
+    const agent = {
+      requestFramePath: vi.fn().mockResolvedValue(null),
+    } as unknown as FrameAgent
+
+    await expect(
+      resolveFramePath(() => {
+        throw new Error('cross-origin')
+      }, agent)
+    ).resolves.toEqual([])
+  })
+
+  it('returns an empty path when there is no agent and the walk throws', async () => {
+    await expect(
+      resolveFramePath(() => {
+        throw new Error('cross-origin')
+      }, null)
+    ).resolves.toEqual([])
+  })
+
+  it('getOwnFramePath returns an empty path in the top frame', async () => {
+    await expect(getOwnFramePath()).resolves.toEqual([])
   })
 })

--- a/src/recorder/browser/frames.test.ts
+++ b/src/recorder/browser/frames.test.ts
@@ -8,6 +8,7 @@ import {
   getFramePathAsync,
   getOwnFramePath,
   resolveFramePath,
+  resolveOwnFramePath,
   withFrames,
 } from './frames'
 import { FrameAgent, installFrameAgent } from './messaging/frames'
@@ -153,5 +154,64 @@ describe('getFramePathAsync', () => {
 
   it('getOwnFramePath returns an empty path in the top frame', async () => {
     await expect(getOwnFramePath()).resolves.toEqual([])
+  })
+})
+
+describe('resolveOwnFramePath', () => {
+  it('falls back to the frame agent when the walk throws', async () => {
+    const agent = {
+      requestFramePath: vi
+        .fn()
+        .mockResolvedValue([{ selectors: { css: 'iframe#outer' } }]),
+    } as unknown as FrameAgent
+
+    await expect(
+      resolveOwnFramePath(() => {
+        throw new Error('cross-origin')
+      }, agent)
+    ).resolves.toEqual([{ selectors: { css: 'iframe#outer' } }])
+  })
+
+  it('returns null when the walk throws and the agent cannot resolve one', async () => {
+    const agent = {
+      requestFramePath: vi.fn().mockResolvedValue(null),
+    } as unknown as FrameAgent
+
+    await expect(
+      resolveOwnFramePath(() => {
+        throw new Error('cross-origin')
+      }, agent)
+    ).resolves.toBeNull()
+  })
+
+  it('returns null when the walk throws and there is no agent', async () => {
+    await expect(
+      resolveOwnFramePath(() => {
+        throw new Error('cross-origin')
+      }, null)
+    ).resolves.toBeNull()
+  })
+
+  it('returns null when the walk throws and the agent rejects', async () => {
+    const agent = {
+      requestFramePath: vi.fn().mockRejectedValue(new Error('timeout')),
+    } as unknown as FrameAgent
+
+    await expect(
+      resolveOwnFramePath(() => {
+        throw new Error('cross-origin')
+      }, agent)
+    ).resolves.toBeNull()
+  })
+
+  it('returns the walk result without consulting the agent when the walk succeeds', async () => {
+    const requestFramePath = vi.fn()
+    const agent = { requestFramePath } as unknown as FrameAgent
+
+    await expect(
+      resolveOwnFramePath(() => [{ selectors: { css: 'iframe#outer' } }], agent)
+    ).resolves.toEqual([{ selectors: { css: 'iframe#outer' } }])
+
+    expect(requestFramePath).not.toHaveBeenCalled()
   })
 })

--- a/src/recorder/browser/frames.test.ts
+++ b/src/recorder/browser/frames.test.ts
@@ -4,10 +4,10 @@ import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
 
 import {
   buildFramePath,
+  createNegativeCachedResolver,
   getCssFramePathForElement,
   getFramePathAsync,
   getOwnFramePath,
-  resolveFramePath,
   resolveOwnFramePath,
   withFrames,
 } from './frames'
@@ -118,42 +118,41 @@ describe('getFramePathAsync', () => {
     await expect(getFramePathAsync()).resolves.toEqual([])
   })
 
-  it('falls back to the frame agent when the sync walk throws', async () => {
-    const agent = {
-      requestFramePath: vi
-        .fn()
-        .mockResolvedValue([{ selectors: { css: 'iframe#outer' } }]),
-    } as unknown as FrameAgent
-
-    await expect(
-      resolveFramePath(() => {
-        throw new Error('cross-origin')
-      }, agent)
-    ).resolves.toEqual([{ selectors: { css: 'iframe#outer' } }])
-  })
-
-  it('returns an empty path when the agent cannot resolve one', async () => {
-    const agent = {
-      requestFramePath: vi.fn().mockResolvedValue(null),
-    } as unknown as FrameAgent
-
-    await expect(
-      resolveFramePath(() => {
-        throw new Error('cross-origin')
-      }, agent)
-    ).resolves.toEqual([])
-  })
-
-  it('returns an empty path when there is no agent and the walk throws', async () => {
-    await expect(
-      resolveFramePath(() => {
-        throw new Error('cross-origin')
-      }, null)
-    ).resolves.toEqual([])
-  })
-
   it('getOwnFramePath returns an empty path in the top frame', async () => {
     await expect(getOwnFramePath()).resolves.toEqual([])
+  })
+})
+
+describe('createNegativeCachedResolver', () => {
+  it('returns an empty path and stops resolving after a null result', async () => {
+    const resolve = vi.fn().mockResolvedValue(null)
+    const resolver = createNegativeCachedResolver(resolve)
+
+    await expect(resolver()).resolves.toEqual([])
+    await expect(resolver()).resolves.toEqual([])
+
+    expect(resolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes a resolved path through without caching a negative result', async () => {
+    const path: BrowserEventTarget[] = [{ selectors: { css: 'iframe#outer' } }]
+    const resolve = vi.fn().mockResolvedValue(path)
+    const resolver = createNegativeCachedResolver(resolve)
+
+    await expect(resolver()).resolves.toEqual(path)
+    await expect(resolver()).resolves.toEqual(path)
+
+    expect(resolve).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns an empty path and stops resolving after a rejection', async () => {
+    const resolve = vi.fn().mockRejectedValue(new Error('timeout'))
+    const resolver = createNegativeCachedResolver(resolve)
+
+    await expect(resolver()).resolves.toEqual([])
+    await expect(resolver()).resolves.toEqual([])
+
+    expect(resolve).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -28,24 +28,6 @@ export function buildFramePath(
   return path
 }
 
-function safeFramePath(start: Window): BrowserEventTarget[] {
-  try {
-    return buildFramePath(start, getElementDetails)
-  } catch {
-    return []
-  }
-}
-
-/**
- * The chain of iframe locators from the top frame down to the current frame,
- * outermost first. Empty when running in the top frame. Relies on the recorder
- * launching the browser with web security and site isolation disabled so that
- * `window.frameElement` is readable across origins.
- */
-export function getFramePath(): BrowserEventTarget[] {
-  return safeFramePath(window)
-}
-
 /**
  * Composition seam for getFramePathAsync: tries the synchronous walk first
  * (top frame and fully same-origin chains), then the postMessage protocol for
@@ -110,7 +92,14 @@ export async function getOwnFramePath(): Promise<BrowserEventTarget[] | null> {
  * an iframe). Empty when the element is in the top frame.
  */
 export function getFramePathForElement(element: Element): BrowserEventTarget[] {
-  return safeFramePath(element.ownerDocument.defaultView ?? window)
+  try {
+    return buildFramePath(
+      element.ownerDocument.defaultView ?? window,
+      getElementDetails
+    )
+  } catch {
+    return []
+  }
 }
 
 /**

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -3,6 +3,8 @@ import { BrowserEvent, BrowserEventTarget } from '@/schemas/recording'
 import { forEachOwningFrame } from '@/utils/dom/frameChain'
 import { getCssSelector, getElementDetails } from '@/utils/dom/selectors'
 
+import { FrameAgent, getFrameAgent } from './messaging/frames'
+
 /**
  * Walks from `start` up to the top frame, collecting details for each owning
  * `<iframe>` element along the way. The result is ordered outermost first, so it
@@ -42,6 +44,64 @@ function safeFramePath(start: Window): BrowserEventTarget[] {
  */
 export function getFramePath(): BrowserEventTarget[] {
   return safeFramePath(window)
+}
+
+/**
+ * Composition seam for getFramePathAsync: tries the synchronous walk first
+ * (top frame and fully same-origin chains), then the postMessage protocol for
+ * cross-origin frames, then gives up with no frame path.
+ */
+export async function resolveFramePath(
+  walk: () => BrowserEventTarget[],
+  agent: FrameAgent | null
+): Promise<BrowserEventTarget[]> {
+  try {
+    return walk()
+  } catch {
+    // Cross-origin chain; fall through to the protocol.
+  }
+
+  if (agent === null) {
+    return []
+  }
+
+  try {
+    return (await agent.requestFramePath()) ?? []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The chain of iframe locators from the top frame down to the current frame,
+ * outermost first. Empty when running in the top frame or when the chain can't
+ * be determined. Same-origin chains resolve synchronously via frameElement;
+ * cross-origin frames ask their ancestors over postMessage.
+ */
+export function getFramePathAsync(): Promise<BrowserEventTarget[]> {
+  return resolveFramePath(
+    () => buildFramePath(window, getElementDetails),
+    getFrameAgent()
+  )
+}
+
+/**
+ * Like getFramePathAsync but distinguishes "top frame" ([]) from "unknown"
+ * (null), so a parent answering a child's request over the frame agent doesn't
+ * claim a wrong, shallow position in the frame tree.
+ */
+export async function getOwnFramePath(): Promise<BrowserEventTarget[] | null> {
+  try {
+    return buildFramePath(window, getElementDetails)
+  } catch {
+    // Cross-origin chain; ask the ancestors instead.
+  }
+
+  try {
+    return (await getFrameAgent()?.requestFramePath()) ?? null
+  } catch {
+    return null
+  }
 }
 
 /**

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -68,22 +68,41 @@ export function getFramePathAsync(): Promise<BrowserEventTarget[]> {
 }
 
 /**
- * Like getFramePathAsync but distinguishes "top frame" ([]) from "unknown"
- * (null), so a parent answering a child's request over the frame agent doesn't
- * claim a wrong, shallow position in the frame tree.
+ * Composition seam for getOwnFramePath: tries the synchronous walk first, then
+ * the postMessage protocol for cross-origin frames, then gives up with null
+ * rather than a wrong, shallow path.
  */
-export async function getOwnFramePath(): Promise<BrowserEventTarget[] | null> {
+export async function resolveOwnFramePath(
+  walk: () => BrowserEventTarget[],
+  agent: FrameAgent | null
+): Promise<BrowserEventTarget[] | null> {
   try {
-    return buildFramePath(window, getElementDetails)
+    return walk()
   } catch {
     // Cross-origin chain; ask the ancestors instead.
   }
 
+  if (agent === null) {
+    return null
+  }
+
   try {
-    return (await getFrameAgent()?.requestFramePath()) ?? null
+    return (await agent.requestFramePath()) ?? null
   } catch {
     return null
   }
+}
+
+/**
+ * Like getFramePathAsync but distinguishes "top frame" ([]) from "unknown"
+ * (null), so a parent answering a child's request over the frame agent doesn't
+ * claim a wrong, shallow position in the frame tree.
+ */
+export function getOwnFramePath(): Promise<BrowserEventTarget[] | null> {
+  return resolveOwnFramePath(
+    () => buildFramePath(window, getElementDetails),
+    getFrameAgent()
+  )
 }
 
 /**

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -29,42 +29,52 @@ export function buildFramePath(
 }
 
 /**
- * Composition seam for getFramePathAsync: tries the synchronous walk first
- * (top frame and fully same-origin chains), then the postMessage protocol for
- * cross-origin frames, then gives up with no frame path.
+ * Wraps a frame path lookup with a negative cache: once the lookup resolves
+ * null (an ancestor never answered) or rejects, every later call
+ * short-circuits to an empty path instead of paying the full request timeout
+ * again. An unresponsive ancestor stays unresponsive for this document's
+ * lifetime; the recorder script is re-injected per document, so the cache
+ * resets naturally on navigation.
  */
-export async function resolveFramePath(
-  walk: () => BrowserEventTarget[],
-  agent: FrameAgent | null
-): Promise<BrowserEventTarget[]> {
-  try {
-    return walk()
-  } catch {
-    // Cross-origin chain; fall through to the protocol.
-  }
+export function createNegativeCachedResolver(
+  resolve: () => Promise<BrowserEventTarget[] | null>
+): () => Promise<BrowserEventTarget[]> {
+  let ancestorUnresponsive = false
 
-  if (agent === null) {
-    return []
-  }
+  return async () => {
+    if (ancestorUnresponsive) {
+      return []
+    }
 
-  try {
-    return (await agent.requestFramePath()) ?? []
-  } catch {
-    return []
+    const path = await resolve().catch(() => null)
+
+    if (path === null) {
+      ancestorUnresponsive = true
+      return []
+    }
+
+    return path
   }
 }
+
+const resolveCrossOriginFramePath = createNegativeCachedResolver(
+  () => getFrameAgent()?.requestFramePath() ?? Promise.resolve(null)
+)
 
 /**
  * The chain of iframe locators from the top frame down to the current frame,
  * outermost first. Empty when running in the top frame or when the chain can't
  * be determined. Same-origin chains resolve synchronously via frameElement;
- * cross-origin frames ask their ancestors over postMessage.
+ * cross-origin frames ask their ancestors over postMessage, with unanswered
+ * lookups negative-cached so one silent ancestor can't stall every event.
  */
 export function getFramePathAsync(): Promise<BrowserEventTarget[]> {
-  return resolveFramePath(
-    () => buildFramePath(window, getElementDetails),
-    getFrameAgent()
-  )
+  try {
+    return Promise.resolve(buildFramePath(window, getElementDetails))
+  } catch {
+    // Cross-origin chain; fall back to the protocol.
+    return resolveCrossOriginFramePath()
+  }
 }
 
 /**

--- a/src/recorder/browser/frames.ts
+++ b/src/recorder/browser/frames.ts
@@ -57,8 +57,8 @@ export function createNegativeCachedResolver(
   }
 }
 
-const resolveCrossOriginFramePath = createNegativeCachedResolver(
-  () => getFrameAgent()?.requestFramePath() ?? Promise.resolve(null)
+const resolveEventFramePath = createNegativeCachedResolver(() =>
+  getOwnFramePath()
 )
 
 /**
@@ -69,12 +69,7 @@ const resolveCrossOriginFramePath = createNegativeCachedResolver(
  * lookups negative-cached so one silent ancestor can't stall every event.
  */
 export function getFramePathAsync(): Promise<BrowserEventTarget[]> {
-  try {
-    return Promise.resolve(buildFramePath(window, getElementDetails))
-  } catch {
-    // Cross-origin chain; fall back to the protocol.
-    return resolveCrossOriginFramePath()
-  }
+  return resolveEventFramePath()
 }
 
 /**

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -1,3 +1,7 @@
+import { getElementDetails } from '@/utils/dom/selectors'
+
+import { getOwnFramePath } from './frames'
+import { FrameAgent, installFrameAgent } from './messaging/frames'
 import { startRecording } from './recording'
 import { client } from './routing'
 import { configureStorage } from './storage'
@@ -7,18 +11,50 @@ import {
   attachInspectionDetection,
   attachTextSelectionDetection,
 } from './view/inspection'
+import { useInBrowserUIStore } from './view/store'
 import { trackTabFocus } from './window'
 
 // CDP injects this script into every frame. We capture events in all frames so
 // that interactions inside iframes are recorded, but the recorder UI and tab
-// focus tracking only make sense in the top frame. Child frames instead forward
-// element inspection to the top frame's inspector.
+// focus tracking only make sense in the top frame. Same-origin child frames
+// forward element inspection to the top frame's inspector; cross-origin frames
+// coordinate over the frame agent's postMessage protocol instead.
 const storage = configureStorage(client)
 
+const agent = new FrameAgent({
+  win: window,
+  parentWindow: isInFrame() ? window.parent : null,
+  getFrames: () =>
+    [...document.querySelectorAll('iframe, frame')].flatMap((element) => {
+      if (
+        element instanceof HTMLIFrameElement ||
+        element instanceof HTMLFrameElement
+      ) {
+        return [{ element, contentWindow: element.contentWindow }]
+      }
+
+      return []
+    }),
+  getIframeLocator: getElementDetails,
+  getOwnPath: getOwnFramePath,
+})
+
+installFrameAgent(agent)
+
 if (isInFrame()) {
+  agent.announce()
   attachInspectionDetection()
   attachTextSelectionDetection()
 } else {
+  useInBrowserUIStore.subscribe((state, previous) => {
+    const active = state.tool !== null
+    const wasActive = previous.tool !== null
+
+    if (active !== wasActive) {
+      agent.broadcastToolState(active)
+    }
+  })
+
   trackTabFocus(client)
   initializeView(client, storage)
 }

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -1,3 +1,4 @@
+import { isHTMLFrameElement, isHTMLIFrameElement } from '@/utils/dom/realm'
 import { getElementDetails } from '@/utils/dom/selectors'
 
 import { getOwnFramePath } from './frames'
@@ -26,10 +27,7 @@ const agent = new FrameAgent({
   parentWindow: isInFrame() ? window.parent : null,
   getFrames: () =>
     [...document.querySelectorAll('iframe, frame')].flatMap((element) => {
-      if (
-        element instanceof HTMLIFrameElement ||
-        element instanceof HTMLFrameElement
-      ) {
+      if (isHTMLIFrameElement(element) || isHTMLFrameElement(element)) {
         return [{ element, contentWindow: element.contentWindow }]
       }
 

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -8,6 +8,7 @@ import { client } from './routing'
 import { configureStorage } from './storage'
 import { isInFrame } from './utils'
 import { initializeView } from './view'
+import { attachFrameHighlights } from './view/frameHighlights'
 import {
   attachInspectionDetection,
   attachTextSelectionDetection,
@@ -43,6 +44,7 @@ if (isInFrame()) {
   agent.announce()
   attachInspectionDetection()
   attachTextSelectionDetection()
+  attachFrameHighlights(client, getOwnFramePath)
 } else {
   useInBrowserUIStore.subscribe((state, previous) => {
     const active = state.tool !== null

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -425,6 +425,46 @@ describe('FrameAgent handshake and tool state', () => {
     ])
   })
 
+  it('relays the acked tool state to its own child frames on handshake-ack', () => {
+    const parentWin = new FakeFrameWindow()
+    const childWin = new FakeFrameWindow()
+    const iframeElement = { id: 'child-iframe' } as unknown as Element
+
+    const { win, agent } = createAgent({
+      parentWindow: parentWin,
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const sent: Array<{ message: { type: string; id: string } }> = []
+    parentWin.addEventListener('message', (event) => {
+      sent.push(event.data as { message: { type: string; id: string } })
+    })
+
+    agent.announce()
+
+    const relayed: unknown[] = []
+    childWin.addEventListener('message', (event) => relayed.push(event.data))
+
+    win.deliverFrom(parentWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: {
+        type: 'handshake-ack',
+        id: sent[0]?.message.id ?? '',
+        toolActive: true,
+      },
+    })
+
+    expect(agent.isToolActive).toBe(true)
+    expect(relayed).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: { type: 'tool-state', active: true },
+      },
+    ])
+  })
+
   it('ignores tool-state that does not come from the parent', () => {
     const parentWin = new FakeFrameWindow()
     const intruder = new FakeFrameWindow()

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -168,3 +168,102 @@ describe('FrameAgent.requestFramePath', () => {
     await expect(pathPromise).resolves.toBeNull()
   })
 })
+
+describe('FrameAgent responder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function linkChild(parentSetup: {
+    getOwnPath?: () => Promise<BrowserEventTarget[] | null>
+  }) {
+    const childWin = new FakeFrameWindow()
+    const iframeElement = { id: 'child-iframe' } as unknown as Element
+
+    const { win: parentWin } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+      getIframeLocator: () => locator('iframe#child'),
+      getOwnPath: parentSetup.getOwnPath ?? (() => Promise.resolve([])),
+    })
+
+    return { parentWin, childWin }
+  }
+
+  function requestFromChild(
+    parentWin: FakeFrameWindow,
+    childWin: FakeFrameWindow
+  ) {
+    const received: unknown[] = []
+    childWin.addEventListener('message', (event) => received.push(event.data))
+
+    parentWin.deliverFrom(childWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'frame-path-request', id: 'req-1' },
+    })
+
+    return received
+  }
+
+  it('responds with its own path plus the child iframe locator', async () => {
+    const { parentWin, childWin } = linkChild({
+      getOwnPath: () => Promise.resolve([locator('iframe#outer')]),
+    })
+
+    const received = requestFromChild(parentWin, childWin)
+
+    await vi.runAllTimersAsync()
+
+    expect(received).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: {
+          type: 'frame-path-response',
+          id: 'req-1',
+          path: [locator('iframe#outer'), locator('iframe#child')],
+        },
+      },
+    ])
+  })
+
+  it('responds with a null path when its own path is unknown', async () => {
+    const { parentWin, childWin } = linkChild({
+      getOwnPath: () => Promise.resolve(null),
+    })
+
+    const received = requestFromChild(parentWin, childWin)
+
+    await vi.runAllTimersAsync()
+
+    expect(received).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: { type: 'frame-path-response', id: 'req-1', path: null },
+      },
+    ])
+  })
+
+  it('ignores requests from windows that are not its own frames', async () => {
+    const { parentWin, childWin } = linkChild({})
+    const intruder = new FakeFrameWindow()
+
+    const received: unknown[] = []
+    childWin.addEventListener('message', (event) => received.push(event.data))
+
+    parentWin.deliverFrom(intruder, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'frame-path-request', id: 'req-1' },
+    })
+
+    await vi.runAllTimersAsync()
+
+    expect(received).toEqual([])
+  })
+})

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { BrowserEventTarget } from '@/schemas/recording'
+
+import { FrameAgent, FrameMessageEvent } from './frames'
+
+type Listener = (event: FrameMessageEvent) => void
+
+/**
+ * Minimal stand-in for a frame's window. Real cross-origin frames can't be
+ * simulated under jsdom, so agents are wired together through these fakes:
+ * an agent sends by calling deliverFrom on the target, which dispatches a
+ * message event with the sender attached as `source`.
+ */
+class FakeFrameWindow {
+  #listeners: Listener[] = []
+
+  addEventListener(_type: 'message', listener: Listener) {
+    this.#listeners.push(listener)
+  }
+
+  removeEventListener(_type: 'message', listener: Listener) {
+    this.#listeners = this.#listeners.filter((entry) => entry !== listener)
+  }
+
+  deliverFrom(sender: FakeFrameWindow, data: unknown) {
+    this.#listeners.forEach((listener) => listener({ data, source: sender }))
+  }
+}
+
+/**
+ * Send function bound to the sending agent's window, standing in for the
+ * browser attributing `event.source` on postMessage.
+ */
+function sendFrom(sender: FakeFrameWindow) {
+  return (target: unknown, envelope: unknown) => {
+    if (target instanceof FakeFrameWindow) {
+      target.deliverFrom(sender, envelope)
+    }
+  }
+}
+
+const locator = (id: string): BrowserEventTarget => ({
+  selectors: { css: id },
+})
+
+function createAgent(
+  overrides: Partial<ConstructorParameters<typeof FrameAgent>[0]> = {}
+) {
+  const win = new FakeFrameWindow()
+
+  const agent = new FrameAgent({
+    win,
+    parentWindow: null,
+    getFrames: () => [],
+    getIframeLocator: () => locator('iframe#unused'),
+    getOwnPath: () => Promise.resolve([]),
+    send: sendFrom(win),
+    ...overrides,
+  })
+
+  return { win, agent }
+}
+
+describe('FrameAgent.requestFramePath', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves an empty path immediately in the top frame', async () => {
+    const { agent } = createAgent({ parentWindow: null })
+
+    await expect(agent.requestFramePath()).resolves.toEqual([])
+  })
+
+  it('resolves the path from a frame-path-response with a matching id', async () => {
+    const parentWin = new FakeFrameWindow()
+    const { win, agent } = createAgent({ parentWindow: parentWin })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    const pathPromise = agent.requestFramePath()
+
+    const [envelope] = sent as [{ message: { type: string; id: string } }]
+
+    expect(envelope.message.type).toBe('frame-path-request')
+
+    win.deliverFrom(parentWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: {
+        type: 'frame-path-response',
+        id: envelope.message.id,
+        path: [locator('iframe#outer')],
+      },
+    })
+
+    await expect(pathPromise).resolves.toEqual([locator('iframe#outer')])
+  })
+
+  it('resolves null when no response arrives before the timeout', async () => {
+    const parentWin = new FakeFrameWindow()
+    const { agent } = createAgent({
+      parentWindow: parentWin,
+      requestTimeoutMs: 1000,
+    })
+
+    const pathPromise = agent.requestFramePath()
+
+    vi.advanceTimersByTime(1000)
+
+    await expect(pathPromise).resolves.toBeNull()
+  })
+
+  it('ignores messages that do not match the protocol envelope', async () => {
+    const parentWin = new FakeFrameWindow()
+    const { win, agent } = createAgent({
+      parentWindow: parentWin,
+      requestTimeoutMs: 1000,
+    })
+
+    const pathPromise = agent.requestFramePath()
+
+    win.deliverFrom(parentWin, {
+      type: 'frame-path-response',
+      id: 'spoof',
+      path: [],
+    })
+    win.deliverFrom(parentWin, 'not even an object')
+
+    vi.advanceTimersByTime(1000)
+
+    await expect(pathPromise).resolves.toBeNull()
+  })
+
+  it('ignores a response coming from a window other than the parent', async () => {
+    const parentWin = new FakeFrameWindow()
+    const intruder = new FakeFrameWindow()
+    const { win, agent } = createAgent({
+      parentWindow: parentWin,
+      requestTimeoutMs: 1000,
+    })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    const pathPromise = agent.requestFramePath()
+
+    const [envelope] = sent as [{ message: { id: string } }]
+
+    win.deliverFrom(intruder, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: {
+        type: 'frame-path-response',
+        id: envelope.message.id,
+        path: [locator('iframe#evil')],
+      },
+    })
+
+    vi.advanceTimersByTime(1000)
+
+    await expect(pathPromise).resolves.toBeNull()
+  })
+})

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -268,6 +268,45 @@ describe('FrameAgent responder', () => {
   })
 })
 
+describe('FrameAgent default send', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('posts to a parent window that only exposes postMessage, like a cross-origin WindowProxy', () => {
+    const win = new FakeFrameWindow()
+    const postMessage = vi.fn()
+    const parentWindow = { postMessage }
+
+    const agent = new FrameAgent({
+      win,
+      parentWindow,
+      getFrames: () => [],
+      getIframeLocator: () => locator('iframe#unused'),
+      getOwnPath: () => Promise.resolve([]),
+    })
+
+    void agent.requestFramePath()
+
+    expect(postMessage).toHaveBeenCalledTimes(1)
+
+    const [envelope, targetOrigin] = postMessage.mock.calls[0] as [
+      { source: string; message: { type: string } },
+      string,
+    ]
+
+    expect(envelope.source).toBe('k6-studio-frames')
+    expect(envelope.message.type).toBe('frame-path-request')
+    expect(targetOrigin).toBe('*')
+
+    agent.dispose()
+  })
+})
+
 describe('FrameAgent handshake and tool state', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -267,3 +267,136 @@ describe('FrameAgent responder', () => {
     expect(received).toEqual([])
   })
 })
+
+describe('FrameAgent handshake and tool state', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retries the handshake until acknowledged and caches the acked tool state', () => {
+    const parentWin = new FakeFrameWindow()
+    const { win, agent } = createAgent({ parentWindow: parentWin })
+
+    const sent: Array<{ message: { type: string; id: string } }> = []
+    parentWin.addEventListener('message', (event) => {
+      sent.push(event.data as { message: { type: string; id: string } })
+    })
+
+    agent.announce()
+
+    expect(sent).toHaveLength(1)
+
+    vi.advanceTimersByTime(100)
+
+    expect(sent).toHaveLength(2)
+    expect(sent.every((entry) => entry.message.type === 'handshake')).toBe(true)
+
+    win.deliverFrom(parentWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: {
+        type: 'handshake-ack',
+        id: sent[1]?.message.id ?? '',
+        toolActive: true,
+      },
+    })
+
+    expect(agent.isToolActive).toBe(true)
+
+    // Acked: no further retries.
+    vi.advanceTimersByTime(10_000)
+
+    expect(sent).toHaveLength(2)
+  })
+
+  it('stops retrying the handshake after the attempt limit', () => {
+    const parentWin = new FakeFrameWindow()
+    const { agent } = createAgent({ parentWindow: parentWin })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    agent.announce()
+
+    vi.advanceTimersByTime(60_000)
+
+    expect(sent).toHaveLength(5)
+  })
+
+  it('acknowledges a child handshake with the current tool state', () => {
+    const childWin = new FakeFrameWindow()
+    const iframeElement = { id: 'child-iframe' } as unknown as Element
+
+    const { win: parentWin, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    agent.broadcastToolState(true)
+
+    const received: unknown[] = []
+    childWin.addEventListener('message', (event) => received.push(event.data))
+
+    parentWin.deliverFrom(childWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'handshake', id: 'hs-1' },
+    })
+
+    expect(received).toContainEqual({
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'handshake-ack', id: 'hs-1', toolActive: true },
+    })
+  })
+
+  it('relays tool-state from the parent to its own child frames and caches it', () => {
+    const parentWin = new FakeFrameWindow()
+    const grandchildWin = new FakeFrameWindow()
+    const iframeElement = { id: 'grandchild-iframe' } as unknown as Element
+
+    const { win, agent } = createAgent({
+      parentWindow: parentWin,
+      getFrames: () => [
+        { element: iframeElement, contentWindow: grandchildWin },
+      ],
+    })
+
+    const relayed: unknown[] = []
+    grandchildWin.addEventListener('message', (event) =>
+      relayed.push(event.data)
+    )
+
+    win.deliverFrom(parentWin, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'tool-state', active: true },
+    })
+
+    expect(agent.isToolActive).toBe(true)
+    expect(relayed).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: { type: 'tool-state', active: true },
+      },
+    ])
+  })
+
+  it('ignores tool-state that does not come from the parent', () => {
+    const parentWin = new FakeFrameWindow()
+    const intruder = new FakeFrameWindow()
+    const { win, agent } = createAgent({ parentWindow: parentWin })
+
+    win.deliverFrom(intruder, {
+      source: 'k6-studio-frames',
+      version: 1,
+      message: { type: 'tool-state', active: true },
+    })
+
+    expect(agent.isToolActive).toBe(false)
+  })
+})

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { BrowserEventTarget } from '@/schemas/recording'
 
-import { FrameAgent, FrameMessageEvent } from './frames'
+import {
+  ElementPickPayload,
+  FrameAgent,
+  FrameMessageEvent,
+  TextSelectionPayload,
+} from './frames'
 
 type Listener = (event: FrameMessageEvent) => void
 
@@ -48,6 +53,45 @@ const envelope = (message: unknown) => ({
   source: 'k6-studio-frames',
   version: 1,
   message,
+})
+
+/**
+ * Fake iframe element for offset relay tests. `clientLeft`/`clientTop` are
+ * non-zero and deliberately excluded from the expected offsets in the tests
+ * below, matching `getFrameOffset` (src/utils/dom/layout.ts), which only
+ * accumulates `getBoundingClientRect().left`/`.top` per hop.
+ */
+function fakeIframeElement(rect: { left: number; top: number }): Element {
+  return {
+    getBoundingClientRect: () =>
+      ({
+        left: rect.left,
+        top: rect.top,
+        width: 0,
+        height: 0,
+        right: rect.left,
+        bottom: rect.top,
+        x: rect.left,
+        y: rect.top,
+      }) as DOMRect,
+    clientLeft: 3,
+    clientTop: 4,
+  } as unknown as Element
+}
+
+const textSelectionPayload = (): Omit<TextSelectionPayload, 'offset'> => ({
+  text: 'hello world',
+  elements: [],
+  framePath: null,
+  highlights: [{ top: 0, left: 0, width: 10, height: 10 }],
+  bounds: { top: 0, left: 0, width: 10, height: 10 },
+})
+
+const elementPickPayload = (): Omit<ElementPickPayload, 'offset'> => ({
+  elements: [],
+  associatedControl: null,
+  framePath: null,
+  position: { left: 3, top: 4 },
 })
 
 function createAgent(
@@ -479,5 +523,270 @@ describe('FrameAgent handshake and tool state', () => {
     win.deliverFrom(intruder, envelope({ type: 'tool-state', active: true }))
 
     expect(agent.isToolActive).toBe(false)
+  })
+})
+
+describe('FrameAgent text-selection and element-pick relay', () => {
+  it('accumulates the offset over two hops and delivers the payload once to the top listener', () => {
+    const topWin = new FakeFrameWindow()
+    const middleWin = new FakeFrameWindow()
+    const grandchildWin = new FakeFrameWindow()
+
+    const middleIframeElement = fakeIframeElement({ left: 10, top: 20 })
+    const grandchildIframeElement = fakeIframeElement({ left: 5, top: 7 })
+
+    const topAgent = new FrameAgent({
+      win: topWin,
+      parentWindow: null,
+      getFrames: () => [
+        { element: middleIframeElement, contentWindow: middleWin },
+      ],
+      getIframeLocator: () => locator('iframe#unused'),
+      getOwnPath: () => Promise.resolve([]),
+      send: sendFrom(topWin),
+    })
+
+    const middleAgent = new FrameAgent({
+      win: middleWin,
+      parentWindow: topWin,
+      getFrames: () => [
+        { element: grandchildIframeElement, contentWindow: grandchildWin },
+      ],
+      getIframeLocator: () => locator('iframe#unused'),
+      getOwnPath: () => Promise.resolve([]),
+      send: sendFrom(middleWin),
+    })
+
+    const grandchildAgent = new FrameAgent({
+      win: grandchildWin,
+      parentWindow: middleWin,
+      getFrames: () => [],
+      getIframeLocator: () => locator('iframe#unused'),
+      getOwnPath: () => Promise.resolve([]),
+      send: sendFrom(grandchildWin),
+    })
+
+    const received: TextSelectionPayload[] = []
+    topAgent.onTextSelection((payload) => received.push(payload))
+
+    grandchildAgent.sendTextSelection(textSelectionPayload())
+
+    // Hand-computed: grandchild hop (left: 5, top: 7) + middle hop
+    // (left: 10, top: 20), clientLeft/clientTop excluded.
+    expect(received).toEqual([
+      { ...textSelectionPayload(), offset: { left: 15, top: 27 } },
+    ])
+
+    topAgent.dispose()
+    middleAgent.dispose()
+    grandchildAgent.dispose()
+  })
+
+  it('accumulates the offset for a single hop when relaying an element pick', () => {
+    const childWin = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 8, top: 3 })
+
+    const { win, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const received: ElementPickPayload[] = []
+    agent.onElementPick((payload) => received.push(payload))
+
+    win.deliverFrom(
+      childWin,
+      envelope({
+        type: 'element-pick',
+        payload: { ...elementPickPayload(), offset: { left: 0, top: 0 } },
+      })
+    )
+
+    expect(received).toEqual([
+      { ...elementPickPayload(), offset: { left: 8, top: 3 } },
+    ])
+  })
+
+  it('reposts a text-selection message upward, adding its own hop, when it has a parent', () => {
+    const parentWin = new FakeFrameWindow()
+    const childWin = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 6, top: 9 })
+
+    const { win } = createAgent({
+      parentWindow: parentWin,
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    win.deliverFrom(
+      childWin,
+      envelope({
+        type: 'text-selection',
+        payload: { ...textSelectionPayload(), offset: { left: 1, top: 2 } },
+      })
+    )
+
+    expect(sent).toEqual([
+      envelope({
+        type: 'text-selection',
+        payload: {
+          ...textSelectionPayload(),
+          offset: { left: 7, top: 11 },
+        },
+      }),
+    ])
+  })
+
+  it('ignores a text-selection relay from a window that is not a matched child frame', () => {
+    const childWin = new FakeFrameWindow()
+    const intruder = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 10, top: 20 })
+
+    const { win, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const received: TextSelectionPayload[] = []
+    agent.onTextSelection((payload) => received.push(payload))
+
+    win.deliverFrom(
+      intruder,
+      envelope({
+        type: 'text-selection',
+        payload: { ...textSelectionPayload(), offset: { left: 0, top: 0 } },
+      })
+    )
+
+    expect(received).toEqual([])
+  })
+
+  it('ignores an element-pick relay from a window that is not a matched child frame', () => {
+    const childWin = new FakeFrameWindow()
+    const intruder = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 10, top: 20 })
+
+    const { win, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const received: ElementPickPayload[] = []
+    agent.onElementPick((payload) => received.push(payload))
+
+    win.deliverFrom(
+      intruder,
+      envelope({
+        type: 'element-pick',
+        payload: { ...elementPickPayload(), offset: { left: 0, top: 0 } },
+      })
+    )
+
+    expect(received).toEqual([])
+  })
+
+  it('stops delivering element-pick payloads to a listener after it unsubscribes', () => {
+    const childWin = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 1, top: 2 })
+
+    const { win, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const received: ElementPickPayload[] = []
+    const unsubscribe = agent.onElementPick((payload) => received.push(payload))
+
+    const deliver = () =>
+      win.deliverFrom(
+        childWin,
+        envelope({
+          type: 'element-pick',
+          payload: { ...elementPickPayload(), offset: { left: 0, top: 0 } },
+        })
+      )
+
+    deliver()
+
+    expect(received).toHaveLength(1)
+
+    unsubscribe()
+    deliver()
+
+    expect(received).toHaveLength(1)
+  })
+
+  it('allows multiple listeners to receive the same text-selection payload', () => {
+    const childWin = new FakeFrameWindow()
+    const iframeElement = fakeIframeElement({ left: 1, top: 2 })
+
+    const { win, agent } = createAgent({
+      getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
+    })
+
+    const receivedByFirst: TextSelectionPayload[] = []
+    const receivedBySecond: TextSelectionPayload[] = []
+    agent.onTextSelection((payload) => receivedByFirst.push(payload))
+    agent.onTextSelection((payload) => receivedBySecond.push(payload))
+
+    win.deliverFrom(
+      childWin,
+      envelope({
+        type: 'text-selection',
+        payload: { ...textSelectionPayload(), offset: { left: 0, top: 0 } },
+      })
+    )
+
+    expect(receivedByFirst).toHaveLength(1)
+    expect(receivedBySecond).toHaveLength(1)
+  })
+
+  it('does not send anything when sendTextSelection/sendElementPick are called in the top frame', () => {
+    const sendSpy = vi.fn()
+    const agent = new FrameAgent({
+      win: new FakeFrameWindow(),
+      parentWindow: null,
+      getFrames: () => [],
+      getIframeLocator: () => locator('iframe#unused'),
+      getOwnPath: () => Promise.resolve([]),
+      send: sendSpy,
+    })
+
+    agent.sendTextSelection(textSelectionPayload())
+    agent.sendElementPick(elementPickPayload())
+
+    expect(sendSpy).not.toHaveBeenCalled()
+  })
+
+  it('posts a text-selection message to the parent with a zero offset', () => {
+    const parentWin = new FakeFrameWindow()
+    const { agent } = createAgent({ parentWindow: parentWin })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    agent.sendTextSelection(textSelectionPayload())
+
+    expect(sent).toEqual([
+      envelope({
+        type: 'text-selection',
+        payload: { ...textSelectionPayload(), offset: { left: 0, top: 0 } },
+      }),
+    ])
+  })
+
+  it('posts an element-pick message to the parent with a zero offset', () => {
+    const parentWin = new FakeFrameWindow()
+    const { agent } = createAgent({ parentWindow: parentWin })
+
+    const sent: unknown[] = []
+    parentWin.addEventListener('message', (event) => sent.push(event.data))
+
+    agent.sendElementPick(elementPickPayload())
+
+    expect(sent).toEqual([
+      envelope({
+        type: 'element-pick',
+        payload: { ...elementPickPayload(), offset: { left: 0, top: 0 } },
+      }),
+    ])
   })
 })

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -180,13 +180,15 @@ describe('FrameAgent responder', () => {
 
   function linkChild(parentSetup: {
     getOwnPath?: () => Promise<BrowserEventTarget[] | null>
+    getIframeLocator?: (iframe: Element) => BrowserEventTarget
   }) {
     const childWin = new FakeFrameWindow()
     const iframeElement = { id: 'child-iframe' } as unknown as Element
 
     const { win: parentWin } = createAgent({
       getFrames: () => [{ element: iframeElement, contentWindow: childWin }],
-      getIframeLocator: () => locator('iframe#child'),
+      getIframeLocator:
+        parentSetup.getIframeLocator ?? (() => locator('iframe#child')),
       getOwnPath: parentSetup.getOwnPath ?? (() => Promise.resolve([])),
     })
 
@@ -265,6 +267,45 @@ describe('FrameAgent responder', () => {
     await vi.runAllTimersAsync()
 
     expect(received).toEqual([])
+  })
+
+  it('responds with a null path when computing the iframe locator throws', async () => {
+    const { parentWin, childWin } = linkChild({
+      getOwnPath: () => Promise.resolve([locator('iframe#outer')]),
+      getIframeLocator: () => {
+        throw new Error('detached iframe')
+      },
+    })
+
+    const received = requestFromChild(parentWin, childWin)
+
+    await vi.runAllTimersAsync()
+
+    expect(received).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: { type: 'frame-path-response', id: 'req-1', path: null },
+      },
+    ])
+  })
+
+  it('responds with a null path when getOwnPath rejects', async () => {
+    const { parentWin, childWin } = linkChild({
+      getOwnPath: () => Promise.reject(new Error('boom')),
+    })
+
+    const received = requestFromChild(parentWin, childWin)
+
+    await vi.runAllTimersAsync()
+
+    expect(received).toEqual([
+      {
+        source: 'k6-studio-frames',
+        version: 1,
+        message: { type: 'frame-path-response', id: 'req-1', path: null },
+      },
+    ])
   })
 })
 

--- a/src/recorder/browser/messaging/frames.test.ts
+++ b/src/recorder/browser/messaging/frames.test.ts
@@ -44,6 +44,12 @@ const locator = (id: string): BrowserEventTarget => ({
   selectors: { css: id },
 })
 
+const envelope = (message: unknown) => ({
+  source: 'k6-studio-frames',
+  version: 1,
+  message,
+})
+
 function createAgent(
   overrides: Partial<ConstructorParameters<typeof FrameAgent>[0]> = {}
 ) {
@@ -86,19 +92,20 @@ describe('FrameAgent.requestFramePath', () => {
 
     const pathPromise = agent.requestFramePath()
 
-    const [envelope] = sent as [{ message: { type: string; id: string } }]
+    const [requestEnvelope] = sent as [
+      { message: { type: string; id: string } },
+    ]
 
-    expect(envelope.message.type).toBe('frame-path-request')
+    expect(requestEnvelope.message.type).toBe('frame-path-request')
 
-    win.deliverFrom(parentWin, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: {
+    win.deliverFrom(
+      parentWin,
+      envelope({
         type: 'frame-path-response',
-        id: envelope.message.id,
+        id: requestEnvelope.message.id,
         path: [locator('iframe#outer')],
-      },
-    })
+      })
+    )
 
     await expect(pathPromise).resolves.toEqual([locator('iframe#outer')])
   })
@@ -151,17 +158,16 @@ describe('FrameAgent.requestFramePath', () => {
 
     const pathPromise = agent.requestFramePath()
 
-    const [envelope] = sent as [{ message: { id: string } }]
+    const [sentEnvelope] = sent as [{ message: { id: string } }]
 
-    win.deliverFrom(intruder, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: {
+    win.deliverFrom(
+      intruder,
+      envelope({
         type: 'frame-path-response',
-        id: envelope.message.id,
+        id: sentEnvelope.message.id,
         path: [locator('iframe#evil')],
-      },
-    })
+      })
+    )
 
     vi.advanceTimersByTime(1000)
 
@@ -221,15 +227,11 @@ describe('FrameAgent responder', () => {
     await vi.runAllTimersAsync()
 
     expect(received).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: {
-          type: 'frame-path-response',
-          id: 'req-1',
-          path: [locator('iframe#outer'), locator('iframe#child')],
-        },
-      },
+      envelope({
+        type: 'frame-path-response',
+        id: 'req-1',
+        path: [locator('iframe#outer'), locator('iframe#child')],
+      }),
     ])
   })
 
@@ -243,11 +245,7 @@ describe('FrameAgent responder', () => {
     await vi.runAllTimersAsync()
 
     expect(received).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: { type: 'frame-path-response', id: 'req-1', path: null },
-      },
+      envelope({ type: 'frame-path-response', id: 'req-1', path: null }),
     ])
   })
 
@@ -258,11 +256,10 @@ describe('FrameAgent responder', () => {
     const received: unknown[] = []
     childWin.addEventListener('message', (event) => received.push(event.data))
 
-    parentWin.deliverFrom(intruder, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: { type: 'frame-path-request', id: 'req-1' },
-    })
+    parentWin.deliverFrom(
+      intruder,
+      envelope({ type: 'frame-path-request', id: 'req-1' })
+    )
 
     await vi.runAllTimersAsync()
 
@@ -282,11 +279,7 @@ describe('FrameAgent responder', () => {
     await vi.runAllTimersAsync()
 
     expect(received).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: { type: 'frame-path-response', id: 'req-1', path: null },
-      },
+      envelope({ type: 'frame-path-response', id: 'req-1', path: null }),
     ])
   })
 
@@ -300,11 +293,7 @@ describe('FrameAgent responder', () => {
     await vi.runAllTimersAsync()
 
     expect(received).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: { type: 'frame-path-response', id: 'req-1', path: null },
-      },
+      envelope({ type: 'frame-path-response', id: 'req-1', path: null }),
     ])
   })
 })
@@ -375,15 +364,14 @@ describe('FrameAgent handshake and tool state', () => {
     expect(sent).toHaveLength(2)
     expect(sent.every((entry) => entry.message.type === 'handshake')).toBe(true)
 
-    win.deliverFrom(parentWin, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: {
+    win.deliverFrom(
+      parentWin,
+      envelope({
         type: 'handshake-ack',
         id: sent[1]?.message.id ?? '',
         toolActive: true,
-      },
-    })
+      })
+    )
 
     expect(agent.isToolActive).toBe(true)
 
@@ -420,17 +408,11 @@ describe('FrameAgent handshake and tool state', () => {
     const received: unknown[] = []
     childWin.addEventListener('message', (event) => received.push(event.data))
 
-    parentWin.deliverFrom(childWin, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: { type: 'handshake', id: 'hs-1' },
-    })
+    parentWin.deliverFrom(childWin, envelope({ type: 'handshake', id: 'hs-1' }))
 
-    expect(received).toContainEqual({
-      source: 'k6-studio-frames',
-      version: 1,
-      message: { type: 'handshake-ack', id: 'hs-1', toolActive: true },
-    })
+    expect(received).toContainEqual(
+      envelope({ type: 'handshake-ack', id: 'hs-1', toolActive: true })
+    )
   })
 
   it('relays tool-state from the parent to its own child frames and caches it', () => {
@@ -450,20 +432,10 @@ describe('FrameAgent handshake and tool state', () => {
       relayed.push(event.data)
     )
 
-    win.deliverFrom(parentWin, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: { type: 'tool-state', active: true },
-    })
+    win.deliverFrom(parentWin, envelope({ type: 'tool-state', active: true }))
 
     expect(agent.isToolActive).toBe(true)
-    expect(relayed).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: { type: 'tool-state', active: true },
-      },
-    ])
+    expect(relayed).toEqual([envelope({ type: 'tool-state', active: true })])
   })
 
   it('relays the acked tool state to its own child frames on handshake-ack', () => {
@@ -486,24 +458,17 @@ describe('FrameAgent handshake and tool state', () => {
     const relayed: unknown[] = []
     childWin.addEventListener('message', (event) => relayed.push(event.data))
 
-    win.deliverFrom(parentWin, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: {
+    win.deliverFrom(
+      parentWin,
+      envelope({
         type: 'handshake-ack',
         id: sent[0]?.message.id ?? '',
         toolActive: true,
-      },
-    })
+      })
+    )
 
     expect(agent.isToolActive).toBe(true)
-    expect(relayed).toEqual([
-      {
-        source: 'k6-studio-frames',
-        version: 1,
-        message: { type: 'tool-state', active: true },
-      },
-    ])
+    expect(relayed).toEqual([envelope({ type: 'tool-state', active: true })])
   })
 
   it('ignores tool-state that does not come from the parent', () => {
@@ -511,11 +476,7 @@ describe('FrameAgent handshake and tool state', () => {
     const intruder = new FakeFrameWindow()
     const { win, agent } = createAgent({ parentWindow: parentWin })
 
-    win.deliverFrom(intruder, {
-      source: 'k6-studio-frames',
-      version: 1,
-      message: { type: 'tool-state', active: true },
-    })
+    win.deliverFrom(intruder, envelope({ type: 'tool-state', active: true }))
 
     expect(agent.isToolActive).toBe(false)
   })

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -328,7 +328,7 @@ export class FrameAgent {
           this.#handshakeTimer = null
         }
 
-        this.#toolActive = message.toolActive
+        this.broadcastToolState(message.toolActive)
 
         return
       }

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -1,0 +1,185 @@
+import { nanoid } from 'nanoid'
+import { z } from 'zod/v4'
+
+import {
+  BrowserEventTarget,
+  BrowserEventTargetSchema,
+} from '@/schemas/recording'
+
+const PROTOCOL_SOURCE = 'k6-studio-frames'
+const PROTOCOL_VERSION = 1
+
+const FramePathRequestSchema = z.object({
+  type: z.literal('frame-path-request'),
+  id: z.string(),
+})
+
+const FramePathResponseSchema = z.object({
+  type: z.literal('frame-path-response'),
+  id: z.string(),
+  // null means the responder could not determine its own path. Propagating a
+  // partial path would resolve locators in the wrong frame, so the requester
+  // falls back to no frame path instead.
+  path: BrowserEventTargetSchema.array().nullable(),
+})
+
+const FrameMessageSchema = z.discriminatedUnion('type', [
+  FramePathRequestSchema,
+  FramePathResponseSchema,
+])
+
+const FrameEnvelopeSchema = z.object({
+  source: z.literal(PROTOCOL_SOURCE),
+  version: z.literal(PROTOCOL_VERSION),
+  message: FrameMessageSchema,
+})
+
+type FrameMessage = z.infer<typeof FrameMessageSchema>
+
+export interface FrameMessageEvent {
+  data: unknown
+  source: unknown
+}
+
+export interface FrameWindowLike {
+  addEventListener(
+    type: 'message',
+    listener: (event: FrameMessageEvent) => void
+  ): void
+  removeEventListener(
+    type: 'message',
+    listener: (event: FrameMessageEvent) => void
+  ): void
+}
+
+export interface FrameRef {
+  element: Element
+  contentWindow: unknown
+}
+
+export interface FrameAgentOptions {
+  win: FrameWindowLike
+  /** The window to send requests to, or null when running in the top frame. */
+  parentWindow: unknown
+  /** The frame elements of this frame's document, used to match `event.source`. */
+  getFrames: () => FrameRef[]
+  /** Locator details for one of this frame's own iframe elements. */
+  getIframeLocator: (iframe: Element) => BrowserEventTarget
+  /** This frame's own path, used when answering a child's request. */
+  getOwnPath: () => Promise<BrowserEventTarget[] | null>
+  /** Injectable for tests; defaults to postMessage with targetOrigin '*'. */
+  send?: (target: unknown, envelope: unknown) => void
+  requestTimeoutMs?: number
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 1000
+
+function defaultSend(target: unknown, envelope: unknown) {
+  if (target instanceof Window) {
+    target.postMessage(envelope, '*')
+  }
+}
+
+interface PendingRequest {
+  resolve: (path: BrowserEventTarget[] | null) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+/**
+ * Cross-origin frame coordination over postMessage. Same-origin frames keep
+ * using the synchronous walks and bridges; this protocol is the fallback for
+ * frames where those throw. The envelope filter guards against accidental
+ * collisions with page messages, not against a hostile page.
+ */
+export class FrameAgent {
+  #options: FrameAgentOptions
+  #send: (target: unknown, envelope: unknown) => void
+  #requestTimeoutMs: number
+  #pending = new Map<string, PendingRequest>()
+
+  #handleMessage = (event: FrameMessageEvent) => {
+    const parsed = FrameEnvelopeSchema.safeParse(event.data)
+
+    if (!parsed.success) {
+      return
+    }
+
+    this.#dispatch(parsed.data.message, event.source)
+  }
+
+  constructor(options: FrameAgentOptions) {
+    this.#options = options
+    this.#send = options.send ?? defaultSend
+    this.#requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+
+    options.win.addEventListener('message', this.#handleMessage)
+  }
+
+  requestFramePath(): Promise<BrowserEventTarget[] | null> {
+    if (this.#options.parentWindow === null) {
+      return Promise.resolve([])
+    }
+
+    const id = nanoid()
+
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        this.#pending.delete(id)
+        resolve(null)
+      }, this.#requestTimeoutMs)
+
+      this.#pending.set(id, { resolve, timeout })
+
+      this.#post(this.#options.parentWindow, {
+        type: 'frame-path-request',
+        id,
+      })
+    })
+  }
+
+  dispose() {
+    this.#options.win.removeEventListener('message', this.#handleMessage)
+
+    this.#pending.forEach(({ resolve, timeout }) => {
+      clearTimeout(timeout)
+      resolve(null)
+    })
+
+    this.#pending.clear()
+  }
+
+  #post(target: unknown, message: FrameMessage) {
+    this.#send(target, {
+      source: PROTOCOL_SOURCE,
+      version: PROTOCOL_VERSION,
+      message,
+    })
+  }
+
+  #dispatch(message: FrameMessage, source: unknown) {
+    switch (message.type) {
+      case 'frame-path-response': {
+        if (source !== this.#options.parentWindow) {
+          return
+        }
+
+        const pending = this.#pending.get(message.id)
+
+        if (pending === undefined) {
+          return
+        }
+
+        clearTimeout(pending.timeout)
+        this.#pending.delete(message.id)
+        pending.resolve(message.path)
+
+        return
+      }
+
+      case 'frame-path-request':
+        // Handled in Task 2.
+        return
+    }
+  }
+}

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -177,9 +177,30 @@ export class FrameAgent {
         return
       }
 
-      case 'frame-path-request':
-        // Handled in Task 2.
+      case 'frame-path-request': {
+        const frame = this.#options
+          .getFrames()
+          .find((candidate) => candidate.contentWindow === source)
+
+        if (frame === undefined) {
+          return
+        }
+
+        void this.#options.getOwnPath().then((ownPath) => {
+          const path =
+            ownPath === null
+              ? null
+              : [...ownPath, this.#options.getIframeLocator(frame.element)]
+
+          this.#post(source, {
+            type: 'frame-path-response',
+            id: message.id,
+            path,
+          })
+        })
+
         return
+      }
     }
   }
 }

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -23,10 +23,32 @@ const FramePathResponseSchema = z.object({
   path: BrowserEventTargetSchema.array().nullable(),
 })
 
+const HandshakeSchema = z.object({
+  type: z.literal('handshake'),
+  id: z.string(),
+})
+
+const HandshakeAckSchema = z.object({
+  type: z.literal('handshake-ack'),
+  id: z.string(),
+  toolActive: z.boolean(),
+})
+
+const ToolStateSchema = z.object({
+  type: z.literal('tool-state'),
+  active: z.boolean(),
+})
+
 const FrameMessageSchema = z.discriminatedUnion('type', [
   FramePathRequestSchema,
   FramePathResponseSchema,
+  HandshakeSchema,
+  HandshakeAckSchema,
+  ToolStateSchema,
 ])
+
+const HANDSHAKE_RETRY_MS = 100
+const MAX_HANDSHAKE_ATTEMPTS = 5
 
 const FrameEnvelopeSchema = z.object({
   source: z.literal(PROTOCOL_SOURCE),
@@ -96,6 +118,9 @@ export class FrameAgent {
   #send: (target: unknown, envelope: unknown) => void
   #requestTimeoutMs: number
   #pending = new Map<string, PendingRequest>()
+  #toolActive = false
+  #handshakeId: string | null = null
+  #handshakeTimer: ReturnType<typeof setTimeout> | null = null
 
   #handleMessage = (event: FrameMessageEvent) => {
     const parsed = FrameEnvelopeSchema.safeParse(event.data)
@@ -114,6 +139,36 @@ export class FrameAgent {
       options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
 
     options.win.addEventListener('message', this.#handleMessage)
+  }
+
+  get isToolActive(): boolean {
+    return this.#toolActive
+  }
+
+  /**
+   * Announces this frame to its parent, retrying with backoff until the
+   * parent's agent acknowledges (covers the child-before-parent init race).
+   * The ack carries the current tool state.
+   */
+  announce() {
+    if (this.#options.parentWindow === null) {
+      return
+    }
+
+    this.#handshakeId = nanoid()
+    this.#sendHandshake(0)
+  }
+
+  /**
+   * Caches the tool state and pushes it to all direct child frames. Used by
+   * the top frame on tool changes and by child frames to relay downward.
+   */
+  broadcastToolState(active: boolean) {
+    this.#toolActive = active
+
+    this.#options.getFrames().forEach((frame) => {
+      this.#post(frame.contentWindow, { type: 'tool-state', active })
+    })
   }
 
   requestFramePath(): Promise<BrowserEventTarget[] | null> {
@@ -147,6 +202,11 @@ export class FrameAgent {
     })
 
     this.#pending.clear()
+
+    if (this.#handshakeTimer !== null) {
+      clearTimeout(this.#handshakeTimer)
+      this.#handshakeTimer = null
+    }
   }
 
   #post(target: unknown, message: FrameMessage) {
@@ -155,6 +215,24 @@ export class FrameAgent {
       version: PROTOCOL_VERSION,
       message,
     })
+  }
+
+  #sendHandshake(attempt: number) {
+    if (this.#handshakeId === null || attempt >= MAX_HANDSHAKE_ATTEMPTS) {
+      return
+    }
+
+    this.#post(this.#options.parentWindow, {
+      type: 'handshake',
+      id: this.#handshakeId,
+    })
+
+    this.#handshakeTimer = setTimeout(
+      () => {
+        this.#sendHandshake(attempt + 1)
+      },
+      HANDSHAKE_RETRY_MS * 2 ** attempt
+    )
   }
 
   #dispatch(message: FrameMessage, source: unknown) {
@@ -201,6 +279,64 @@ export class FrameAgent {
 
         return
       }
+
+      case 'handshake': {
+        const frame = this.#options
+          .getFrames()
+          .find((candidate) => candidate.contentWindow === source)
+
+        if (frame === undefined) {
+          return
+        }
+
+        this.#post(source, {
+          type: 'handshake-ack',
+          id: message.id,
+          toolActive: this.#toolActive,
+        })
+
+        return
+      }
+
+      case 'handshake-ack': {
+        if (
+          source !== this.#options.parentWindow ||
+          message.id !== this.#handshakeId
+        ) {
+          return
+        }
+
+        this.#handshakeId = null
+
+        if (this.#handshakeTimer !== null) {
+          clearTimeout(this.#handshakeTimer)
+          this.#handshakeTimer = null
+        }
+
+        this.#toolActive = message.toolActive
+
+        return
+      }
+
+      case 'tool-state': {
+        if (source !== this.#options.parentWindow) {
+          return
+        }
+
+        this.broadcastToolState(message.active)
+
+        return
+      }
     }
   }
+}
+
+let installedAgent: FrameAgent | null = null
+
+export function installFrameAgent(agent: FrameAgent | null) {
+  installedAgent = agent
+}
+
+export function getFrameAgent(): FrameAgent | null {
+  return installedAgent
 }

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -96,8 +96,23 @@ export interface FrameAgentOptions {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 1000
 
+interface PostMessageTarget {
+  postMessage(message: unknown, targetOrigin: string): void
+}
+
+function isPostMessageTarget(target: unknown): target is PostMessageTarget {
+  return (
+    typeof target === 'object' &&
+    target !== null &&
+    typeof (target as PostMessageTarget).postMessage === 'function'
+  )
+}
+
+// A cross-origin WindowProxy fails `instanceof Window` silently, because its
+// prototype chain is inaccessible cross-origin. Checking for postMessage
+// structurally works for both same-origin windows and cross-origin proxies.
 function defaultSend(target: unknown, envelope: unknown) {
-  if (target instanceof Window) {
+  if (isPostMessageTarget(target)) {
     target.postMessage(envelope, '*')
   }
 }

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -2,9 +2,16 @@ import { nanoid } from 'nanoid'
 import { z } from 'zod/v4'
 
 import {
+  BoundsSchema,
+  SerializedElementState,
+  SerializedElementStateSchema,
+} from '@/recorder/browser/serialization'
+import {
   BrowserEventTarget,
   BrowserEventTargetSchema,
 } from '@/schemas/recording'
+
+type Bounds = z.infer<typeof BoundsSchema>
 
 const PROTOCOL_SOURCE = 'k6-studio-frames'
 const PROTOCOL_VERSION = 1
@@ -39,13 +46,98 @@ const ToolStateSchema = z.object({
   active: z.boolean(),
 })
 
+const OffsetSchema = z.object({
+  left: z.number(),
+  top: z.number(),
+})
+
+const TextSelectionPayloadSchema = z.object({
+  text: z.string(),
+  elements: SerializedElementStateSchema.array(),
+  framePath: BrowserEventTargetSchema.array().nullable(),
+  highlights: BoundsSchema.array(),
+  bounds: BoundsSchema,
+  offset: OffsetSchema,
+})
+
+const ElementPickPayloadSchema = z.object({
+  elements: SerializedElementStateSchema.array(),
+  associatedControl: SerializedElementStateSchema.nullable(),
+  framePath: BrowserEventTargetSchema.array().nullable(),
+  position: OffsetSchema,
+  offset: OffsetSchema,
+})
+
+const TextSelectionSchema = z.object({
+  type: z.literal('text-selection'),
+  payload: TextSelectionPayloadSchema,
+})
+
+const ElementPickSchema = z.object({
+  type: z.literal('element-pick'),
+  payload: ElementPickPayloadSchema,
+})
+
 const FrameMessageSchema = z.discriminatedUnion('type', [
   FramePathRequestSchema,
   FramePathResponseSchema,
   HandshakeSchema,
   HandshakeAckSchema,
   ToolStateSchema,
+  TextSelectionSchema,
+  ElementPickSchema,
 ])
+
+/**
+ * Payload carried by a `text-selection` message, relayed from the frame where
+ * the selection was made up to the top frame. `offset` accumulates each
+ * intermediate frame's viewport position as the message travels upward,
+ * starting at `{ left: 0, top: 0 }` in the sending frame.
+ */
+export interface TextSelectionPayload {
+  text: string
+  /** commonAncestor chain, innermost first. */
+  elements: SerializedElementState[]
+  framePath: BrowserEventTarget[] | null
+  /** Range client rects, in the sending frame's viewport coordinates. */
+  highlights: Bounds[]
+  /** Range bounding rect, in the sending frame's viewport coordinates. */
+  bounds: Bounds
+  offset: { left: number; top: number }
+}
+
+/**
+ * Payload carried by an `element-pick` message, relayed from the frame where
+ * the element was picked up to the top frame. `offset` accumulates each
+ * intermediate frame's viewport position as the message travels upward,
+ * starting at `{ left: 0, top: 0 }` in the sending frame.
+ */
+export interface ElementPickPayload {
+  /** Picked element chain, innermost first. */
+  elements: SerializedElementState[]
+  associatedControl: SerializedElementState | null
+  framePath: BrowserEventTarget[] | null
+  /** clientX/Y, in the sending frame's viewport coordinates. */
+  position: { left: number; top: number }
+  offset: { left: number; top: number }
+}
+
+/**
+ * Accumulates one frame hop's viewport offset onto `offset`. Mirrors the
+ * single-hop math in `getFrameOffset` (src/utils/dom/layout.ts): only the
+ * iframe's bounding rect position is added, not `clientLeft`/`clientTop`.
+ */
+function addFrameHopOffset(
+  offset: { left: number; top: number },
+  iframe: Element
+): { left: number; top: number } {
+  const rect = iframe.getBoundingClientRect()
+
+  return {
+    left: offset.left + rect.left,
+    top: offset.top + rect.top,
+  }
+}
 
 const HANDSHAKE_RETRY_MS = 100
 const MAX_HANDSHAKE_ATTEMPTS = 5
@@ -149,6 +241,8 @@ export class FrameAgent {
   #toolActive = false
   #handshakeId: string | null = null
   #handshakeTimer: ReturnType<typeof setTimeout> | null = null
+  #textSelectionListeners = new Set<(payload: TextSelectionPayload) => void>()
+  #elementPickListeners = new Set<(payload: ElementPickPayload) => void>()
 
   #handleMessage = (event: FrameMessageEvent) => {
     // This listener sees every postMessage the page receives (ads, widgets,
@@ -228,6 +322,56 @@ export class FrameAgent {
     })
   }
 
+  /**
+   * Sends a text selection made in this frame toward the top frame, starting
+   * with a zero offset. A no-op in the top frame: there is no parent to send
+   * to, and the top frame delivers payloads to listeners instead of sending.
+   */
+  sendTextSelection(payload: Omit<TextSelectionPayload, 'offset'>) {
+    if (this.#options.parentWindow === null) {
+      return
+    }
+
+    this.#post(this.#options.parentWindow, {
+      type: 'text-selection',
+      payload: { ...payload, offset: { left: 0, top: 0 } },
+    })
+  }
+
+  /**
+   * Sends an element pick made in this frame toward the top frame, starting
+   * with a zero offset. A no-op in the top frame, for the same reason as
+   * {@link sendTextSelection}.
+   */
+  sendElementPick(payload: Omit<ElementPickPayload, 'offset'>) {
+    if (this.#options.parentWindow === null) {
+      return
+    }
+
+    this.#post(this.#options.parentWindow, {
+      type: 'element-pick',
+      payload: { ...payload, offset: { left: 0, top: 0 } },
+    })
+  }
+
+  /** Registers a listener for text selections relayed up to the top frame. */
+  onTextSelection(listener: (payload: TextSelectionPayload) => void) {
+    this.#textSelectionListeners.add(listener)
+
+    return () => {
+      this.#textSelectionListeners.delete(listener)
+    }
+  }
+
+  /** Registers a listener for element picks relayed up to the top frame. */
+  onElementPick(listener: (payload: ElementPickPayload) => void) {
+    this.#elementPickListeners.add(listener)
+
+    return () => {
+      this.#elementPickListeners.delete(listener)
+    }
+  }
+
   dispose() {
     this.#options.win.removeEventListener('message', this.#handleMessage)
 
@@ -237,6 +381,8 @@ export class FrameAgent {
     })
 
     this.#pending.clear()
+    this.#textSelectionListeners.clear()
+    this.#elementPickListeners.clear()
 
     if (this.#handshakeTimer !== null) {
       clearTimeout(this.#handshakeTimer)
@@ -367,6 +513,58 @@ export class FrameAgent {
         }
 
         this.broadcastToolState(message.active)
+
+        return
+      }
+
+      case 'text-selection': {
+        const frame = this.#findChildFrame(source)
+
+        if (frame === undefined) {
+          return
+        }
+
+        const payload: TextSelectionPayload = {
+          ...message.payload,
+          offset: addFrameHopOffset(message.payload.offset, frame.element),
+        }
+
+        if (this.#options.parentWindow === null) {
+          this.#textSelectionListeners.forEach((listener) => listener(payload))
+
+          return
+        }
+
+        this.#post(this.#options.parentWindow, {
+          type: 'text-selection',
+          payload,
+        })
+
+        return
+      }
+
+      case 'element-pick': {
+        const frame = this.#findChildFrame(source)
+
+        if (frame === undefined) {
+          return
+        }
+
+        const payload: ElementPickPayload = {
+          ...message.payload,
+          offset: addFrameHopOffset(message.payload.offset, frame.element),
+        }
+
+        if (this.#options.parentWindow === null) {
+          this.#elementPickListeners.forEach((listener) => listener(payload))
+
+          return
+        }
+
+        this.#post(this.#options.parentWindow, {
+          type: 'element-pick',
+          payload,
+        })
 
         return
       }

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -58,6 +58,19 @@ const FrameEnvelopeSchema = z.object({
 
 type FrameMessage = z.infer<typeof FrameMessageSchema>
 
+/**
+ * Fast pre-check for the protocol's envelope marker, so unrelated page
+ * messages are discarded on one property read instead of a full schema parse.
+ */
+function isProtocolEnvelope(data: unknown): boolean {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'source' in data &&
+    data.source === PROTOCOL_SOURCE
+  )
+}
+
 export interface FrameMessageEvent {
   data: unknown
   source: unknown
@@ -138,6 +151,13 @@ export class FrameAgent {
   #handshakeTimer: ReturnType<typeof setTimeout> | null = null
 
   #handleMessage = (event: FrameMessageEvent) => {
+    // This listener sees every postMessage the page receives (ads, widgets,
+    // analytics), so bail on a single property read before paying for full
+    // schema validation of unrelated traffic.
+    if (!isProtocolEnvelope(event.data)) {
+      return
+    }
+
     const parsed = FrameEnvelopeSchema.safeParse(event.data)
 
     if (!parsed.success) {
@@ -250,6 +270,13 @@ export class FrameAgent {
     )
   }
 
+  /** The child frame whose contentWindow sent a message, if it is ours. */
+  #findChildFrame(source: unknown): FrameRef | undefined {
+    return this.#options
+      .getFrames()
+      .find((candidate) => candidate.contentWindow === source)
+  }
+
   #dispatch(message: FrameMessage, source: unknown) {
     switch (message.type) {
       case 'frame-path-response': {
@@ -271,9 +298,7 @@ export class FrameAgent {
       }
 
       case 'frame-path-request': {
-        const frame = this.#options
-          .getFrames()
-          .find((candidate) => candidate.contentWindow === source)
+        const frame = this.#findChildFrame(source)
 
         if (frame === undefined) {
           return
@@ -303,11 +328,7 @@ export class FrameAgent {
       }
 
       case 'handshake': {
-        const frame = this.#options
-          .getFrames()
-          .find((candidate) => candidate.contentWindow === source)
-
-        if (frame === undefined) {
+        if (this.#findChildFrame(source) === undefined) {
           return
         }
 

--- a/src/recorder/browser/messaging/frames.ts
+++ b/src/recorder/browser/messaging/frames.ts
@@ -279,18 +279,25 @@ export class FrameAgent {
           return
         }
 
-        void this.#options.getOwnPath().then((ownPath) => {
-          const path =
+        // Any failure (getOwnPath rejecting or the locator computation
+        // throwing, e.g. on a detached iframe) still answers with a null
+        // path, so the child falls back immediately instead of stalling
+        // its full request timeout.
+        void this.#options
+          .getOwnPath()
+          .then((ownPath) =>
             ownPath === null
               ? null
               : [...ownPath, this.#options.getIframeLocator(frame.element)]
-
-          this.#post(source, {
-            type: 'frame-path-response',
-            id: message.id,
-            path,
+          )
+          .catch(() => null)
+          .then((path) => {
+            this.#post(source, {
+              type: 'frame-path-response',
+              id: message.id,
+              path,
+            })
           })
-        })
 
         return
       }

--- a/src/recorder/browser/recording.ts
+++ b/src/recorder/browser/recording.ts
@@ -1,7 +1,5 @@
 import { nanoid } from 'nanoid'
 
-import { BrowserEvent } from '@/schemas/recording'
-
 import {
   findAssociatedElement,
   findInteractiveElement,
@@ -12,7 +10,8 @@ import {
 } from '../../utils/dom/dom'
 import { getElementDetails } from '../../utils/dom/selectors'
 
-import { getFramePath, withFrames } from './frames'
+import { createSequentialEmitter } from './emitQueue'
+import { getFramePathAsync } from './frames'
 import { eventManager } from './manager'
 import { BrowserExtensionClient } from './messaging'
 import { getTabId } from './utils'
@@ -55,18 +54,12 @@ export function startRecording(
     }
   }
 
-  function recordEvents(events: BrowserEvent[] | BrowserEvent) {
-    const list = Array.isArray(events) ? events : [events]
-
-    // All events captured in this listener happened in the current frame, so
-    // they share the same frame path.
-    const frames = getFramePath()
-
+  const recordEvents = createSequentialEmitter(getFramePathAsync, (events) => {
     client.send({
       type: 'record-events',
-      events: list.map((event) => withFrames(event, frames)),
+      events,
     })
-  }
+  })
 
   const manager = eventManager
 

--- a/src/recorder/browser/recording.ts
+++ b/src/recorder/browser/recording.ts
@@ -54,12 +54,17 @@ export function startRecording(
     }
   }
 
-  const recordEvents = createSequentialEmitter(getFramePathAsync, (events) => {
-    client.send({
-      type: 'record-events',
-      events,
-    })
-  })
+  const { emit: recordEvents, flush } = createSequentialEmitter(
+    getFramePathAsync,
+    (events) => {
+      client.send({
+        type: 'record-events',
+        events,
+      })
+    }
+  )
+
+  window.addEventListener('pagehide', flush)
 
   const manager = eventManager
 

--- a/src/recorder/browser/serialization.test.ts
+++ b/src/recorder/browser/serialization.test.ts
@@ -69,6 +69,68 @@ describe('serializeElementState', () => {
     expect(state.textBoxValue).toBe('hello world')
   })
 
+  it('captures the text content of the element itself', () => {
+    const div = document.createElement('div')
+    div.textContent = 'Some text'
+    document.body.append(div)
+
+    const state = serializeElementState(div)
+
+    expect(state.textContent).toBe('Some text')
+  })
+
+  it('captures an empty text content for an element without text', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const state = serializeElementState(div)
+
+    expect(state.textContent).toBe('')
+  })
+
+  it('reports a textarea as a multiline text box', () => {
+    const textarea = document.createElement('textarea')
+    document.body.append(textarea)
+
+    const state = serializeElementState(textarea)
+
+    expect(state.isMultilineTextBox).toBe(true)
+  })
+
+  it('reports an aria-multiline textbox as a multiline text box', () => {
+    const div = document.createElement('div')
+    div.setAttribute('role', 'textbox')
+    div.setAttribute('aria-multiline', 'true')
+    document.body.append(div)
+
+    const state = serializeElementState(div)
+
+    expect(state.isMultilineTextBox).toBe(true)
+  })
+
+  it('reports a single-line text input as not multiline', () => {
+    const textInput = document.createElement('input')
+    textInput.type = 'text'
+    document.body.append(textInput)
+
+    const state = serializeElementState(textInput)
+
+    expect(state.isMultilineTextBox).toBe(false)
+  })
+
+  it('resolves multiline-ness through an associated label', () => {
+    const label = document.createElement('label')
+    const textarea = document.createElement('textarea')
+    textarea.id = 'notes'
+    label.setAttribute('for', 'notes')
+
+    document.body.append(label, textarea)
+
+    const state = serializeElementState(label)
+
+    expect(state.isMultilineTextBox).toBe(true)
+  })
+
   it('captures viewport bounds from getBoundingClientRect', () => {
     const div = document.createElement('div')
     document.body.append(div)

--- a/src/recorder/browser/serialization.test.ts
+++ b/src/recorder/browser/serialization.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  ElementRoleSchema,
+  SerializedElementStateSchema,
+  serializeElementChain,
+  serializeElementState,
+} from './serialization'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('serializeElementState', () => {
+  it('snapshots a checked native checkbox', () => {
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.checked = true
+    document.body.append(checkbox)
+
+    const state = serializeElementState(checkbox)
+
+    expect(state.checkedState).toBe('checked')
+    expect(state.isNativeCheckbox).toBe(true)
+  })
+
+  it('snapshots an unchecked native checkbox', () => {
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.checked = false
+    document.body.append(checkbox)
+
+    const state = serializeElementState(checkbox)
+
+    expect(state.checkedState).toBe('unchecked')
+    expect(state.isNativeCheckbox).toBe(true)
+  })
+
+  it('snapshots an indeterminate native checkbox', () => {
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.indeterminate = true
+    document.body.append(checkbox)
+
+    const state = serializeElementState(checkbox)
+
+    expect(state.checkedState).toBe('indeterminate')
+    expect(state.isNativeCheckbox).toBe(true)
+  })
+
+  it('reports isNativeCheckbox as false for a non-checkbox input', () => {
+    const textInput = document.createElement('input')
+    textInput.type = 'text'
+    document.body.append(textInput)
+
+    const state = serializeElementState(textInput)
+
+    expect(state.isNativeCheckbox).toBe(false)
+  })
+
+  it('captures the text box value of a text input', () => {
+    const textInput = document.createElement('input')
+    textInput.type = 'text'
+    textInput.value = 'hello world'
+    document.body.append(textInput)
+
+    const state = serializeElementState(textInput)
+
+    expect(state.textBoxValue).toBe('hello world')
+  })
+
+  it('captures viewport bounds from getBoundingClientRect', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    div.getBoundingClientRect = () =>
+      ({
+        top: 10,
+        left: 20,
+        width: 30,
+        height: 40,
+      }) as DOMRect
+
+    const state = serializeElementState(div)
+
+    expect(state.bounds).toEqual({ top: 10, left: 20, width: 30, height: 40 })
+  })
+
+  it('resolves checked state through an associated label', () => {
+    const label = document.createElement('label')
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.id = 'agree'
+    checkbox.checked = true
+    label.setAttribute('for', 'agree')
+
+    document.body.append(label, checkbox)
+
+    const state = serializeElementState(label)
+
+    expect(state.checkedState).toBe('checked')
+    expect(state.isNativeCheckbox).toBe(true)
+  })
+
+  it('parses cleanly against SerializedElementStateSchema', () => {
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    document.body.append(checkbox)
+
+    const state = serializeElementState(checkbox)
+
+    expect(() => SerializedElementStateSchema.parse(state)).not.toThrow()
+  })
+})
+
+describe('serializeElementChain', () => {
+  it('orders the chain innermost first and excludes documentElement', () => {
+    const outer = document.createElement('div')
+    outer.id = 'outer'
+    const middle = document.createElement('div')
+    middle.id = 'middle'
+    const inner = document.createElement('div')
+    inner.id = 'inner'
+
+    outer.append(middle)
+    middle.append(inner)
+    document.body.append(outer)
+
+    const chain = serializeElementChain(inner)
+
+    expect(chain).toHaveLength(4)
+    expect(chain.map((state) => state.target.selectors.css)).toEqual([
+      '#inner',
+      '#middle',
+      '#outer',
+      'body',
+    ])
+  })
+
+  it('does not include the documentElement in the chain', () => {
+    const chain = serializeElementChain(document.body)
+
+    expect(chain).toHaveLength(1)
+    expect(chain[0]?.target.selectors.css).toBe('body')
+  })
+})
+
+describe('ElementRoleSchema', () => {
+  it('parses both intrinsic and explicit roles', () => {
+    expect(() =>
+      ElementRoleSchema.parse({ type: 'intrinsic', role: 'button' })
+    ).not.toThrow()
+    expect(() =>
+      ElementRoleSchema.parse({ type: 'explicit', role: 'tab' })
+    ).not.toThrow()
+  })
+
+  it('rejects an unknown type', () => {
+    expect(() =>
+      ElementRoleSchema.parse({ type: 'unknown', role: 'button' })
+    ).toThrow()
+  })
+})

--- a/src/recorder/browser/serialization.ts
+++ b/src/recorder/browser/serialization.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod/v4'
+
+import {
+  getCheckedState,
+  getTextBoxValue,
+} from '@/recorder/browser/view/ElementInspector/ElementMenu.utils'
+import { BrowserEventTargetSchema } from '@/schemas/recording'
+import { ElementRole, getElementRoles } from '@/utils/dom/aria'
+import { findAssociatedElement } from '@/utils/dom/dom'
+import { isHTMLInputElement } from '@/utils/dom/realm'
+import { getElementDetails } from '@/utils/dom/selectors'
+
+export const ElementRoleSchema = z.object({
+  type: z.enum(['intrinsic', 'explicit']),
+  role: z.string(),
+}) satisfies z.ZodType<ElementRole>
+
+export const BoundsSchema = z.object({
+  top: z.number(),
+  left: z.number(),
+  width: z.number(),
+  height: z.number(),
+})
+
+export const SerializedElementStateSchema = z.object({
+  target: BrowserEventTargetSchema,
+  roles: z.array(ElementRoleSchema),
+  bounds: BoundsSchema,
+  checkedState: z.enum(['checked', 'unchecked', 'indeterminate']),
+  textBoxValue: z.string(),
+  isNativeCheckbox: z.boolean(),
+})
+
+export type SerializedElementState = z.infer<
+  typeof SerializedElementStateSchema
+>
+
+/**
+ * Snapshots everything the cross-origin inspector needs to describe `element`
+ * without keeping a live reference to it, so the state can be relayed across
+ * frame boundaries as plain, serializable data.
+ *
+ * A label wrapping a checkbox/radio/textbox has no checked state or value of
+ * its own, so `checkedState`, `textBoxValue`, and `isNativeCheckbox` are read
+ * from the associated control when `element` is a label, falling back to
+ * `element` itself otherwise. `target` and `roles` always describe `element`
+ * as inspected, since that is what the user pointed at.
+ */
+export function serializeElementState(
+  element: Element
+): SerializedElementState {
+  const controlElement = findAssociatedElement(element) ?? element
+  const bounds = element.getBoundingClientRect()
+
+  return {
+    target: getElementDetails(element),
+    roles: [...getElementRoles(element)],
+    bounds: {
+      top: bounds.top,
+      left: bounds.left,
+      width: bounds.width,
+      height: bounds.height,
+    },
+    checkedState: getCheckedState(controlElement),
+    textBoxValue: getTextBoxValue(controlElement),
+    isNativeCheckbox:
+      isHTMLInputElement(controlElement) && controlElement.type === 'checkbox',
+  }
+}
+
+/**
+ * Serializes `element` and its ancestor chain, innermost first, stopping
+ * before `documentElement` so `<body>` is included but `<html>` is not.
+ */
+export function serializeElementChain(
+  element: Element
+): SerializedElementState[] {
+  const documentElement = element.ownerDocument.documentElement
+  const chain: Element[] = []
+
+  let current: Element | null = element
+
+  while (current !== null && current !== documentElement) {
+    chain.push(current)
+    current = current.parentElement
+  }
+
+  return chain.map(serializeElementState)
+}

--- a/src/recorder/browser/serialization.ts
+++ b/src/recorder/browser/serialization.ts
@@ -7,7 +7,7 @@ import {
 import { BrowserEventTargetSchema } from '@/schemas/recording'
 import { ElementRole, getElementRoles } from '@/utils/dom/aria'
 import { findAssociatedElement } from '@/utils/dom/dom'
-import { isHTMLInputElement } from '@/utils/dom/realm'
+import { isHTMLInputElement, isHTMLTextAreaElement } from '@/utils/dom/realm'
 import { getElementDetails } from '@/utils/dom/selectors'
 
 export const ElementRoleSchema = z.object({
@@ -26,9 +26,11 @@ export const SerializedElementStateSchema = z.object({
   target: BrowserEventTargetSchema,
   roles: z.array(ElementRoleSchema),
   bounds: BoundsSchema,
+  textContent: z.string(),
   checkedState: z.enum(['checked', 'unchecked', 'indeterminate']),
   textBoxValue: z.string(),
   isNativeCheckbox: z.boolean(),
+  isMultilineTextBox: z.boolean(),
 })
 
 export type SerializedElementState = z.infer<
@@ -41,10 +43,11 @@ export type SerializedElementState = z.infer<
  * frame boundaries as plain, serializable data.
  *
  * A label wrapping a checkbox/radio/textbox has no checked state or value of
- * its own, so `checkedState`, `textBoxValue`, and `isNativeCheckbox` are read
- * from the associated control when `element` is a label, falling back to
- * `element` itself otherwise. `target` and `roles` always describe `element`
- * as inspected, since that is what the user pointed at.
+ * its own, so `checkedState`, `textBoxValue`, `isNativeCheckbox`, and
+ * `isMultilineTextBox` are read from the associated control when `element` is
+ * a label, falling back to `element` itself otherwise. `target`, `roles`, and
+ * `textContent` always describe `element` as inspected, since that is what
+ * the user pointed at.
  */
 export function serializeElementState(
   element: Element
@@ -61,10 +64,16 @@ export function serializeElementState(
       width: bounds.width,
       height: bounds.height,
     },
+    textContent: element.textContent ?? '',
     checkedState: getCheckedState(controlElement),
     textBoxValue: getTextBoxValue(controlElement),
     isNativeCheckbox:
       isHTMLInputElement(controlElement) && controlElement.type === 'checkbox',
+    // Mirrors how the live menu decides `multiline` for a text-input
+    // assertion (see TextInputAssertion in ElementMenu.tsx).
+    isMultilineTextBox:
+      isHTMLTextAreaElement(controlElement) ||
+      controlElement.getAttribute('aria-multiline') === 'true',
   }
 }
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.test.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.test.ts
@@ -1,0 +1,155 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  FrameAgent,
+  installFrameAgent,
+} from '@/recorder/browser/messaging/frames'
+import { serializeElementChain } from '@/recorder/browser/serialization'
+
+import { useInspectedElement } from './ElementInspector.hooks'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  installFrameAgent(null)
+})
+
+function installPickListener() {
+  let onElementPick: ((payload: unknown) => void) | undefined
+
+  installFrameAgent({
+    onElementPick: (listener: (payload: unknown) => void) => {
+      onElementPick = listener
+
+      return () => {}
+    },
+  } as unknown as FrameAgent)
+
+  return () => {
+    if (onElementPick === undefined) {
+      throw new Error('expected useInspectedElement to subscribe')
+    }
+
+    return onElementPick
+  }
+}
+
+describe('useInspectedElement remote picks', () => {
+  it('pins a remote element from a payload relayed over the frame agent', () => {
+    const getPickListener = installPickListener()
+
+    document.body.innerHTML = '<input type="checkbox" id="checkbox" checked />'
+    const checkbox = document.querySelector('#checkbox')
+
+    if (checkbox === null) {
+      throw new Error('expected #checkbox element')
+    }
+
+    checkbox.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, width: 100, height: 100 }) as DOMRect
+
+    const [state] = serializeElementChain(checkbox)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const { result } = renderHook(() => useInspectedElement())
+
+    act(() => {
+      getPickListener()({
+        elements: [state],
+        associatedControl: state,
+        framePath: null,
+        position: { left: 10, top: 10 },
+        offset: { left: 0, top: 0 },
+      })
+    })
+
+    expect(result.current.pinned?.kind).toBe('remote')
+    expect(result.current.element?.kind).toBe('remote')
+    expect(result.current.mousePosition).toEqual({ left: 10, top: 10 })
+
+    if (result.current.pinned?.kind !== 'remote') {
+      throw new Error('expected a remote pinned element')
+    }
+
+    expect(result.current.pinned.associatedControl).toBe(state)
+  })
+
+  it('ignores a pick outside the picked element bounds', () => {
+    const getPickListener = installPickListener()
+
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    target.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, width: 10, height: 10 }) as DOMRect
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const { result } = renderHook(() => useInspectedElement())
+
+    act(() => {
+      getPickListener()({
+        elements: [state],
+        associatedControl: null,
+        framePath: null,
+        position: { left: 1000, top: 1000 },
+        offset: { left: 0, top: 0 },
+      })
+    })
+
+    expect(result.current.pinned).toBeNull()
+  })
+
+  it('resets instead of pinning a new remote element when one is already pinned', () => {
+    const getPickListener = installPickListener()
+
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    target.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, width: 100, height: 100 }) as DOMRect
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const { result } = renderHook(() => useInspectedElement())
+
+    const payload = {
+      elements: [state],
+      associatedControl: null,
+      framePath: null,
+      position: { left: 10, top: 10 },
+      offset: { left: 0, top: 0 },
+    }
+
+    act(() => {
+      getPickListener()(payload)
+    })
+
+    expect(result.current.pinned).not.toBeNull()
+
+    act(() => {
+      getPickListener()(payload)
+    })
+
+    expect(result.current.pinned).toBeNull()
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
@@ -9,7 +9,7 @@ import { useHighlightDebounce } from '../hooks/useHighlightDebounce'
 import { usePreventClick } from '../hooks/usePreventClick'
 
 import { usePinnedElement } from './hooks'
-import { toTrackedElement, TrackedElement } from './utils'
+import { LiveTrackedElement, toTrackedElement } from './utils'
 
 function isInsideBounds(
   position: Position,
@@ -42,7 +42,7 @@ export function useInspectedElement() {
    *    the selection and removed when the user contracts the selection. If the
    *    stack is empty, then no element is pinned.
    */
-  const [hoveredEl, setHoveredEl] = useState<TrackedElement | null>(null)
+  const [hoveredEl, setHoveredEl] = useState<LiveTrackedElement | null>(null)
 
   const { selected, pinned, pin, unpin, expand, contract } = usePinnedElement()
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.hooks.ts
@@ -3,13 +3,20 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Bounds, Position } from '@/components/Browser/types'
 import { isHTMLIFrameElement } from '@/utils/dom/realm'
 
+import { ElementPickPayload, getFrameAgent } from '../../messaging/frames'
 import { toTopFramePosition } from '../frameGeometry'
 import { useGlobalClass } from '../GlobalStyles'
 import { useHighlightDebounce } from '../hooks/useHighlightDebounce'
 import { usePreventClick } from '../hooks/usePreventClick'
 
 import { usePinnedElement } from './hooks'
-import { LiveTrackedElement, toTrackedElement } from './utils'
+import {
+  finalizeRemotePosition,
+  InspectedElement,
+  LiveTrackedElement,
+  toRemoteTrackedElement,
+  toTrackedElement,
+} from './utils'
 
 function isInsideBounds(
   position: Position,
@@ -44,7 +51,8 @@ export function useInspectedElement() {
    */
   const [hoveredEl, setHoveredEl] = useState<LiveTrackedElement | null>(null)
 
-  const { selected, pinned, pin, unpin, expand, contract } = usePinnedElement()
+  const { selected, pinned, pin, unpin, expand, contract } =
+    usePinnedElement<InspectedElement>()
 
   useGlobalClass('inspecting')
 
@@ -163,6 +171,44 @@ export function useInspectedElement() {
     )
   }
 
+  // Picks made in a cross-origin child frame can't reach the bridge above, so
+  // they're relayed to the top frame over the frame agent instead (see
+  // attachInspectionDetection). Kept in a ref for the same reason as
+  // hoverRef/pickRef: the subscription below is only set up once.
+  const remotePickRef = useRef<(payload: ElementPickPayload) => void>(() => {})
+
+  remotePickRef.current = (payload) => {
+    if (pinned !== null) {
+      reset()
+
+      return
+    }
+
+    const [elementState, ...ancestors] = payload.elements
+
+    if (elementState === undefined) {
+      return
+    }
+
+    const remote = toRemoteTrackedElement(
+      elementState,
+      ancestors,
+      payload.framePath,
+      payload.offset,
+      payload.associatedControl
+    )
+
+    const position = finalizeRemotePosition(payload.position, payload.offset)
+
+    // Mirrors pinElement's own bounds check for the live case.
+    if (!isInsideBounds(position, remote.bounds)) {
+      return
+    }
+
+    setMousePosition(position)
+    pin(remote)
+  }
+
   useEffect(() => {
     window.__K6_STUDIO_INSPECTION__ = {
       hover: (element) => hoverRef.current(element),
@@ -172,6 +218,16 @@ export function useInspectedElement() {
 
     return () => {
       delete window.__K6_STUDIO_INSPECTION__
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = getFrameAgent()?.onElementPick((payload) => {
+      remotePickRef.current(payload)
+    })
+
+    return () => {
+      unsubscribe?.()
     }
   }, [])
 

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.tsx
@@ -7,7 +7,7 @@ import { Overlay } from '@/components/Browser/Overlay'
 import { Tooltip } from '@/components/primitives/Tooltip'
 import { ElementRole } from '@/utils/dom/aria'
 
-import { getFramePathForElement, withFrames } from '../../frames'
+import { withFrames } from '../../frames'
 import { getTabId } from '../../utils'
 import { Anchor } from '../Anchor'
 import { useEscape } from '../hooks/useEscape'
@@ -16,7 +16,7 @@ import { useStudioClient } from '../StudioClientProvider'
 import { AssertionEditor } from './assertions/AssertionEditor'
 import { AssertionData } from './assertions/types'
 import { useInspectedElement } from './ElementInspector.hooks'
-import { toAssertion } from './ElementInspector.utils'
+import { getFramesForElement, toAssertion } from './ElementInspector.utils'
 import { ElementMenu } from './ElementMenu'
 import { ElementPopover } from './ElementPopover'
 import { useElementHighlight } from './hooks'
@@ -88,7 +88,7 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
   }
 
   const handleAssertionSubmit = (assertion: AssertionData) => {
-    const frames = element ? getFramePathForElement(element.element) : []
+    const frames = getFramesForElement(element)
 
     client.send({
       type: 'record-events',
@@ -115,7 +115,7 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
   }
 
   const handleAddWaitFor = (data: WaitForData) => {
-    const frames = element ? getFramePathForElement(element.element) : []
+    const frames = getFramesForElement(element)
 
     client.send({
       type: 'record-events',
@@ -141,7 +141,12 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
     return null
   }
 
-  if (pinned === null) {
+  // Hover previews only come from same-origin detection: remote picks are
+  // pinned as soon as they arrive (see useInspectedElement), so this branch
+  // never actually sees a remote element. Guarded here rather than assumed,
+  // so a future remote hover source degrades to no preview instead of
+  // crashing on the DOM-only fields below.
+  if (pinned === null && element.kind === 'live') {
     return (
       <Tooltip.Root open={true}>
         <Tooltip.Trigger asChild>
@@ -168,6 +173,10 @@ export function ElementInspector({ onClose }: ElementInspectorProps) {
         </Tooltip.Portal>
       </Tooltip.Root>
     )
+  }
+
+  if (pinned === null) {
+    return null
   }
 
   return (

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.utils.test.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.utils.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { serializeElementChain } from '@/recorder/browser/serialization'
+import { getElementDetails } from '@/utils/dom/selectors'
+
+import { getFramesForElement } from './ElementInspector.utils'
+import { toRemoteTrackedElement, toTrackedElement } from './utils'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('getFramesForElement', () => {
+  it('returns an empty path when there is no element', () => {
+    expect(getFramesForElement(null)).toEqual([])
+  })
+
+  it('returns an empty path for a live element in the top frame', () => {
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    expect(getFramesForElement(toTrackedElement(target))).toEqual([])
+  })
+
+  it('walks the owning iframe chain for a live element inside an iframe', () => {
+    const iframe = document.createElement('iframe')
+    iframe.id = 'child-frame'
+    document.body.append(iframe)
+
+    const doc = iframe.contentDocument
+
+    if (doc === null) {
+      throw new Error('iframe has no contentDocument')
+    }
+
+    const inner = doc.createElement('div')
+    doc.body.append(inner)
+
+    expect(getFramesForElement(toTrackedElement(inner))).toEqual([
+      getElementDetails(iframe),
+    ])
+  })
+
+  it('returns the relayed frame path for a remote element', () => {
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const framePath = [{ selectors: { css: 'iframe#a' } }]
+    const remote = toRemoteTrackedElement(state, [], framePath, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(getFramesForElement(remote)).toBe(framePath)
+  })
+
+  it('returns an empty path for a remote element with an unresolved frame path', () => {
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(getFramesForElement(remote)).toEqual([])
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/ElementInspector.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementInspector.utils.ts
@@ -1,7 +1,27 @@
-import { Assertion } from '@/schemas/recording'
+import { Assertion, BrowserEventTarget } from '@/schemas/recording'
 import { exhaustive } from '@/utils/typescript'
 
+import { getFramePathForElement } from '../../frames'
+
 import { AssertionData } from './assertions/types'
+import { InspectedElement } from './utils'
+
+/**
+ * The frame path a recorded event should carry for `element`: a live element
+ * can walk its own DOM to find it, while a remote element only knows the
+ * frame path the relay resolved when it was picked.
+ */
+export function getFramesForElement(
+  element: InspectedElement | null
+): BrowserEventTarget[] {
+  if (element === null) {
+    return []
+  }
+
+  return element.kind === 'live'
+    ? getFramePathForElement(element.element)
+    : (element.framePath ?? [])
+}
 
 export function toAssertion(data: AssertionData): Assertion {
   switch (data.type) {

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.test.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.test.tsx
@@ -161,14 +161,58 @@ describe('ElementMenu with a remote element', () => {
     expect(onSelectAssertion).toHaveBeenCalledWith({
       type: 'text-input',
       target: inputState.target,
-      // A remote control's multiline-ness can't be read without live DOM
-      // access, so it degrades to single-line.
       multiline: false,
       expected: 'hello',
     })
   })
 
-  it('reports an empty text assertion, since a remote element has no live textContent', () => {
+  it('reports a multiline text-input assertion for a textarea control', () => {
+    document.body.innerHTML =
+      '<label id="label"></label><textarea id="notes">hello</textarea>'
+
+    const label = document.querySelector('#label')
+    const textarea = document.querySelector('#notes')
+
+    if (label === null || textarea === null) {
+      throw new Error('expected #label and #notes elements')
+    }
+
+    const [labelState] = serializeElementChain(label)
+    const [textareaState] = serializeElementChain(textarea)
+
+    if (labelState === undefined || textareaState === undefined) {
+      throw new Error('expected serialized states')
+    }
+
+    const remote = toRemoteTrackedElement(
+      labelState,
+      [],
+      null,
+      { left: 0, top: 0 },
+      textareaState
+    )
+
+    const onSelectAssertion = vi.fn<(data: AssertionData) => void>()
+
+    const { getByText } = render(
+      <ElementMenu
+        element={remote}
+        onSelectAssertion={onSelectAssertion}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Add value assertion'))
+
+    expect(onSelectAssertion).toHaveBeenCalledWith({
+      type: 'text-input',
+      target: textareaState.target,
+      multiline: true,
+      expected: 'hello',
+    })
+  })
+
+  it('prefills the text assertion from the serialized text content', () => {
     document.body.innerHTML = '<div id="target">Some text</div>'
     const target = document.querySelector('#target')
 
@@ -202,7 +246,7 @@ describe('ElementMenu with a remote element', () => {
     expect(onSelectAssertion).toHaveBeenCalledWith({
       type: 'text',
       target: state.target,
-      text: '',
+      text: 'Some text',
     })
   })
 })

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.test.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { serializeElementChain } from '@/recorder/browser/serialization'
+import { getElementDetails } from '@/utils/dom/selectors'
+
+import { AssertionData } from './assertions/types'
+import { ElementMenu } from './ElementMenu'
+import { toRemoteTrackedElement, toTrackedElement } from './utils'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('ElementMenu with a live element', () => {
+  it('reports a check assertion read from the live DOM', () => {
+    document.body.innerHTML = '<input type="checkbox" id="checkbox" checked />'
+    const checkbox = document.querySelector('#checkbox')
+
+    if (checkbox === null) {
+      throw new Error('expected #checkbox element')
+    }
+
+    const onSelectAssertion = vi.fn<(data: AssertionData) => void>()
+
+    const { getByText } = render(
+      <ElementMenu
+        element={toTrackedElement(checkbox)}
+        onSelectAssertion={onSelectAssertion}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Add check assertion'))
+
+    expect(onSelectAssertion).toHaveBeenCalledWith({
+      type: 'check',
+      target: getElementDetails(checkbox),
+      inputType: 'native',
+      expected: 'checked',
+    })
+  })
+})
+
+describe('ElementMenu with a remote element', () => {
+  it('reports a check assertion read from the payload associated control', () => {
+    document.body.innerHTML =
+      '<label id="label"></label><input type="checkbox" id="checkbox" checked />'
+
+    const label = document.querySelector('#label')
+    const checkbox = document.querySelector('#checkbox')
+
+    if (label === null || checkbox === null) {
+      throw new Error('expected #label and #checkbox elements')
+    }
+
+    const [labelState] = serializeElementChain(label)
+    const [checkboxState] = serializeElementChain(checkbox)
+
+    if (labelState === undefined || checkboxState === undefined) {
+      throw new Error('expected serialized states')
+    }
+
+    const remote = toRemoteTrackedElement(
+      labelState,
+      [],
+      null,
+      { left: 0, top: 0 },
+      checkboxState
+    )
+
+    const onSelectAssertion = vi.fn<(data: AssertionData) => void>()
+
+    const { getByText } = render(
+      <ElementMenu
+        element={remote}
+        onSelectAssertion={onSelectAssertion}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Add check assertion'))
+
+    expect(onSelectAssertion).toHaveBeenCalledWith({
+      type: 'check',
+      target: checkboxState.target,
+      inputType: 'native',
+      expected: 'checked',
+    })
+  })
+
+  it('does not render role-specific assertions when there is no associated control', () => {
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    const { queryByText } = render(
+      <ElementMenu
+        element={remote}
+        onSelectAssertion={vi.fn()}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    expect(queryByText('Add check assertion')).toBeNull()
+    expect(queryByText('Add value assertion')).toBeNull()
+  })
+
+  it('reports a text-input assertion read from the payload associated control', () => {
+    document.body.innerHTML =
+      '<label id="label"></label><input type="text" id="input" value="hello" />'
+
+    const label = document.querySelector('#label')
+    const input = document.querySelector('#input')
+
+    if (label === null || input === null) {
+      throw new Error('expected #label and #input elements')
+    }
+
+    const [labelState] = serializeElementChain(label)
+    const [inputState] = serializeElementChain(input)
+
+    if (labelState === undefined || inputState === undefined) {
+      throw new Error('expected serialized states')
+    }
+
+    const remote = toRemoteTrackedElement(
+      labelState,
+      [],
+      null,
+      { left: 0, top: 0 },
+      inputState
+    )
+
+    const onSelectAssertion = vi.fn<(data: AssertionData) => void>()
+
+    const { getByText } = render(
+      <ElementMenu
+        element={remote}
+        onSelectAssertion={onSelectAssertion}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Add value assertion'))
+
+    expect(onSelectAssertion).toHaveBeenCalledWith({
+      type: 'text-input',
+      target: inputState.target,
+      // A remote control's multiline-ness can't be read without live DOM
+      // access, so it degrades to single-line.
+      multiline: false,
+      expected: 'hello',
+    })
+  })
+
+  it('reports an empty text assertion, since a remote element has no live textContent', () => {
+    document.body.innerHTML = '<div id="target">Some text</div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    const onSelectAssertion = vi.fn<(data: AssertionData) => void>()
+
+    const { getByText } = render(
+      <ElementMenu
+        element={remote}
+        onSelectAssertion={onSelectAssertion}
+        onAddWaitFor={vi.fn()}
+      />
+    )
+
+    fireEvent.click(getByText('Add text assertion'))
+
+    expect(onSelectAssertion).toHaveBeenCalledWith({
+      type: 'text',
+      target: state.target,
+      text: '',
+    })
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
@@ -21,7 +21,7 @@ import {
   LabeledControl,
   getTextBoxValue,
 } from './ElementMenu.utils'
-import { TrackedElement } from './utils'
+import { LiveTrackedElement } from './utils'
 import { WaitForData } from './waitConditions/types'
 
 function ToolbarRoot(props: ComponentProps<typeof Toolbar.Root>) {
@@ -186,7 +186,7 @@ function RoleAssertions({ role, input, onAddAssertion }: RoleCategoryProps) {
 }
 
 interface ElementMenuProps {
-  element: TrackedElement
+  element: LiveTrackedElement
   onSelectAssertion: (data: AssertionData) => void
   onAddWaitFor: (data: WaitForData) => void
 }

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
@@ -17,11 +17,13 @@ import { AssertionData, CheckAssertionData } from './assertions/types'
 import {
   findAssociatedControl,
   getCheckedState,
-  isNative,
-  LabeledControl,
+  getRemoteAssociatedControl,
   getTextBoxValue,
+  isNative,
+  isNativeRemote,
+  LabeledControl,
 } from './ElementMenu.utils'
-import { LiveTrackedElement } from './utils'
+import { getTarget, InspectedElement } from './utils'
 import { WaitForData } from './waitConditions/types'
 
 function ToolbarRoot(props: ComponentProps<typeof Toolbar.Root>) {
@@ -91,11 +93,19 @@ function CheckboxAssertion({
   onAddAssertion,
 }: CheckboxCategoryProps) {
   function handleAddCheckAssertion() {
+    const isInputNative =
+      input.kind === 'live'
+        ? isNative(role, input.element)
+        : isNativeRemote(role, input.isNativeCheckbox)
+
     onAddAssertion({
       type: 'check',
       target: input.target,
-      inputType: isNative(role, input.element) ? 'native' : 'aria',
-      expected: getCheckedState(input.element),
+      inputType: isInputNative ? 'native' : 'aria',
+      expected:
+        input.kind === 'live'
+          ? getCheckedState(input.element)
+          : input.checkedState,
     })
   }
 
@@ -117,13 +127,22 @@ function TextInputAssertion({
   onAddAssertion,
 }: TextInputAssertionProps) {
   const handleAddAssertion = () => {
+    // Whether the control is multiline can only be read from the live DOM
+    // (tag name or `aria-multiline`), so a remote control defaults to
+    // single-line; the user can still submit and edit the expected value.
+    const multiline =
+      input.kind === 'live' &&
+      (isHTMLTextAreaElement(input.element) ||
+        input.element.getAttribute('aria-multiline') === 'true')
+
     onAddAssertion({
       type: 'text-input',
       target: input.target,
-      multiline:
-        isHTMLTextAreaElement(input.element) ||
-        input.element.getAttribute('aria-multiline') === 'true',
-      expected: getTextBoxValue(input.element),
+      multiline,
+      expected:
+        input.kind === 'live'
+          ? getTextBoxValue(input.element)
+          : input.textBoxValue,
     })
   }
 
@@ -186,7 +205,7 @@ function RoleAssertions({ role, input, onAddAssertion }: RoleCategoryProps) {
 }
 
 interface ElementMenuProps {
-  element: LiveTrackedElement
+  element: InspectedElement
   onSelectAssertion: (data: AssertionData) => void
   onAddWaitFor: (data: WaitForData) => void
 }
@@ -196,12 +215,15 @@ export function ElementMenu({
   onSelectAssertion,
   onAddWaitFor,
 }: ElementMenuProps) {
-  const associatedElement = findAssociatedControl(element)
+  const associatedElement =
+    element.kind === 'live'
+      ? findAssociatedControl(element)
+      : getRemoteAssociatedControl(element)
 
   const handleAddVisibilityAssertion = () => {
     onSelectAssertion({
       type: 'visibility',
-      target: element.target,
+      target: getTarget(element),
       state: 'visible',
     })
   }
@@ -209,14 +231,16 @@ export function ElementMenu({
   const handleAddTextAssertion = () => {
     onSelectAssertion({
       type: 'text',
-      target: element.target,
-      text: element.element.textContent ?? '',
+      target: getTarget(element),
+      // A remote element has no live textContent to prefill from, so the
+      // assertion starts empty; the user can still type the expected text.
+      text: element.kind === 'live' ? (element.element.textContent ?? '') : '',
     })
   }
 
   const handleAddWaitFor = () => {
     onAddWaitFor({
-      target: element.target,
+      target: getTarget(element),
     })
   }
 

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.tsx
@@ -127,13 +127,11 @@ function TextInputAssertion({
   onAddAssertion,
 }: TextInputAssertionProps) {
   const handleAddAssertion = () => {
-    // Whether the control is multiline can only be read from the live DOM
-    // (tag name or `aria-multiline`), so a remote control defaults to
-    // single-line; the user can still submit and edit the expected value.
     const multiline =
-      input.kind === 'live' &&
-      (isHTMLTextAreaElement(input.element) ||
-        input.element.getAttribute('aria-multiline') === 'true')
+      input.kind === 'live'
+        ? isHTMLTextAreaElement(input.element) ||
+          input.element.getAttribute('aria-multiline') === 'true'
+        : input.isMultilineTextBox
 
     onAddAssertion({
       type: 'text-input',
@@ -232,9 +230,10 @@ export function ElementMenu({
     onSelectAssertion({
       type: 'text',
       target: getTarget(element),
-      // A remote element has no live textContent to prefill from, so the
-      // assertion starts empty; the user can still type the expected text.
-      text: element.kind === 'live' ? (element.element.textContent ?? '') : '',
+      text:
+        element.kind === 'live'
+          ? (element.element.textContent ?? '')
+          : element.state.textContent,
     })
   }
 

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.test.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { serializeElementChain } from '@/recorder/browser/serialization'
+import { ElementRole } from '@/utils/dom/aria'
+
+import { getRemoteAssociatedControl, isNativeRemote } from './ElementMenu.utils'
+import { toRemoteTrackedElement } from './utils'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('isNativeRemote', () => {
+  it('is native for an intrinsic role', () => {
+    const role: ElementRole = { type: 'intrinsic', role: 'checkbox' }
+
+    expect(isNativeRemote(role, false)).toBe(true)
+  })
+
+  it('is not native for an explicit role that is not a switch on a native checkbox', () => {
+    const role: ElementRole = { type: 'explicit', role: 'checkbox' }
+
+    expect(isNativeRemote(role, false)).toBe(false)
+  })
+
+  it('is native for a switch role backed by a native checkbox', () => {
+    const role: ElementRole = { type: 'explicit', role: 'switch' }
+
+    expect(isNativeRemote(role, true)).toBe(true)
+  })
+
+  it('is not native for a switch role not backed by a native checkbox', () => {
+    const role: ElementRole = { type: 'explicit', role: 'switch' }
+
+    expect(isNativeRemote(role, false)).toBe(false)
+  })
+})
+
+describe('getRemoteAssociatedControl', () => {
+  it('returns null when the remote element has no associated control', () => {
+    document.body.innerHTML = '<div id="target"></div>'
+
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const [state] = serializeElementChain(target)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(getRemoteAssociatedControl(remote)).toBeNull()
+  })
+
+  it('reads the control fields from the payload associated control', () => {
+    document.body.innerHTML =
+      '<label id="label"></label><input type="checkbox" id="checkbox" checked />'
+
+    const label = document.querySelector('#label')
+    const checkbox = document.querySelector('#checkbox')
+
+    if (label === null || checkbox === null) {
+      throw new Error('expected #label and #checkbox elements')
+    }
+
+    const [labelState] = serializeElementChain(label)
+    const [checkboxState] = serializeElementChain(checkbox)
+
+    if (labelState === undefined || checkboxState === undefined) {
+      throw new Error('expected serialized states')
+    }
+
+    const remote = toRemoteTrackedElement(
+      labelState,
+      [],
+      null,
+      { left: 0, top: 0 },
+      checkboxState
+    )
+
+    const control = getRemoteAssociatedControl(remote)
+
+    expect(control).toEqual({
+      kind: 'remote',
+      target: checkboxState.target,
+      roles: checkboxState.roles,
+      checkedState: checkboxState.checkedState,
+      textBoxValue: checkboxState.textBoxValue,
+      isNativeCheckbox: checkboxState.isNativeCheckbox,
+    })
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.test.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.test.ts
@@ -95,6 +95,7 @@ describe('getRemoteAssociatedControl', () => {
       checkedState: checkboxState.checkedState,
       textBoxValue: checkboxState.textBoxValue,
       isNativeCheckbox: checkboxState.isNativeCheckbox,
+      isMultilineTextBox: checkboxState.isMultilineTextBox,
     })
   })
 })

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
@@ -1,3 +1,4 @@
+import { SerializedElementState } from '@/recorder/browser/serialization'
 import { BrowserEventTarget } from '@/schemas/recording'
 import { ElementRole, getElementRoles } from '@/utils/dom/aria'
 import { findAssociatedElement } from '@/utils/dom/dom'
@@ -11,7 +12,7 @@ import {
 import { getElementDetails } from '@/utils/dom/selectors'
 
 import { CheckAssertionData } from './assertions/types'
-import { LiveTrackedElement } from './utils'
+import { LiveTrackedElement, RemoteTrackedElement } from './utils'
 
 function* getAncestors(element: Element) {
   let currentElement: Element | null = element
@@ -23,11 +24,29 @@ function* getAncestors(element: Element) {
   }
 }
 
-export interface LabeledControl {
+export interface LiveLabeledControl {
+  kind: 'live'
   element: Element
   target: BrowserEventTarget
   roles: ElementRole[]
 }
+
+export interface RemoteLabeledControl {
+  kind: 'remote'
+  target: BrowserEventTarget
+  roles: ElementRole[]
+  checkedState: SerializedElementState['checkedState']
+  textBoxValue: string
+  isNativeCheckbox: boolean
+}
+
+/**
+ * A control the assertion menu can read from, either a live DOM element or a
+ * remote element's serialized state. The role-specific menu items branch on
+ * `kind` to read checked/value state through the DOM helpers below for a live
+ * control, or straight from the serialized fields for a remote one.
+ */
+export type LabeledControl = LiveLabeledControl | RemoteLabeledControl
 
 // Only these three fields feed the association walk. The narrowed parameter
 // lets callers without a full LiveTrackedElement (e.g. cross-origin child-frame
@@ -39,7 +58,7 @@ export function findAssociatedControl({
 }: Pick<
   LiveTrackedElement,
   'element' | 'target' | 'roles'
->): LabeledControl | null {
+>): LiveLabeledControl | null {
   // If the target is already a control, then we don't need to do a search.
   if (
     isHTMLInputElement(element) ||
@@ -48,6 +67,7 @@ export function findAssociatedControl({
     isHTMLTextAreaElement(element)
   ) {
     return {
+      kind: 'live',
       element,
       target,
       roles,
@@ -69,9 +89,35 @@ export function findAssociatedControl({
   }
 
   return {
+    kind: 'live',
     element: associatedElement,
     target: getElementDetails(associatedElement),
     roles: [...getElementRoles(associatedElement)],
+  }
+}
+
+/**
+ * The remote equivalent of `findAssociatedControl`: the picked element's
+ * associated control, as relayed in the `element-pick` payload. Only the
+ * originally picked remote element carries it (see `RemoteTrackedElement`),
+ * so this returns null once the user has expanded to an ancestor.
+ */
+export function getRemoteAssociatedControl(
+  element: RemoteTrackedElement
+): RemoteLabeledControl | null {
+  const { associatedControl } = element
+
+  if (associatedControl === null) {
+    return null
+  }
+
+  return {
+    kind: 'remote',
+    target: associatedControl.target,
+    roles: associatedControl.roles,
+    checkedState: associatedControl.checkedState,
+    textBoxValue: associatedControl.textBoxValue,
+    isNativeCheckbox: associatedControl.isNativeCheckbox,
   }
 }
 
@@ -110,17 +156,27 @@ export function getTextBoxValue(element: Element): string {
   return element.textContent ?? ''
 }
 
-export function isNative(role: ElementRole, element: Element) {
-  // The 'switch' role differs from 'checkbox' only in semantics, so if it is on a
-  // native checkbox we want the generated code to use `.toBeChecked()` and not
-  // `.toHaveAttribute()`.
-  if (
-    role.role === 'switch' &&
-    isHTMLInputElement(element) &&
-    element.type === 'checkbox'
-  ) {
+// The 'switch' role differs from 'checkbox' only in semantics, so if it is on a
+// native checkbox we want the generated code to use `.toBeChecked()` and not
+// `.toHaveAttribute()`. Shared by the live and remote variants below so the
+// rule stays in one place; the remote variant is given the precomputed
+// `isNativeCheckbox` flag instead of the element itself since it has no DOM
+// access to check.
+function isNativeGivenCheckbox(role: ElementRole, isNativeCheckbox: boolean) {
+  if (role.role === 'switch' && isNativeCheckbox) {
     return true
   }
 
   return role.type === 'intrinsic'
+}
+
+export function isNative(role: ElementRole, element: Element) {
+  return isNativeGivenCheckbox(
+    role,
+    isHTMLInputElement(element) && element.type === 'checkbox'
+  )
+}
+
+export function isNativeRemote(role: ElementRole, isNativeCheckbox: boolean) {
+  return isNativeGivenCheckbox(role, isNativeCheckbox)
 }

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
@@ -38,6 +38,7 @@ export interface RemoteLabeledControl {
   checkedState: SerializedElementState['checkedState']
   textBoxValue: string
   isNativeCheckbox: boolean
+  isMultilineTextBox: boolean
 }
 
 /**
@@ -118,6 +119,7 @@ export function getRemoteAssociatedControl(
     checkedState: associatedControl.checkedState,
     textBoxValue: associatedControl.textBoxValue,
     isNativeCheckbox: associatedControl.isNativeCheckbox,
+    isMultilineTextBox: associatedControl.isMultilineTextBox,
   }
 }
 

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
@@ -29,11 +29,17 @@ export interface LabeledControl {
   roles: ElementRole[]
 }
 
+// Only these three fields feed the association walk. The narrowed parameter
+// lets callers without a full TrackedElement (e.g. cross-origin child-frame
+// capture, which must not compute top-frame bounds) reuse the same logic.
 export function findAssociatedControl({
   element,
   target,
   roles,
-}: TrackedElement): LabeledControl | null {
+}: Pick<
+  TrackedElement,
+  'element' | 'target' | 'roles'
+>): LabeledControl | null {
   // If the target is already a control, then we don't need to do a search.
   if (
     isHTMLInputElement(element) ||

--- a/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
+++ b/src/recorder/browser/view/ElementInspector/ElementMenu.utils.ts
@@ -11,7 +11,7 @@ import {
 import { getElementDetails } from '@/utils/dom/selectors'
 
 import { CheckAssertionData } from './assertions/types'
-import { TrackedElement } from './utils'
+import { LiveTrackedElement } from './utils'
 
 function* getAncestors(element: Element) {
   let currentElement: Element | null = element
@@ -30,14 +30,14 @@ export interface LabeledControl {
 }
 
 // Only these three fields feed the association walk. The narrowed parameter
-// lets callers without a full TrackedElement (e.g. cross-origin child-frame
+// lets callers without a full LiveTrackedElement (e.g. cross-origin child-frame
 // capture, which must not compute top-frame bounds) reuse the same logic.
 export function findAssociatedControl({
   element,
   target,
   roles,
 }: Pick<
-  TrackedElement,
+  LiveTrackedElement,
   'element' | 'target' | 'roles'
 >): LabeledControl | null {
   // If the target is already a control, then we don't need to do a search.

--- a/src/recorder/browser/view/ElementInspector/ElementPopover.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementPopover.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@/components/primitives/IconButton'
 import { Popover } from '@/components/primitives/Popover'
 import { Tooltip } from '@/components/primitives/Tooltip'
 
-import { LiveTrackedElement } from './utils'
+import { getTarget, InspectedElement } from './utils'
 
 interface ElementPopoverProps {
   open?: boolean
@@ -75,7 +75,7 @@ ElementPopover.Heading = function PopoverHeading(props: PopoverHeadingProps) {
 }
 
 interface ElementSelectorProps {
-  element: LiveTrackedElement
+  element: InspectedElement
   onExpand?: () => void
   onContract?: () => void
 }
@@ -97,7 +97,7 @@ ElementPopover.Selector = function ElementSelector({
           flex: 1 1 0;
         `}
       >
-        {element.target.selectors.css}
+        {getTarget(element).selectors.css}
       </ElementPopover.Heading>
       <Tooltip asChild content="Select child element">
         <IconButton disabled={onContract === undefined} onClick={onContract}>

--- a/src/recorder/browser/view/ElementInspector/ElementPopover.tsx
+++ b/src/recorder/browser/view/ElementInspector/ElementPopover.tsx
@@ -7,7 +7,7 @@ import { IconButton } from '@/components/primitives/IconButton'
 import { Popover } from '@/components/primitives/Popover'
 import { Tooltip } from '@/components/primitives/Tooltip'
 
-import { TrackedElement } from './utils'
+import { LiveTrackedElement } from './utils'
 
 interface ElementPopoverProps {
   open?: boolean
@@ -75,7 +75,7 @@ ElementPopover.Heading = function PopoverHeading(props: PopoverHeadingProps) {
 }
 
 interface ElementSelectorProps {
-  element: TrackedElement
+  element: LiveTrackedElement
   onExpand?: () => void
   onContract?: () => void
 }

--- a/src/recorder/browser/view/ElementInspector/hooks.test.tsx
+++ b/src/recorder/browser/view/ElementInspector/hooks.test.tsx
@@ -1,0 +1,319 @@
+import { act, renderHook } from '@testing-library/react'
+import { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { BrowserExtensionClient } from '@/recorder/browser/messaging'
+import { serializeElementChain } from '@/recorder/browser/serialization'
+import { cssLocatorOptions } from '@/schemas/locator'
+import { BrowserEventTarget } from '@/schemas/recording'
+
+import { StudioClientProvider } from '../StudioClientProvider'
+
+import { usePinnedElement, useElementHighlight } from './hooks'
+import {
+  RemoteTrackedElement,
+  toRemoteTrackedElement,
+  toTrackedElement,
+} from './utils'
+
+const frameTarget = (css: string): BrowserEventTarget => ({
+  selectors: { css },
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('usePinnedElement with a live element', () => {
+  it('starts with nothing pinned', () => {
+    const { result } = renderHook(() => usePinnedElement())
+
+    expect(result.current.pinned).toBeNull()
+    expect(result.current.selected).toBeNull()
+    expect(result.current.expand).toBeUndefined()
+    expect(result.current.contract).toBeUndefined()
+  })
+
+  it('pins the given element as both pinned and selected', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+    const live = toTrackedElement(div)
+
+    const { result } = renderHook(() => usePinnedElement())
+
+    act(() => {
+      result.current.pin(live)
+    })
+
+    expect(result.current.pinned).toBe(live)
+    expect(result.current.selected).toBe(live)
+  })
+
+  it('expands to the parent element and contracts back', () => {
+    document.body.innerHTML = '<div id="outer"><div id="inner"></div></div>'
+    const inner = document.querySelector('#inner')
+    const outer = document.querySelector('#outer')
+
+    if (inner === null || outer === null) {
+      throw new Error('expected inner and outer elements')
+    }
+
+    const { result } = renderHook(() => usePinnedElement())
+
+    act(() => {
+      result.current.pin(toTrackedElement(inner))
+    })
+
+    expect(result.current.expand).toBeDefined()
+
+    act(() => {
+      result.current.expand?.()
+    })
+
+    expect(result.current.selected?.element).toBe(outer)
+    expect(result.current.pinned?.element).toBe(inner)
+    expect(result.current.contract).toBeDefined()
+
+    act(() => {
+      result.current.contract?.()
+    })
+
+    expect(result.current.selected?.element).toBe(inner)
+    expect(result.current.contract).toBeUndefined()
+  })
+
+  it('cannot expand past the document element boundary', () => {
+    document.body.innerHTML = '<div id="only"></div>'
+    const only = document.querySelector('#only')
+
+    if (only === null) {
+      throw new Error('expected #only element')
+    }
+
+    const { result } = renderHook(() => usePinnedElement())
+
+    act(() => {
+      result.current.pin(toTrackedElement(only))
+    })
+
+    act(() => {
+      result.current.expand?.()
+    })
+
+    expect(result.current.selected?.element).toBe(document.body)
+    expect(result.current.expand).toBeUndefined()
+  })
+
+  it('unpin clears the stack', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const { result } = renderHook(() => usePinnedElement())
+
+    act(() => {
+      result.current.pin(toTrackedElement(div))
+    })
+
+    act(() => {
+      result.current.unpin()
+    })
+
+    expect(result.current.pinned).toBeNull()
+    expect(result.current.selected).toBeNull()
+  })
+})
+
+describe('usePinnedElement with a remote element', () => {
+  it('expands into the next ancestor and contracts back', () => {
+    document.body.innerHTML =
+      '<div id="outer"><div id="middle"><div id="inner"></div></div></div>'
+    const inner = document.querySelector('#inner')
+
+    if (inner === null) {
+      throw new Error('expected #inner element')
+    }
+
+    const chain = serializeElementChain(inner)
+    const [innerState, middleState] = chain
+
+    if (innerState === undefined || middleState === undefined) {
+      throw new Error('expected inner and middle states')
+    }
+
+    const initial = toRemoteTrackedElement(innerState, chain.slice(1), null, {
+      left: 0,
+      top: 0,
+    })
+
+    const { result } = renderHook(() =>
+      usePinnedElement<RemoteTrackedElement>()
+    )
+
+    act(() => {
+      result.current.pin(initial)
+    })
+
+    expect(result.current.expand).toBeDefined()
+
+    act(() => {
+      result.current.expand?.()
+    })
+
+    expect(result.current.selected?.state).toBe(middleState)
+    expect(result.current.pinned?.state).toBe(innerState)
+
+    act(() => {
+      result.current.contract?.()
+    })
+
+    expect(result.current.selected?.state).toBe(innerState)
+  })
+
+  it('cannot expand once there are no ancestors left', () => {
+    document.body.innerHTML = '<div id="only"></div>'
+    const only = document.querySelector('#only')
+
+    if (only === null) {
+      throw new Error('expected #only element')
+    }
+
+    const [state] = serializeElementChain(only)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const initial = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    const { result } = renderHook(() =>
+      usePinnedElement<RemoteTrackedElement>()
+    )
+
+    act(() => {
+      result.current.pin(initial)
+    })
+
+    expect(result.current.expand).toBeUndefined()
+  })
+})
+
+describe('useElementHighlight', () => {
+  function createClient() {
+    const client = new BrowserExtensionClient('test')
+    const send = vi.spyOn(client, 'send').mockImplementation(() => {})
+
+    function wrapper({ children }: { children: ReactNode }) {
+      return (
+        <StudioClientProvider client={client}>{children}</StudioClientProvider>
+      )
+    }
+
+    return { client, send, wrapper }
+  }
+
+  it('sends a css locator with no frames for a top-frame live element', () => {
+    document.body.innerHTML = '<button id="target">Go</button>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    const live = toTrackedElement(target)
+    const { send, wrapper } = createClient()
+
+    renderHook(() => useElementHighlight(live), { wrapper })
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: live.target.selectors.css },
+      frames: undefined,
+    })
+  })
+
+  it('sends frames mapped from the frame path for a remote element', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(
+      state,
+      [],
+      [frameTarget('iframe#a')],
+      { left: 0, top: 0 }
+    )
+    const { send, wrapper } = createClient()
+
+    renderHook(() => useElementHighlight(remote), { wrapper })
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: state.target.selectors.css },
+      frames: [cssLocatorOptions('iframe#a')],
+    })
+  })
+
+  it('sends undefined frames when the remote frame path is null', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+    const { send, wrapper } = createClient()
+
+    renderHook(() => useElementHighlight(remote), { wrapper })
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: state.target.selectors.css },
+      frames: undefined,
+    })
+  })
+
+  it('sends a null locator when there is no element', () => {
+    const { send, wrapper } = createClient()
+
+    renderHook(() => useElementHighlight(null), { wrapper })
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'highlight-elements',
+      locator: null,
+      frames: undefined,
+    })
+  })
+
+  it('sends a null locator on unmount', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+    const live = toTrackedElement(div)
+
+    const { send, wrapper } = createClient()
+    const { unmount } = renderHook(() => useElementHighlight(live), {
+      wrapper,
+    })
+
+    send.mockClear()
+    unmount()
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'highlight-elements',
+      locator: null,
+    })
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/hooks.ts
@@ -6,14 +6,51 @@ import { emptyToUndefined } from '@/utils/list'
 import { getCssFramePathForElement } from '../../frames'
 import { useStudioClient } from '../StudioClientProvider'
 
-import { LiveTrackedElement, toTrackedElement } from './utils'
+import {
+  expandRemoteTrackedElement,
+  getTarget,
+  InspectedElement,
+  LiveTrackedElement,
+  toRemoteFrames,
+  toTrackedElement,
+} from './utils'
 
-export function usePinnedElement(element?: LiveTrackedElement) {
-  const [elements, setElements] = useState<LiveTrackedElement[]>(
+/** Whether `head` has an ancestor left to expand into, without materializing it. */
+function canExpand(head: InspectedElement): boolean {
+  if (head.kind === 'remote') {
+    return head.ancestors.length > 0
+  }
+
+  const parent = head.element.parentElement
+
+  // Use the element's own document so expansion stops correctly for elements
+  // inside iframes, not just the top document.
+  return parent !== null && parent !== parent.ownerDocument.documentElement
+}
+
+/** Expands `head` to its next ancestor, or undefined at the top of the chain. */
+function expandOnce(head: InspectedElement): InspectedElement | undefined {
+  if (head.kind === 'remote') {
+    return expandRemoteTrackedElement(head)
+  }
+
+  const parent = head.element.parentElement
+
+  if (parent === null || parent === parent.ownerDocument.documentElement) {
+    return undefined
+  }
+
+  return toTrackedElement(parent)
+}
+
+export function usePinnedElement<
+  T extends InspectedElement = LiveTrackedElement,
+>(element?: T) {
+  const [elements, setElements] = useState<T[]>(
     element !== undefined ? [element] : []
   )
 
-  const pin = useCallback((element: LiveTrackedElement) => {
+  const pin = useCallback((element: T) => {
     setElements([element])
   }, [])
 
@@ -24,21 +61,25 @@ export function usePinnedElement(element?: LiveTrackedElement) {
   const expand = useMemo(() => {
     const [head] = elements
 
-    if (head === undefined) {
-      return undefined
-    }
-
-    const parent = head.element.parentElement
-
-    // Use the element's own document so expansion stops correctly for elements
-    // inside iframes, not just the top document.
-    if (parent === null || parent === parent.ownerDocument.documentElement) {
+    if (head === undefined || !canExpand(head)) {
       return undefined
     }
 
     return () => {
       setElements((pinned) => {
-        return [toTrackedElement(parent), ...pinned]
+        const [current] = pinned
+        const next = current === undefined ? undefined : expandOnce(current)
+
+        if (next === undefined) {
+          return pinned
+        }
+
+        // A live head only ever expands into another live element, and a
+        // remote head only into another remote one, so `next` always matches
+        // `T`. The switch above narrows on the plain `InspectedElement`
+        // union, not on the generic `T` itself, so TypeScript can't verify
+        // that correspondence here.
+        return [next as T, ...pinned]
       })
     }
   }, [elements])
@@ -68,16 +109,20 @@ export function usePinnedElement(element?: LiveTrackedElement) {
   }
 }
 
-export function useElementHighlight(element: LiveTrackedElement | null) {
+export function useElementHighlight(element: InspectedElement | null) {
   const client = useStudioClient()
 
   // The frame chain is the same for every element in a given document, and
   // computing it runs an expensive selector generation on each ancestor iframe,
   // so memoize it per owner document. Any element in the document yields the
   // same chain, so it is computed from the document element. The chain of iframe
-  // CSS selectors lets the highlight resolve into the right frame.
-  const ownerDocument = element?.element.ownerDocument ?? null
-  const frames = useMemo(
+  // CSS selectors lets the highlight resolve into the right frame. Remote
+  // elements have no live document to walk; their frame path was captured by
+  // the relay and is mapped separately below.
+  const ownerDocument =
+    element?.kind === 'live' ? element.element.ownerDocument : null
+
+  const liveFrames = useMemo(
     () =>
       ownerDocument === null
         ? undefined
@@ -87,12 +132,22 @@ export function useElementHighlight(element: LiveTrackedElement | null) {
     [ownerDocument]
   )
 
+  const remoteFramePath = element?.kind === 'remote' ? element.framePath : null
+  const remoteFrames = useMemo(
+    () => toRemoteFrames(remoteFramePath),
+    [remoteFramePath]
+  )
+
+  const frames = element?.kind === 'remote' ? remoteFrames : liveFrames
+
   useEffect(() => {
+    const target = element === null ? null : getTarget(element)
+
     client.send({
       type: 'highlight-elements',
-      locator: element && {
+      locator: target && {
         type: 'css',
-        selector: element.target.selectors.css,
+        selector: target.selectors.css,
       },
       frames,
     })

--- a/src/recorder/browser/view/ElementInspector/hooks.ts
+++ b/src/recorder/browser/view/ElementInspector/hooks.ts
@@ -6,14 +6,14 @@ import { emptyToUndefined } from '@/utils/list'
 import { getCssFramePathForElement } from '../../frames'
 import { useStudioClient } from '../StudioClientProvider'
 
-import { toTrackedElement, TrackedElement } from './utils'
+import { LiveTrackedElement, toTrackedElement } from './utils'
 
-export function usePinnedElement(element?: TrackedElement) {
-  const [elements, setElements] = useState<TrackedElement[]>(
+export function usePinnedElement(element?: LiveTrackedElement) {
+  const [elements, setElements] = useState<LiveTrackedElement[]>(
     element !== undefined ? [element] : []
   )
 
-  const pin = useCallback((element: TrackedElement) => {
+  const pin = useCallback((element: LiveTrackedElement) => {
     setElements([element])
   }, [])
 
@@ -68,7 +68,7 @@ export function usePinnedElement(element?: TrackedElement) {
   }
 }
 
-export function useElementHighlight(element: TrackedElement | null) {
+export function useElementHighlight(element: LiveTrackedElement | null) {
   const client = useStudioClient()
 
   // The frame chain is the same for every element in a given document, and

--- a/src/recorder/browser/view/ElementInspector/utils.test.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.test.ts
@@ -6,6 +6,8 @@ import { BrowserEventTarget } from '@/schemas/recording'
 
 import {
   expandRemoteTrackedElement,
+  finalizeRemoteBounds,
+  finalizeRemotePosition,
   getBounds,
   getRoles,
   getTarget,
@@ -44,6 +46,37 @@ describe('toTrackedElement', () => {
     document.body.append(div)
 
     expect(toTrackedElement(div).kind).toBe('live')
+  })
+})
+
+describe('finalizeRemotePosition', () => {
+  it('adds the relay offset and the top scroll to the payload point', () => {
+    setScroll(1, 2)
+
+    expect(
+      finalizeRemotePosition({ top: 100, left: 50 }, { left: 5, top: 7 })
+    ).toEqual({
+      top: 100 + 7 + 2,
+      left: 50 + 5 + 1,
+    })
+  })
+})
+
+describe('finalizeRemoteBounds', () => {
+  it('finalizes the position and carries width/height through unchanged', () => {
+    setScroll(1, 2)
+
+    const bounds = finalizeRemoteBounds(
+      { top: 100, left: 50, width: 30, height: 40 },
+      { left: 5, top: 7 }
+    )
+
+    expect(bounds).toEqual({
+      top: 100 + 7 + 2,
+      left: 50 + 5 + 1,
+      width: 30,
+      height: 40,
+    })
   })
 })
 
@@ -94,6 +127,53 @@ describe('toRemoteTrackedElement', () => {
     expect(remote.state).toBe(state)
     expect(remote.ancestors).toEqual([state])
     expect(remote.framePath).toBe(framePath)
+  })
+
+  it('defaults associatedControl to null when not given', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(remote.associatedControl).toBeNull()
+  })
+
+  it('keeps the given associatedControl', () => {
+    document.body.innerHTML =
+      '<label id="label"></label><input type="checkbox" id="checkbox" />'
+
+    const label = document.querySelector('#label')
+    const checkbox = document.querySelector('#checkbox')
+
+    if (label === null || checkbox === null) {
+      throw new Error('expected #label and #checkbox elements')
+    }
+
+    const [state] = serializeElementChain(label)
+    const [associatedControl] = serializeElementChain(checkbox)
+
+    if (state === undefined || associatedControl === undefined) {
+      throw new Error('expected serialized states')
+    }
+
+    const remote = toRemoteTrackedElement(
+      state,
+      [],
+      null,
+      { left: 0, top: 0 },
+      associatedControl
+    )
+
+    expect(remote.associatedControl).toBe(associatedControl)
   })
 })
 
@@ -177,6 +257,48 @@ describe('expandRemoteTrackedElement', () => {
       width: middleState.bounds.width,
       height: middleState.bounds.height,
     })
+  })
+
+  it('clears associatedControl on the expanded ancestor', () => {
+    document.body.innerHTML =
+      '<div id="outer"><div id="inner"></div></div><input type="checkbox" id="checkbox" />'
+
+    const inner = document.querySelector('#inner')
+    const checkbox = document.querySelector('#checkbox')
+
+    if (inner === null || checkbox === null) {
+      throw new Error('expected #inner and #checkbox elements')
+    }
+
+    const chain = serializeElementChain(inner)
+    const [associatedControl] = serializeElementChain(checkbox)
+
+    if (associatedControl === undefined) {
+      throw new Error('expected a serialized associated control')
+    }
+
+    const [innerState] = chain
+
+    if (innerState === undefined) {
+      throw new Error('expected an inner state')
+    }
+
+    const head = toRemoteTrackedElement(
+      innerState,
+      chain.slice(1),
+      null,
+      { left: 0, top: 0 },
+      associatedControl
+    )
+
+    const expanded = expandRemoteTrackedElement(head)
+
+    if (expanded === undefined) {
+      throw new Error('expected expansion to succeed')
+    }
+
+    expect(head.associatedControl).toBe(associatedControl)
+    expect(expanded.associatedControl).toBeNull()
   })
 })
 

--- a/src/recorder/browser/view/ElementInspector/utils.test.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { serializeElementChain } from '@/recorder/browser/serialization'
+import { cssLocatorOptions } from '@/schemas/locator'
+import { BrowserEventTarget } from '@/schemas/recording'
+
+import {
+  expandRemoteTrackedElement,
+  getBounds,
+  getRoles,
+  getTarget,
+  toRemoteFrames,
+  toRemoteTrackedElement,
+  toTrackedElement,
+} from './utils'
+
+const frameTarget = (css: string): BrowserEventTarget => ({
+  selectors: { css },
+})
+
+const scrollDescriptors = ['scrollX', 'scrollY'].map(
+  (property) =>
+    [property, Object.getOwnPropertyDescriptor(window, property)] as const
+)
+
+function setScroll(x: number, y: number) {
+  Object.defineProperty(window, 'scrollX', { value: x, configurable: true })
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true })
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+
+  scrollDescriptors.forEach(([property, descriptor]) => {
+    if (descriptor !== undefined) {
+      Object.defineProperty(window, property, descriptor)
+    }
+  })
+})
+
+describe('toTrackedElement', () => {
+  it('marks the returned element as live', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    expect(toTrackedElement(div).kind).toBe('live')
+  })
+})
+
+describe('toRemoteTrackedElement', () => {
+  it('finalizes bounds from the payload bounds, the relay offset, and the top scroll', () => {
+    setScroll(1, 2)
+
+    const div = document.createElement('div')
+    div.getBoundingClientRect = () =>
+      ({ top: 100, left: 50, width: 30, height: 40 }) as DOMRect
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, { left: 5, top: 7 })
+
+    expect(remote.bounds).toEqual({
+      top: 100 + 7 + 2,
+      left: 50 + 5 + 1,
+      width: 30,
+      height: 40,
+    })
+  })
+
+  it('keeps kind, state, ancestors, and framePath as given', () => {
+    setScroll(0, 0)
+
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const framePath = [frameTarget('iframe#a')]
+    const remote = toRemoteTrackedElement(state, [state], framePath, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(remote.kind).toBe('remote')
+    expect(remote.state).toBe(state)
+    expect(remote.ancestors).toEqual([state])
+    expect(remote.framePath).toBe(framePath)
+  })
+})
+
+describe('expandRemoteTrackedElement', () => {
+  it('returns undefined when there are no ancestors left', () => {
+    document.body.innerHTML = '<div id="inner"></div>'
+
+    const inner = document.querySelector('#inner')
+
+    if (inner === null) {
+      throw new Error('inner not found')
+    }
+
+    const [state] = serializeElementChain(inner)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const head = toRemoteTrackedElement(state, [], null, { left: 0, top: 0 })
+
+    expect(expandRemoteTrackedElement(head)).toBeUndefined()
+  })
+
+  it('walks the ancestor chain, keeping the same offset from each state', () => {
+    document.body.innerHTML =
+      '<div id="outer"><div id="middle"><div id="inner"></div></div></div>'
+
+    const inner = document.querySelector('#inner')
+
+    if (inner === null) {
+      throw new Error('inner not found')
+    }
+
+    inner.getBoundingClientRect = () =>
+      ({ top: 10, left: 10, width: 5, height: 5 }) as DOMRect
+
+    const middle = document.querySelector('#middle')
+
+    if (middle === null) {
+      throw new Error('middle not found')
+    }
+
+    middle.getBoundingClientRect = () =>
+      ({ top: 0, left: 0, width: 50, height: 50 }) as DOMRect
+
+    const chain = serializeElementChain(inner)
+    const [innerState, middleState] = chain
+
+    if (innerState === undefined || middleState === undefined) {
+      throw new Error('expected inner and middle states')
+    }
+
+    const head = toRemoteTrackedElement(innerState, chain.slice(1), null, {
+      left: 3,
+      top: 4,
+    })
+
+    const expanded = expandRemoteTrackedElement(head)
+
+    if (expanded === undefined) {
+      throw new Error('expected expansion to succeed')
+    }
+
+    expect(expanded.kind).toBe('remote')
+    expect(expanded.state).toBe(middleState)
+    expect(expanded.ancestors).toEqual(chain.slice(2))
+    expect(expanded.framePath).toBe(head.framePath)
+
+    // The delta between a head's bounds and its own state bounds stays
+    // constant across the chain, since every ancestor lives in the same
+    // originating frame and was captured at the same top scroll position.
+    const delta = {
+      left: head.bounds.left - head.state.bounds.left,
+      top: head.bounds.top - head.state.bounds.top,
+    }
+
+    expect(expanded.bounds).toEqual({
+      left: middleState.bounds.left + delta.left,
+      top: middleState.bounds.top + delta.top,
+      width: middleState.bounds.width,
+      height: middleState.bounds.height,
+    })
+  })
+})
+
+describe('getTarget, getRoles, getBounds', () => {
+  it('read from the live element for a live tracked element', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const live = toTrackedElement(div)
+
+    expect(getTarget(live)).toBe(live.target)
+    expect(getRoles(live)).toBe(live.roles)
+    expect(getBounds(live)).toBe(live.bounds)
+  })
+
+  it('read from the serialized state for a remote tracked element', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const remote = toRemoteTrackedElement(state, [], null, {
+      left: 0,
+      top: 0,
+    })
+
+    expect(getTarget(remote)).toBe(state.target)
+    expect(getRoles(remote)).toBe(state.roles)
+    expect(getBounds(remote)).toBe(remote.bounds)
+  })
+})
+
+describe('toRemoteFrames', () => {
+  it('maps a null frame path to undefined', () => {
+    expect(toRemoteFrames(null)).toBeUndefined()
+  })
+
+  it('maps an empty frame path to undefined', () => {
+    expect(toRemoteFrames([])).toBeUndefined()
+  })
+
+  it('maps a frame path to css locator options, one per frame', () => {
+    const framePath = [frameTarget('iframe#a'), frameTarget('iframe#b')]
+
+    expect(toRemoteFrames(framePath)).toEqual([
+      cssLocatorOptions('iframe#a'),
+      cssLocatorOptions('iframe#b'),
+    ])
+  })
+})

--- a/src/recorder/browser/view/ElementInspector/utils.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid'
 
-import { Bounds } from '@/components/Browser/types'
+import { Bounds, Position } from '@/components/Browser/types'
 import { SerializedElementState } from '@/recorder/browser/serialization'
 import { cssLocatorOptions, LocatorOptions } from '@/schemas/locator'
 import { BrowserEventTarget } from '@/schemas/recording'
@@ -30,6 +30,14 @@ export interface RemoteTrackedElement {
   framePath: BrowserEventTarget[] | null
   /** Top-document coordinates: payload bounds plus the relay offset and top scroll. */
   bounds: Bounds
+  /**
+   * The control associated with the picked element (e.g. the checkbox a label
+   * wraps), as captured in the picking frame. Only meaningful for the element
+   * that was actually picked; expanding to an ancestor clears it, since
+   * recomputing the association for the ancestor would require live DOM
+   * access the remote element doesn't have.
+   */
+  associatedControl: SerializedElementState | null
 }
 
 export type InspectedElement = LiveTrackedElement | RemoteTrackedElement
@@ -48,17 +56,52 @@ export function toTrackedElement(element: Element): LiveTrackedElement {
 }
 
 /**
+ * Finalizes a point captured in a remote frame (e.g. a click position) into
+ * top-frame document coordinates: the payload's own point plus the frame-hop
+ * offset the relay accumulated on the way up, plus the top document's own
+ * scroll. Only the top frame can read its own scroll position, so this must
+ * run there, once the payload has arrived.
+ */
+export function finalizeRemotePosition(
+  point: Position,
+  offset: { left: number; top: number }
+): Position {
+  return {
+    top: point.top + offset.top + window.scrollY,
+    left: point.left + offset.left + window.scrollX,
+  }
+}
+
+/**
+ * Finalizes a rect captured in a remote frame (e.g. an element's bounds or a
+ * text range's client rect) into top-frame document coordinates, reusing
+ * {@link finalizeRemotePosition} for the position and carrying the size
+ * through unchanged.
+ */
+export function finalizeRemoteBounds(
+  bounds: Bounds,
+  offset: { left: number; top: number }
+): Bounds {
+  return {
+    ...finalizeRemotePosition(bounds, offset),
+    width: bounds.width,
+    height: bounds.height,
+  }
+}
+
+/**
  * Finalizes a remote element's top-frame bounds from the payload's own bounds
  * (viewport-relative in the frame where it was picked), the frame-hop offset
  * the relay accumulated on the way up, and the top document's own scroll.
- * Only the top frame can read its own scroll position, so this must run
- * there, once the payload has arrived.
+ * `associatedControl` defaults to null for callers (e.g. existing tests) that
+ * don't care about it.
  */
 export function toRemoteTrackedElement(
   state: SerializedElementState,
   ancestors: SerializedElementState[],
   framePath: BrowserEventTarget[] | null,
-  offset: { left: number; top: number }
+  offset: { left: number; top: number },
+  associatedControl: SerializedElementState | null = null
 ): RemoteTrackedElement {
   return {
     kind: 'remote',
@@ -66,12 +109,8 @@ export function toRemoteTrackedElement(
     state,
     ancestors,
     framePath,
-    bounds: {
-      top: state.bounds.top + offset.top + window.scrollY,
-      left: state.bounds.left + offset.left + window.scrollX,
-      width: state.bounds.width,
-      height: state.bounds.height,
-    },
+    bounds: finalizeRemoteBounds(state.bounds, offset),
+    associatedControl,
   }
 }
 
@@ -110,6 +149,9 @@ export function expandRemoteTrackedElement(
       width: nextState.bounds.width,
       height: nextState.bounds.height,
     },
+    // The association was only computed for the originally picked element;
+    // recomputing it for the ancestor would require live DOM access.
+    associatedControl: null,
   }
 }
 

--- a/src/recorder/browser/view/ElementInspector/utils.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.ts
@@ -7,7 +7,7 @@ import { getElementDetails } from '@/utils/dom/selectors'
 
 import { getElementBoundsInTopFrame } from '../frameGeometry'
 
-export interface TrackedElement {
+export interface LiveTrackedElement {
   id: string
   roles: ElementRole[]
   target: BrowserEventTarget
@@ -15,7 +15,7 @@ export interface TrackedElement {
   bounds: Bounds
 }
 
-export function toTrackedElement(element: Element): TrackedElement {
+export function toTrackedElement(element: Element): LiveTrackedElement {
   const roles = getElementRoles(element)
 
   return {

--- a/src/recorder/browser/view/ElementInspector/utils.ts
+++ b/src/recorder/browser/view/ElementInspector/utils.ts
@@ -1,13 +1,17 @@
 import { nanoid } from 'nanoid'
 
 import { Bounds } from '@/components/Browser/types'
+import { SerializedElementState } from '@/recorder/browser/serialization'
+import { cssLocatorOptions, LocatorOptions } from '@/schemas/locator'
 import { BrowserEventTarget } from '@/schemas/recording'
 import { ElementRole, getElementRoles } from '@/utils/dom/aria'
 import { getElementDetails } from '@/utils/dom/selectors'
+import { emptyToUndefined } from '@/utils/list'
 
 import { getElementBoundsInTopFrame } from '../frameGeometry'
 
 export interface LiveTrackedElement {
+  kind: 'live'
   id: string
   roles: ElementRole[]
   target: BrowserEventTarget
@@ -15,14 +19,130 @@ export interface LiveTrackedElement {
   bounds: Bounds
 }
 
+export interface RemoteTrackedElement {
+  kind: 'remote'
+  id: string
+  /** The selected element, as captured in its own frame. */
+  state: SerializedElementState
+  /** The remaining ancestor chain above the selected element, innermost first. */
+  ancestors: SerializedElementState[]
+  /** The selected element's frame chain, or null if it couldn't be resolved. */
+  framePath: BrowserEventTarget[] | null
+  /** Top-document coordinates: payload bounds plus the relay offset and top scroll. */
+  bounds: Bounds
+}
+
+export type InspectedElement = LiveTrackedElement | RemoteTrackedElement
+
 export function toTrackedElement(element: Element): LiveTrackedElement {
   const roles = getElementRoles(element)
 
   return {
+    kind: 'live',
     id: nanoid(),
     roles: [...roles],
     target: getElementDetails(element),
     element: element,
     bounds: getElementBoundsInTopFrame(element),
   }
+}
+
+/**
+ * Finalizes a remote element's top-frame bounds from the payload's own bounds
+ * (viewport-relative in the frame where it was picked), the frame-hop offset
+ * the relay accumulated on the way up, and the top document's own scroll.
+ * Only the top frame can read its own scroll position, so this must run
+ * there, once the payload has arrived.
+ */
+export function toRemoteTrackedElement(
+  state: SerializedElementState,
+  ancestors: SerializedElementState[],
+  framePath: BrowserEventTarget[] | null,
+  offset: { left: number; top: number }
+): RemoteTrackedElement {
+  return {
+    kind: 'remote',
+    id: nanoid(),
+    state,
+    ancestors,
+    framePath,
+    bounds: {
+      top: state.bounds.top + offset.top + window.scrollY,
+      left: state.bounds.left + offset.left + window.scrollX,
+      width: state.bounds.width,
+      height: state.bounds.height,
+    },
+  }
+}
+
+/**
+ * Expands a remote selection to its next ancestor, mirroring
+ * `toTrackedElement(parent)` for the live case. The current head's bounds
+ * differ from its own payload bounds by a constant offset (the relay offset
+ * plus the top scroll at the time the chain was captured); every ancestor
+ * lived in the same originating frame, so applying that same offset to the
+ * ancestor's own payload bounds reproduces the top-frame bounds it would have
+ * had, without re-reading the (possibly since-changed) scroll position.
+ */
+export function expandRemoteTrackedElement(
+  head: RemoteTrackedElement
+): RemoteTrackedElement | undefined {
+  const [nextState, ...remainingAncestors] = head.ancestors
+
+  if (nextState === undefined) {
+    return undefined
+  }
+
+  const offset = {
+    left: head.bounds.left - head.state.bounds.left,
+    top: head.bounds.top - head.state.bounds.top,
+  }
+
+  return {
+    kind: 'remote',
+    id: nanoid(),
+    state: nextState,
+    ancestors: remainingAncestors,
+    framePath: head.framePath,
+    bounds: {
+      left: nextState.bounds.left + offset.left,
+      top: nextState.bounds.top + offset.top,
+      width: nextState.bounds.width,
+      height: nextState.bounds.height,
+    },
+  }
+}
+
+/** The target locator details for an inspected element, live or remote. */
+export function getTarget(element: InspectedElement): BrowserEventTarget {
+  return element.kind === 'live' ? element.target : element.state.target
+}
+
+/** The ARIA roles for an inspected element, live or remote. */
+export function getRoles(element: InspectedElement): ElementRole[] {
+  return element.kind === 'live' ? element.roles : element.state.roles
+}
+
+/** The top-frame bounds for an inspected element, live or remote. */
+export function getBounds(element: InspectedElement): Bounds {
+  return element.bounds
+}
+
+/**
+ * Maps a remote element's frame path to CSS-only locator options for the
+ * `highlight-elements` message, mirroring `getCssFramePathForElement` for
+ * live elements (see `frames.ts`). A null path (the ancestor chain couldn't
+ * be resolved) maps to `undefined` frames, so the highlight stays a top-frame
+ * no-op instead of resolving into the wrong frame.
+ */
+export function toRemoteFrames(
+  framePath: BrowserEventTarget[] | null
+): LocatorOptions[] | undefined {
+  if (framePath === null) {
+    return undefined
+  }
+
+  return emptyToUndefined(
+    framePath.map((frame) => cssLocatorOptions(frame.selectors.css))
+  )
 }

--- a/src/recorder/browser/view/RemoteHighlights.tsx
+++ b/src/recorder/browser/view/RemoteHighlights.tsx
@@ -1,27 +1,36 @@
 import { useEffect, useState } from 'react'
 
 import { ElementHighlights } from '@/components/Browser/ElementHighlights'
-import { ElementLocator, LocatorOptions } from '@/schemas/locator'
+import { ElementLocator } from '@/schemas/locator'
 
 import { useStudioClient } from './StudioClientProvider'
 
 /**
  * Highlights elements when hovering over selectors inside k6 Studio.
+ *
+ * Only handles messages that target the top frame's own document. A message
+ * with a non-empty `frames` chain targets a (possibly cross-origin) child
+ * frame instead, which draws its own highlight locally via
+ * `attachFrameHighlights`; same-origin children run that same listener, so
+ * every frame highlights itself uniformly rather than the top frame
+ * descending into them.
  */
 export function RemoteHighlights() {
   const client = useStudioClient()
 
   const [locator, setLocator] = useState<ElementLocator | null>(null)
-  const [frames, setFrames] = useState<LocatorOptions[] | undefined>(undefined)
+  const [targetsAnotherFrame, setTargetsAnotherFrame] = useState(false)
 
   useEffect(() => {
     return client.on('highlight-elements', ({ data }) => {
       setLocator(data.locator)
-      setFrames(data.frames)
+      setTargetsAnotherFrame((data.frames?.length ?? 0) > 0)
     })
   }, [client])
 
-  return (
-    <ElementHighlights root={document.body} target={locator} frames={frames} />
-  )
+  if (targetsAnotherFrame) {
+    return null
+  }
+
+  return <ElementHighlights root={document.body} target={locator} />
 }

--- a/src/recorder/browser/view/TextSelectionPopover.hooks.test.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.hooks.test.ts
@@ -1,0 +1,220 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import * as layout from '@/utils/dom/layout'
+
+import { FrameAgent, installFrameAgent } from '../messaging/frames'
+import { serializeElementChain } from '../serialization'
+
+import {
+  buildRemoteSelection,
+  useTextSelection,
+} from './TextSelectionPopover.hooks'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  installFrameAgent(null)
+  vi.restoreAllMocks()
+})
+
+function fakeRange(commonAncestor: Element): Range {
+  return {
+    toString: () => 'hello',
+    startContainer: commonAncestor,
+    getClientRects: () => [],
+    getBoundingClientRect: () =>
+      ({ top: 0, left: 0, width: 0, height: 0 }) as DOMRect,
+  } as unknown as Range
+}
+
+describe('buildRemoteSelection', () => {
+  it('returns null when the payload has no elements', () => {
+    const result = buildRemoteSelection({
+      text: 'hello',
+      elements: [],
+      framePath: null,
+      highlights: [],
+      bounds: { top: 0, left: 0, width: 0, height: 0 },
+      offset: { left: 0, top: 0 },
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('builds a remote selection with bounds and highlights finalized once from the payload', () => {
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const framePath = [{ selectors: { css: 'iframe#a' } }]
+
+    const result = buildRemoteSelection({
+      text: 'hello',
+      elements: [state],
+      framePath,
+      highlights: [{ top: 1, left: 2, width: 3, height: 4 }],
+      bounds: { top: 10, left: 20, width: 30, height: 40 },
+      offset: { left: 5, top: 6 },
+    })
+
+    if (result === null) {
+      throw new Error('expected a remote selection')
+    }
+
+    expect(result.kind).toBe('remote')
+    expect(result.text).toBe('hello')
+    expect(result.framePath).toBe(framePath)
+    expect(result.element.kind).toBe('remote')
+    expect(result.element.state).toBe(state)
+    expect(result.bounds).toEqual({
+      top: 10 + 6 + window.scrollY,
+      left: 20 + 5 + window.scrollX,
+      width: 30,
+      height: 40,
+    })
+    expect(result.highlights).toEqual([
+      {
+        top: 1 + 6 + window.scrollY,
+        left: 2 + 5 + window.scrollX,
+        width: 3,
+        height: 4,
+      },
+    ])
+  })
+})
+
+describe('useTextSelection', () => {
+  it('starts with no selection', () => {
+    const { result } = renderHook(() => useTextSelection())
+
+    const [selection] = result.current
+
+    expect(selection).toBeNull()
+  })
+
+  it('builds a remote selection from a payload relayed over the frame agent', () => {
+    let onTextSelection: ((payload: unknown) => void) | undefined
+
+    installFrameAgent({
+      onTextSelection: (listener: (payload: unknown) => void) => {
+        onTextSelection = listener
+        return () => {}
+      },
+    } as unknown as FrameAgent)
+
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const { result } = renderHook(() => useTextSelection())
+
+    if (onTextSelection === undefined) {
+      throw new Error('expected useTextSelection to subscribe')
+    }
+
+    act(() => {
+      onTextSelection?.({
+        text: 'hello',
+        elements: [state],
+        framePath: null,
+        highlights: [],
+        bounds: { top: 0, left: 0, width: 0, height: 0 },
+        offset: { left: 0, top: 0 },
+      })
+    })
+
+    const [selection] = result.current
+
+    expect(selection?.kind).toBe('remote')
+    expect(selection?.text).toBe('hello')
+  })
+
+  it('clears the selection', () => {
+    installFrameAgent({
+      onTextSelection: () => () => {},
+    } as unknown as FrameAgent)
+
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    const { result } = renderHook(() => useTextSelection())
+
+    act(() => {
+      result.current[1]()
+    })
+
+    expect(result.current[0]).toBeNull()
+  })
+
+  it('does not subscribe to layout-shift re-measuring for a remote selection', () => {
+    const observeSpy = vi.spyOn(layout, 'observeWindowsForLayoutShift')
+
+    let onTextSelection: ((payload: unknown) => void) | undefined
+
+    installFrameAgent({
+      onTextSelection: (listener: (payload: unknown) => void) => {
+        onTextSelection = listener
+        return () => {}
+      },
+    } as unknown as FrameAgent)
+
+    const div = document.createElement('div')
+    document.body.append(div)
+
+    const [state] = serializeElementChain(div)
+
+    if (state === undefined) {
+      throw new Error('expected a serialized state')
+    }
+
+    renderHook(() => useTextSelection())
+
+    act(() => {
+      onTextSelection?.({
+        text: 'hello',
+        elements: [state],
+        framePath: null,
+        highlights: [],
+        bounds: { top: 0, left: 0, width: 0, height: 0 },
+        offset: { left: 0, top: 0 },
+      })
+    })
+
+    expect(observeSpy).not.toHaveBeenCalled()
+  })
+
+  it('subscribes to layout-shift re-measuring for a live selection', () => {
+    const observeSpy = vi.spyOn(layout, 'observeWindowsForLayoutShift')
+
+    document.body.innerHTML = '<div id="target"></div>'
+    const target = document.querySelector('#target')
+
+    if (target === null) {
+      throw new Error('expected #target element')
+    }
+
+    renderHook(() => useTextSelection())
+
+    act(() => {
+      window.__K6_STUDIO_TEXT_SELECTION__?.select(fakeRange(target), target)
+    })
+
+    expect(observeSpy).toHaveBeenCalled()
+  })
+})

--- a/src/recorder/browser/view/TextSelectionPopover.hooks.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.hooks.ts
@@ -6,10 +6,19 @@ import {
   observeWindowsForLayoutShift,
 } from '@/utils/dom/layout'
 
-import { toTrackedElement } from './ElementInspector/utils'
+import { getFrameAgent, TextSelectionPayload } from '../messaging/frames'
+
+import {
+  finalizeRemoteBounds,
+  toRemoteTrackedElement,
+  toTrackedElement,
+} from './ElementInspector/utils'
 import { toTopFrameBounds } from './frameGeometry'
 import { readSelection } from './inspection'
-import { TextSelection } from './TextSelectionPopover.types'
+import {
+  RemoteTextSelection,
+  TextSelection,
+} from './TextSelectionPopover.types'
 
 function measureRange(range: Range) {
   // The range may live inside an iframe; translate its rects into the top
@@ -24,6 +33,40 @@ function measureRange(range: Range) {
   }
 }
 
+/**
+ * Builds a remote selection from a relayed `text-selection` payload: the
+ * element chain's head becomes the tracked element (the remaining entries are
+ * its ancestors), and the bounds/highlights are finalized once from the
+ * payload's own rects, the relay offset, and the top scroll. Returns null for
+ * a payload with an empty element chain, which shouldn't happen in practice
+ * but would otherwise leave the selection with no element to anchor on.
+ */
+export function buildRemoteSelection(
+  payload: TextSelectionPayload
+): RemoteTextSelection | null {
+  const [elementState, ...ancestors] = payload.elements
+
+  if (elementState === undefined) {
+    return null
+  }
+
+  return {
+    kind: 'remote',
+    text: payload.text,
+    element: toRemoteTrackedElement(
+      elementState,
+      ancestors,
+      payload.framePath,
+      payload.offset
+    ),
+    framePath: payload.framePath,
+    bounds: finalizeRemoteBounds(payload.bounds, payload.offset),
+    highlights: payload.highlights.map((rect) =>
+      finalizeRemoteBounds(rect, payload.offset)
+    ),
+  }
+}
+
 export function useTextSelection() {
   const isSelecting = useRef(false)
 
@@ -34,6 +77,7 @@ export function useTextSelection() {
   const buildSelection = useCallback(
     (range: Range, commonAncestor: Element) => {
       setSelection({
+        kind: 'live',
         text: range.toString(),
         element: toTrackedElement(commonAncestor),
         range,
@@ -105,7 +149,27 @@ export function useTextSelection() {
     }
   }, [buildSelection])
 
-  const selectionRange = selection?.range ?? null
+  // Selections made in a cross-origin child frame can't reach the bridge
+  // above, so they're relayed to the top frame over the frame agent instead
+  // (see attachTextSelectionDetection).
+  useEffect(() => {
+    const unsubscribe = getFrameAgent()?.onTextSelection((payload) => {
+      const remote = buildRemoteSelection(payload)
+
+      if (remote !== null) {
+        setSelection(remote)
+      }
+    })
+
+    return () => {
+      unsubscribe?.()
+    }
+  }, [])
+
+  // Only a live selection has a range to re-measure; a remote selection's
+  // bounds/highlights were already finalized once from the payload and can't
+  // be recomputed without live DOM access.
+  const selectionRange = selection?.kind === 'live' ? selection.range : null
 
   useEffect(() => {
     if (selectionRange === null) {
@@ -114,8 +178,8 @@ export function useTextSelection() {
 
     const recompute = () => {
       setSelection((selection) =>
-        selection === null
-          ? null
+        selection === null || selection.kind !== 'live'
+          ? selection
           : { ...selection, ...measureRange(selection.range) }
       )
     }

--- a/src/recorder/browser/view/TextSelectionPopover.tsx
+++ b/src/recorder/browser/view/TextSelectionPopover.tsx
@@ -11,12 +11,30 @@ import { TextAssertionEditor } from './ElementInspector/assertions/TextAssertion
 import { TextAssertionData } from './ElementInspector/assertions/types'
 import { ElementPopover } from './ElementInspector/ElementPopover'
 import { useElementHighlight, usePinnedElement } from './ElementInspector/hooks'
+import { getTarget } from './ElementInspector/utils'
 import { useGlobalClass } from './GlobalStyles'
 import { useEscape } from './hooks/useEscape'
 import { usePreventClick } from './hooks/usePreventClick'
 import { useStudioClient } from './StudioClientProvider'
 import { useTextSelection } from './TextSelectionPopover.hooks'
 import { TextSelection } from './TextSelectionPopover.types'
+
+/**
+ * Expansion stays within the same frame, so a live selection's element gives
+ * the right frame chain by walking the live DOM. A remote selection has no
+ * live element to walk, so its own relayed frame path is used instead.
+ */
+function getSelectionFrames(selection: TextSelection | null) {
+  if (selection === null) {
+    return []
+  }
+
+  if (selection.kind === 'live') {
+    return getFramePathForElement(selection.element.element)
+  }
+
+  return selection.framePath ?? []
+}
 
 interface TextSelectionPopoverContentProps {
   selection: TextSelection
@@ -33,7 +51,7 @@ function TextSelectionPopoverContent({
 
   const [assertion, setAssertion] = useState<TextAssertionData>({
     type: 'text',
-    target: selection.element.target,
+    target: getTarget(selection.element),
     text: selection.text,
   })
 
@@ -48,7 +66,7 @@ function TextSelectionPopoverContent({
   const handleSubmit = (assertion: TextAssertionData) => {
     onAdd({
       ...assertion,
-      target: targetElement.target,
+      target: getTarget(targetElement),
     })
 
     onClose()
@@ -92,11 +110,7 @@ export function TextSelectionPopover({ onClose }: TextSelectionPopoverProps) {
   })
 
   const handleAdd = (assertion: TextAssertionData) => {
-    // Expansion stays within the same frame, so the selection's element gives
-    // the right frame chain.
-    const frames = selection
-      ? getFramePathForElement(selection.element.element)
-      : []
+    const frames = getSelectionFrames(selection)
 
     client.send({
       type: 'record-events',

--- a/src/recorder/browser/view/TextSelectionPopover.types.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.types.ts
@@ -1,11 +1,28 @@
 import { Bounds } from '@/components/Browser/types'
+import { BrowserEventTarget } from '@/schemas/recording'
 
-import { LiveTrackedElement } from './ElementInspector/utils'
+import {
+  LiveTrackedElement,
+  RemoteTrackedElement,
+} from './ElementInspector/utils'
 
-export interface TextSelection {
+interface TextSelectionBase {
   text: string
-  element: LiveTrackedElement
-  range: Range
   bounds: Bounds
   highlights: Bounds[]
 }
+
+export interface LiveTextSelection extends TextSelectionBase {
+  kind: 'live'
+  element: LiveTrackedElement
+  range: Range
+}
+
+export interface RemoteTextSelection extends TextSelectionBase {
+  kind: 'remote'
+  element: RemoteTrackedElement
+  /** The selection's own frame chain, as resolved when it was relayed up. */
+  framePath: BrowserEventTarget[] | null
+}
+
+export type TextSelection = LiveTextSelection | RemoteTextSelection

--- a/src/recorder/browser/view/TextSelectionPopover.types.ts
+++ b/src/recorder/browser/view/TextSelectionPopover.types.ts
@@ -1,10 +1,10 @@
 import { Bounds } from '@/components/Browser/types'
 
-import { TrackedElement } from './ElementInspector/utils'
+import { LiveTrackedElement } from './ElementInspector/utils'
 
 export interface TextSelection {
   text: string
-  element: TrackedElement
+  element: LiveTrackedElement
   range: Range
   bounds: Bounds
   highlights: Bounds[]

--- a/src/recorder/browser/view/childOverlays.test.ts
+++ b/src/recorder/browser/view/childOverlays.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { Bounds } from '@/components/Browser/types'
 
@@ -22,9 +22,17 @@ function getShadowContainers(): HTMLElement[] {
   )
 }
 
+// MutationObserver callbacks are delivered asynchronously. A macrotask tick
+// flushes all pending microtasks, including observer callbacks and any
+// follow-up callbacks triggered by the repositioning itself.
+function flushMutationObservers(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 afterEach(() => {
   clearChildOverlays(hoverStyle)
   clearChildOverlays(highlightStyle)
+  document.body.innerHTML = ''
 })
 
 describe('showChildOverlays', () => {
@@ -116,6 +124,54 @@ describe('showChildOverlays', () => {
     expect(root.dataset.ksixStudio).toBe('true')
   })
 
+  it('positions the container absolutely without occupying layout space', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    const [container] = getShadowContainers()
+
+    expect(container?.style.position).toBe('absolute')
+    expect(container?.style.top).toBe('0px')
+    expect(container?.style.left).toBe('0px')
+    expect(container?.style.width).toBe('0px')
+    expect(container?.style.height).toBe('0px')
+  })
+
+  it('moves the container back to the end of body when the page appends elements', async () => {
+    // If the container is not the last child of body while a page element is
+    // appended after it, the selector generator can produce an nth-child
+    // selector that breaks once the container is removed. Same failure mode
+    // documented for the top-frame mount in view/index.tsx's positionObserver.
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    const intruder = document.createElement('span')
+
+    document.body.appendChild(intruder)
+
+    await flushMutationObservers()
+
+    const [container] = getShadowContainers()
+
+    expect(document.body.lastElementChild).toBe(container)
+    expect(intruder.nextElementSibling).toBe(container)
+  })
+
+  it('keeps both kind containers trailing in body without fighting each other', async () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], highlightStyle)
+
+    const intruder = document.createElement('span')
+
+    document.body.appendChild(intruder)
+
+    await flushMutationObservers()
+
+    const children = Array.from(document.body.children)
+
+    expect(children[0]).toBe(intruder)
+    expect(getShadowContainers()).toHaveLength(2)
+    expect(children.slice(1)).toEqual(getShadowContainers())
+  })
+
   it('keeps overlay boxes out of light-DOM queries used by selector generation', () => {
     // Selector generation (src/utils/dom/selectors.ts) walks the light DOM
     // via `document.body.querySelectorAll` and `finder`, neither of which
@@ -150,5 +206,37 @@ describe('clearChildOverlays', () => {
 
   it('does not throw when there is nothing to clear', () => {
     expect(() => clearChildOverlays(hoverStyle)).not.toThrow()
+  })
+
+  it('stops repositioning once the containers are cleared', async () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    clearChildOverlays(hoverStyle)
+
+    const intruder = document.createElement('span')
+
+    document.body.appendChild(intruder)
+
+    await flushMutationObservers()
+
+    expect(document.body.lastElementChild).toBe(intruder)
+    expect(getShadowContainers()).toHaveLength(0)
+  })
+
+  it('disconnects the reposition observer when the last container is cleared', () => {
+    const disconnectSpy = vi.spyOn(MutationObserver.prototype, 'disconnect')
+
+    showChildOverlays([makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], highlightStyle)
+
+    clearChildOverlays(hoverStyle)
+
+    expect(disconnectSpy).not.toHaveBeenCalled()
+
+    clearChildOverlays(highlightStyle)
+
+    expect(disconnectSpy).toHaveBeenCalled()
+
+    disconnectSpy.mockRestore()
   })
 })

--- a/src/recorder/browser/view/childOverlays.test.ts
+++ b/src/recorder/browser/view/childOverlays.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { Bounds } from '@/components/Browser/types'
+
+import {
+  ChildOverlayStyle,
+  clearChildOverlays,
+  showChildOverlays,
+} from './childOverlays'
+
+const hoverStyle: ChildOverlayStyle = { kind: 'hover' }
+const highlightStyle: ChildOverlayStyle = { kind: 'highlight' }
+
+function makeBounds(overrides: Partial<Bounds> = {}): Bounds {
+  return { top: 10, left: 20, width: 100, height: 50, ...overrides }
+}
+
+function getShadowContainers(): HTMLElement[] {
+  return Array.from(document.body.children).filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && child.shadowRoot !== null
+  )
+}
+
+afterEach(() => {
+  clearChildOverlays(hoverStyle)
+  clearChildOverlays(highlightStyle)
+})
+
+describe('showChildOverlays', () => {
+  it('creates a container appended to the body', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    expect(getShadowContainers()).toHaveLength(1)
+  })
+
+  it('applies the bounds as fixed-position geometry styles', () => {
+    showChildOverlays(
+      [makeBounds({ top: 1, left: 2, width: 3, height: 4 })],
+      hoverStyle
+    )
+
+    const [container] = getShadowContainers()
+    const root = container?.shadowRoot?.firstElementChild
+    const overlay = root?.firstElementChild as HTMLElement
+
+    expect(overlay.style.position).toBe('fixed')
+    expect(overlay.style.top).toBe('1px')
+    expect(overlay.style.left).toBe('2px')
+    expect(overlay.style.width).toBe('3px')
+    expect(overlay.style.height).toBe('4px')
+    expect(overlay.style.pointerEvents).toBe('none')
+  })
+
+  it('creates one overlay div per bounds entry', () => {
+    showChildOverlays([makeBounds(), makeBounds(), makeBounds()], hoverStyle)
+
+    const [container] = getShadowContainers()
+    const root = container?.shadowRoot?.firstElementChild
+
+    expect(root?.children).toHaveLength(3)
+  })
+
+  it('applies distinct visuals for hover and highlight kinds', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], highlightStyle)
+
+    const [hoverContainer, highlightContainer] = getShadowContainers()
+
+    const hoverOverlay = hoverContainer?.shadowRoot?.firstElementChild
+      ?.firstElementChild as HTMLElement
+    const highlightOverlay = highlightContainer?.shadowRoot?.firstElementChild
+      ?.firstElementChild as HTMLElement
+
+    expect(hoverOverlay.style.border).not.toBe('')
+    expect(highlightOverlay.style.backgroundColor).not.toBe('')
+    expect(hoverOverlay.style.border).not.toBe(highlightOverlay.style.border)
+  })
+
+  it('replaces the previous overlays for the same kind', () => {
+    showChildOverlays([makeBounds(), makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    expect(getShadowContainers()).toHaveLength(1)
+
+    const [container] = getShadowContainers()
+    const root = container?.shadowRoot?.firstElementChild
+
+    expect(root?.children).toHaveLength(1)
+  })
+
+  it('keeps hover and highlight overlays independent of each other', () => {
+    showChildOverlays([makeBounds(), makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], highlightStyle)
+
+    expect(getShadowContainers()).toHaveLength(2)
+
+    showChildOverlays([makeBounds(), makeBounds(), makeBounds()], hoverStyle)
+
+    expect(getShadowContainers()).toHaveLength(2)
+
+    const highlightContainer = getShadowContainers().find(
+      (container) =>
+        container.shadowRoot?.firstElementChild?.children.length === 1
+    )
+
+    expect(highlightContainer).toBeDefined()
+  })
+
+  it('marks the shadow root content with the Studio UI marker', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    const [container] = getShadowContainers()
+    const root = container?.shadowRoot?.firstElementChild as HTMLElement
+
+    expect(root.dataset.ksixStudio).toBe('true')
+  })
+
+  it('keeps overlay boxes out of light-DOM queries used by selector generation', () => {
+    // Selector generation (src/utils/dom/selectors.ts) walks the light DOM
+    // via `document.body.querySelectorAll` and `finder`, neither of which
+    // descends into shadow roots. Only the single container host may appear
+    // in that traversal; the overlay boxes themselves must stay invisible.
+    showChildOverlays([makeBounds(), makeBounds(), makeBounds()], hoverStyle)
+
+    const lightDomDivs = document.body.querySelectorAll('div')
+
+    expect(lightDomDivs).toHaveLength(1)
+    expect(lightDomDivs[0]?.shadowRoot).not.toBeNull()
+  })
+})
+
+describe('clearChildOverlays', () => {
+  it('removes the container entirely from the document', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+
+    clearChildOverlays(hoverStyle)
+
+    expect(getShadowContainers()).toHaveLength(0)
+  })
+
+  it('only clears the overlays for the given kind', () => {
+    showChildOverlays([makeBounds()], hoverStyle)
+    showChildOverlays([makeBounds()], highlightStyle)
+
+    clearChildOverlays(hoverStyle)
+
+    expect(getShadowContainers()).toHaveLength(1)
+  })
+
+  it('does not throw when there is nothing to clear', () => {
+    expect(() => clearChildOverlays(hoverStyle)).not.toThrow()
+  })
+})

--- a/src/recorder/browser/view/childOverlays.ts
+++ b/src/recorder/browser/view/childOverlays.ts
@@ -1,0 +1,118 @@
+import { Bounds } from '@/components/Browser/types'
+
+// Vanilla DOM overlay renderer for cross-origin child frames, which have no
+// React tree of their own. It draws hover/highlight boxes directly.
+//
+// The container must not disturb the selector generator, which walks the
+// light DOM starting at `document.body` (see `src/utils/dom/selectors.ts`).
+// We follow the same mitigation as the top-frame mount in `view/index.tsx`:
+// the overlay markup lives inside an open shadow root, so it never appears
+// in `document.body`'s light DOM tree, and the shadow root's first child
+// carries the `data-ksix-studio` marker used to identify Studio UI.
+export interface ChildOverlayStyle {
+  kind: 'hover' | 'highlight'
+}
+
+interface OverlayContainer {
+  container: HTMLDivElement
+  root: HTMLDivElement
+}
+
+const MAX_Z_INDEX = 2147483647
+
+const containersByKind = new Map<ChildOverlayStyle['kind'], OverlayContainer>()
+
+function applyOverlayVisuals(
+  overlay: HTMLDivElement,
+  kind: ChildOverlayStyle['kind']
+) {
+  if (kind === 'hover') {
+    overlay.style.border = '2px solid #0093ff'
+
+    return
+  }
+
+  overlay.style.backgroundColor = 'rgba(0, 147, 255, 0.24)'
+}
+
+function createOverlayContainer(): OverlayContainer {
+  const container = document.createElement('div')
+
+  document.body.appendChild(container)
+
+  const shadowRoot = container.attachShadow({ mode: 'open' })
+
+  const root = document.createElement('div')
+
+  root.dataset.ksixStudio = 'true'
+
+  shadowRoot.appendChild(root)
+
+  return { container, root }
+}
+
+function getOverlayContainer(
+  kind: ChildOverlayStyle['kind']
+): OverlayContainer {
+  const existing = containersByKind.get(kind)
+
+  if (existing) {
+    return existing
+  }
+
+  const created = createOverlayContainer()
+
+  containersByKind.set(kind, created)
+
+  return created
+}
+
+function createOverlay(
+  bounds: Bounds,
+  kind: ChildOverlayStyle['kind']
+): HTMLDivElement {
+  const overlay = document.createElement('div')
+
+  overlay.style.position = 'fixed'
+  overlay.style.pointerEvents = 'none'
+  overlay.style.zIndex = String(MAX_Z_INDEX)
+  overlay.style.boxSizing = 'border-box'
+  overlay.style.top = `${bounds.top}px`
+  overlay.style.left = `${bounds.left}px`
+  overlay.style.width = `${bounds.width}px`
+  overlay.style.height = `${bounds.height}px`
+
+  applyOverlayVisuals(overlay, kind)
+
+  return overlay
+}
+
+/**
+ * Draws overlays for the given bounds in a child frame. Calling this again
+ * with the same `style.kind` replaces the overlays it previously drew.
+ */
+export function showChildOverlays(
+  bounds: Bounds[],
+  style: ChildOverlayStyle
+): void {
+  const { root } = getOverlayContainer(style.kind)
+
+  root.replaceChildren(
+    ...bounds.map((entry) => createOverlay(entry, style.kind))
+  )
+}
+
+/**
+ * Removes the overlays for the given `style.kind`, including its container,
+ * from the document.
+ */
+export function clearChildOverlays(style: ChildOverlayStyle): void {
+  const existing = containersByKind.get(style.kind)
+
+  if (!existing) {
+    return
+  }
+
+  existing.container.remove()
+  containersByKind.delete(style.kind)
+}

--- a/src/recorder/browser/view/childOverlays.ts
+++ b/src/recorder/browser/view/childOverlays.ts
@@ -22,6 +22,57 @@ const MAX_Z_INDEX = 2147483647
 
 const containersByKind = new Map<ChildOverlayStyle['kind'], OverlayContainer>()
 
+// While a container sits in the body, page insertions after it would get
+// nth-child-shifted selectors that break once the container is removed. This
+// is the same failure mode the top-frame mount guards against with its
+// positionObserver in `view/index.tsx`, so we keep the containers as the
+// trailing children of body while any of them are mounted.
+//
+// Unlike the top-frame mount there can be two containers (one per kind). Two
+// independent observers each re-appending their own container when it has a
+// next sibling would ping-pong each other to the end forever, so a single
+// shared observer repositions all mounted containers at once and settles as
+// soon as they form the tail of the body.
+let positionObserver: MutationObserver | null = null
+
+function areContainersTrailing(): boolean {
+  const mounted = Array.from(containersByKind.values())
+  const tail = Array.from(document.body.children).slice(-mounted.length)
+
+  return mounted.every((entry, index) => tail[index] === entry.container)
+}
+
+function repositionContainers() {
+  if (areContainersTrailing()) {
+    return
+  }
+
+  containersByKind.forEach((entry) => {
+    document.body.appendChild(entry.container)
+  })
+}
+
+function ensurePositionObserver() {
+  if (positionObserver !== null) {
+    return
+  }
+
+  positionObserver = new MutationObserver(repositionContainers)
+
+  positionObserver.observe(document.body, {
+    childList: true,
+  })
+}
+
+function disconnectPositionObserverWhenIdle() {
+  if (containersByKind.size > 0 || positionObserver === null) {
+    return
+  }
+
+  positionObserver.disconnect()
+  positionObserver = null
+}
+
 function applyOverlayVisuals(
   overlay: HTMLDivElement,
   kind: ChildOverlayStyle['kind']
@@ -37,6 +88,12 @@ function applyOverlayVisuals(
 
 function createOverlayContainer(): OverlayContainer {
   const container = document.createElement('div')
+
+  container.style.position = 'absolute'
+  container.style.top = '0px'
+  container.style.left = '0px'
+  container.style.width = '0px'
+  container.style.height = '0px'
 
   document.body.appendChild(container)
 
@@ -63,6 +120,7 @@ function getOverlayContainer(
   const created = createOverlayContainer()
 
   containersByKind.set(kind, created)
+  ensurePositionObserver()
 
   return created
 }
@@ -115,4 +173,5 @@ export function clearChildOverlays(style: ChildOverlayStyle): void {
 
   existing.container.remove()
   containersByKind.delete(style.kind)
+  disconnectPositionObserverWhenIdle()
 }

--- a/src/recorder/browser/view/frameHighlights.test.ts
+++ b/src/recorder/browser/view/frameHighlights.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { cssLocatorOptions, LocatorOptions } from '@/schemas/locator'
+import { BrowserEventTarget } from '@/schemas/recording'
+
+import { BrowserExtensionClient } from '../messaging'
+
+import * as childOverlays from './childOverlays'
+import { attachFrameHighlights } from './frameHighlights'
+
+vi.mock('./childOverlays', () => ({
+  showChildOverlays: vi.fn(),
+  clearChildOverlays: vi.fn(),
+}))
+
+const showChildOverlays = vi.mocked(childOverlays.showChildOverlays)
+const clearChildOverlays = vi.mocked(childOverlays.clearChildOverlays)
+
+const ownTarget = (css: string): BrowserEventTarget => ({
+  selectors: { css },
+})
+
+/** A promise plus its resolve function, so a test can settle it on demand. */
+function deferred<Value>() {
+  let resolve: (value: Value) => void = () => {}
+
+  const promise = new Promise<Value>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  document.body.innerHTML = ''
+})
+
+describe('attachFrameHighlights', () => {
+  it('draws overlays when the message frame chain matches this frame', async () => {
+    document.body.innerHTML = '<div class="target"></div>'
+
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(showChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).toHaveBeenCalledWith(
+      [expect.objectContaining({ top: 0, left: 0, width: 0, height: 0 })],
+      { kind: 'highlight' }
+    )
+    expect(clearChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears overlays when the frame chain does not match this frame', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#other-frame')],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(clearChildOverlays).toHaveBeenCalledWith({ kind: 'highlight' })
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears overlays when frames is absent (a top-frame-only message)', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears overlays when the locator is null, without waiting on own path', () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue(null)
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: null,
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    // No flush/await: clearing on a null locator must not require the own
+    // path lookup to settle first.
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(getOwnPath).not.toHaveBeenCalled()
+  })
+
+  it('clears overlays and ignores non-css locator types even on a matching chain', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'testid', testId: 'submit' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears overlays and treats a non-css frame entry as no match', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    const nonCssFrame: LocatorOptions = {
+      current: 'testid',
+      values: { testid: { type: 'testid', testId: 'frame-id' } },
+    }
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [nonCssFrame],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('treats mismatched chain length (shorter message chain) as no match', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi
+      .fn()
+      .mockResolvedValue([ownTarget('#outer'), ownTarget('#inner')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#outer')],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('treats mismatched chain length (longer message chain) as no match', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#outer')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#outer'), cssLocatorOptions('#inner')],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('draws when a nested, multi-frame chain matches index-for-index', async () => {
+    document.body.innerHTML = '<div class="target"></div>'
+
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi
+      .fn()
+      .mockResolvedValue([ownTarget('#outer'), ownTarget('#inner')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#outer'), cssLocatorOptions('#inner')],
+    })
+
+    await flush()
+
+    expect(showChildOverlays).toHaveBeenCalledTimes(1)
+    expect(clearChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears when a nested chain matches at the outer index but diverges at an inner one', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi
+      .fn()
+      .mockResolvedValue([ownTarget('#outer'), ownTarget('#inner')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      // Same outer frame, different inner one: a naive comparison against
+      // only ownPath[0] would wrongly call this a match.
+      frames: [cssLocatorOptions('#outer'), cssLocatorOptions('#other-inner')],
+    })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('draws with an empty bounds list when the chain matches but no element is found', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.does-not-exist' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(showChildOverlays).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).toHaveBeenCalledWith([], { kind: 'highlight' })
+    expect(clearChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('never matches and does not draw when the own path can never be resolved', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue(null)
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(showChildOverlays).not.toHaveBeenCalled()
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a null own path, retrying resolution on the next message', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(getOwnPath).toHaveBeenCalledTimes(1)
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(getOwnPath).toHaveBeenCalledTimes(2)
+    expect(showChildOverlays).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a resolved own path across messages instead of asking again', async () => {
+    const client = new BrowserExtensionClient('test')
+    const getOwnPath = vi.fn().mockResolvedValue([ownTarget('#frame')])
+
+    attachFrameHighlights(client, getOwnPath)
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    await flush()
+
+    expect(getOwnPath).toHaveBeenCalledTimes(1)
+    expect(showChildOverlays).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not let a stale resolution overwrite a newer clear', async () => {
+    const client = new BrowserExtensionClient('test')
+    const ownPathLookup = deferred<[BrowserEventTarget] | null>()
+    const getOwnPath = vi.fn().mockReturnValue(ownPathLookup.promise)
+
+    attachFrameHighlights(client, getOwnPath)
+
+    // First message: matches this frame, but own path resolution is slow.
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.target' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    // Second, newer message: a null locator clears synchronously, without
+    // waiting on the own path lookup at all.
+    client.send({
+      type: 'highlight-elements',
+      locator: null,
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+
+    // The slow lookup for the first (now stale) message finally resolves as
+    // a match; it must not draw over the newer clear.
+    ownPathLookup.resolve([ownTarget('#frame')])
+
+    await flush()
+
+    expect(showChildOverlays).not.toHaveBeenCalled()
+    expect(clearChildOverlays).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies only the newest message once a shared pending own-path lookup settles', async () => {
+    document.body.innerHTML =
+      '<div class="old"></div><div class="old"></div><div class="new"></div>'
+
+    const client = new BrowserExtensionClient('test')
+    const ownPathLookup = deferred<[BrowserEventTarget] | null>()
+    const getOwnPath = vi.fn().mockReturnValue(ownPathLookup.promise)
+
+    attachFrameHighlights(client, getOwnPath)
+
+    // Both messages match this frame's chain and race the same in-flight
+    // own-path lookup; only the newer one should end up drawing.
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.old' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    client.send({
+      type: 'highlight-elements',
+      locator: { type: 'css', selector: '.new' },
+      frames: [cssLocatorOptions('#frame')],
+    })
+
+    expect(getOwnPath).toHaveBeenCalledTimes(1)
+
+    ownPathLookup.resolve([ownTarget('#frame')])
+
+    await flush()
+
+    expect(showChildOverlays).toHaveBeenCalledTimes(1)
+
+    const [bounds] = showChildOverlays.mock.calls[0] ?? []
+
+    expect(bounds).toHaveLength(1)
+  })
+})

--- a/src/recorder/browser/view/frameHighlights.ts
+++ b/src/recorder/browser/view/frameHighlights.ts
@@ -1,0 +1,130 @@
+import { Bounds } from '@/components/Browser/types'
+import { LocatorOptions } from '@/schemas/locator'
+import { BrowserEventTarget } from '@/schemas/recording'
+
+import { BrowserExtensionClient } from '../messaging'
+
+import { clearChildOverlays, showChildOverlays } from './childOverlays'
+
+const HIGHLIGHT_STYLE = { kind: 'highlight' } as const
+
+/**
+ * Resolves the CSS selector chain a `highlight-elements` message targets,
+ * outermost frame first. Absent for top-frame elements.
+ */
+function frameChainSelectors(frames: LocatorOptions[]): (string | undefined)[] {
+  return frames.map((frame) => frame.values.css?.selector)
+}
+
+/**
+ * Whether a message's frame chain identifies this exact frame: same length as
+ * this frame's own path, and every link is a css locator matching the
+ * corresponding ancestor's own css selector. A message with no frames targets
+ * the top frame, never a child, so it never matches here.
+ */
+function matchesOwnFramePath(
+  frames: LocatorOptions[],
+  ownPath: BrowserEventTarget[]
+): boolean {
+  if (frames.length === 0 || frames.length !== ownPath.length) {
+    return false
+  }
+
+  return frameChainSelectors(frames).every(
+    (css, index) => css !== undefined && css === ownPath[index]?.selectors.css
+  )
+}
+
+function toBounds(element: Element): Bounds {
+  const rect = element.getBoundingClientRect()
+
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+/**
+ * Draws or clears this frame's local highlight overlays for `highlight-elements`
+ * messages that target it. The recorder's WS server broadcasts every message
+ * to every frame, so each frame decides for itself whether the message's frame
+ * chain identifies it, then resolves and draws its own matches instead of
+ * relying on a top-frame component to descend into it (which cross-origin
+ * frames can't do anyway).
+ *
+ * `getOwnPath` is awaited lazily on the first message and cached, since the
+ * chain is stable for the lifetime of the document. A null result (the
+ * ancestor chain couldn't be resolved, e.g. an unresponsive cross-origin
+ * ancestor) is never cached, so the next message retries in case the ancestor
+ * answers later.
+ */
+export function attachFrameHighlights(
+  client: BrowserExtensionClient,
+  getOwnPath: () => Promise<BrowserEventTarget[] | null>
+): void {
+  let ownPath: BrowserEventTarget[] | null = null
+  let pendingOwnPath: Promise<BrowserEventTarget[] | null> | null = null
+  let latestMessageId = 0
+
+  const resolveOwnPath = async (): Promise<BrowserEventTarget[] | null> => {
+    if (ownPath !== null) {
+      return ownPath
+    }
+
+    if (pendingOwnPath === null) {
+      pendingOwnPath = getOwnPath()
+    }
+
+    const resolved = await pendingOwnPath
+
+    if (resolved === null) {
+      // Don't cache a negative result: the ancestor may still answer later.
+      pendingOwnPath = null
+    } else {
+      ownPath = resolved
+    }
+
+    return resolved
+  }
+
+  client.on('highlight-elements', ({ data }) => {
+    const messageId = ++latestMessageId
+    const { locator, frames = [] } = data
+
+    if (locator === null) {
+      clearChildOverlays(HIGHLIGHT_STYLE)
+
+      return
+    }
+
+    void resolveOwnPath().then((path) => {
+      // Messages can arrive faster than own-path resolution settles. Only the
+      // outcome of the newest message is allowed to draw or clear, so a slow
+      // resolution for an older message can't overwrite a newer one.
+      if (messageId !== latestMessageId) {
+        return
+      }
+
+      if (
+        path === null ||
+        locator.type !== 'css' ||
+        !matchesOwnFramePath(frames, path)
+      ) {
+        clearChildOverlays(HIGHLIGHT_STYLE)
+
+        return
+      }
+
+      const bounds = Array.from(
+        document.querySelectorAll(locator.selector)
+      ).map(toBounds)
+
+      // An empty match list still draws (with zero boxes) rather than
+      // clearing, so "matched this frame, nothing found" and "matched and
+      // drew" share one code path.
+      showChildOverlays(bounds, HIGHLIGHT_STYLE)
+    })
+  })
+}

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -9,7 +9,9 @@ import {
   vi,
 } from 'vitest'
 
-import { attachInspectionDetection } from './inspection'
+import { FrameAgent, installFrameAgent } from '../messaging/frames'
+
+import { attachInspectionDetection, isTopFrameToolActive } from './inspection'
 
 const hover = vi.fn()
 const pick = vi.fn()
@@ -74,5 +76,29 @@ describe('attachInspectionDetection', () => {
     dispatch('click', iframe, { clientX: 5, clientY: 6 })
 
     expect(pick).not.toHaveBeenCalled()
+  })
+})
+
+describe('isTopFrameToolActive with a frame agent', () => {
+  beforeEach(() => {
+    // The outer suite's beforeEach installs an inspection bridge; these tests
+    // exercise the no-bridge, frame-agent-only path.
+    delete window.__K6_STUDIO_INSPECTION__
+  })
+
+  afterEach(() => {
+    installFrameAgent(null as unknown as FrameAgent)
+  })
+
+  it('is true when the frame agent has received an active tool state', () => {
+    installFrameAgent({ isToolActive: true } as unknown as FrameAgent)
+
+    expect(isTopFrameToolActive()).toBe(true)
+  })
+
+  it('is false when the frame agent tool state is inactive and no bridge exists', () => {
+    installFrameAgent({ isToolActive: false } as unknown as FrameAgent)
+
+    expect(isTopFrameToolActive()).toBe(false)
   })
 })

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -87,7 +87,7 @@ describe('isTopFrameToolActive with a frame agent', () => {
   })
 
   afterEach(() => {
-    installFrameAgent(null as unknown as FrameAgent)
+    installFrameAgent(null)
   })
 
   it('is true when the frame agent has received an active tool state', () => {

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -326,6 +326,59 @@ describe('attachInspectionDetection with no top-frame bridge and an active frame
     expect(pick).toHaveBeenCalledWith(button, 5, 6)
     expect(sendElementPick).not.toHaveBeenCalled()
   })
+
+  describe('when top-window scroll access throws like a cross-origin frame', () => {
+    // In a real cross-origin frame, reading `scrollX`/`scrollY` on the top
+    // WindowProxy throws a SecurityError. jsdom neither enforces cross-origin
+    // access nor allows redefining `window.top` (non-configurable), but in
+    // this environment `window.top === window`, so making `window`'s own
+    // scroll accessors throw puts the SecurityError at the exact property
+    // read the top-scroll lookup performs.
+    const scrollDescriptors = ['scrollX', 'scrollY'].map(
+      (property) =>
+        [property, Object.getOwnPropertyDescriptor(window, property)] as const
+    )
+
+    beforeEach(() => {
+      scrollDescriptors.forEach(([property]) => {
+        Object.defineProperty(window, property, {
+          configurable: true,
+          get() {
+            throw new DOMException('cross-origin', 'SecurityError')
+          },
+        })
+      })
+    })
+
+    afterEach(() => {
+      scrollDescriptors.forEach(([property, descriptor]) => {
+        if (descriptor !== undefined) {
+          Object.defineProperty(window, property, descriptor)
+        }
+      })
+    })
+
+    it('still sends a serialized pick with the associated control', async () => {
+      const label = document.createElement('label')
+      label.id = 'label'
+      const checkbox = document.createElement('input')
+      checkbox.type = 'checkbox'
+      checkbox.id = 'checkbox'
+      checkbox.checked = true
+      label.append(checkbox, document.createTextNode('Accept'))
+      document.body.append(label)
+
+      dispatch('click', label, { clientX: 5, clientY: 6 })
+
+      await flush()
+
+      expect(sendElementPick).toHaveBeenCalledTimes(1)
+
+      const payload = sendElementPick.mock.calls[0]![0]
+
+      expect(payload.associatedControl).toEqual(serializeElementState(checkbox))
+    })
+  })
 })
 
 describe('attachTextSelectionDetection', () => {

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -9,15 +9,52 @@ import {
   vi,
 } from 'vitest'
 
-import { FrameAgent, installFrameAgent } from '../messaging/frames'
+import {
+  ElementPickPayload,
+  FrameAgent,
+  installFrameAgent,
+  TextSelectionPayload,
+} from '../messaging/frames'
+import { serializeElementChain, serializeElementState } from '../serialization'
 
-import { attachInspectionDetection, isTopFrameToolActive } from './inspection'
+import * as childOverlays from './childOverlays'
+import {
+  attachInspectionDetection,
+  attachTextSelectionDetection,
+  isTopFrameToolActive,
+} from './inspection'
+
+vi.mock('./childOverlays', () => ({
+  showChildOverlays: vi.fn(),
+  clearChildOverlays: vi.fn(),
+}))
+
+const showChildOverlays = vi.mocked(childOverlays.showChildOverlays)
+const clearChildOverlays = vi.mocked(childOverlays.clearChildOverlays)
 
 const hover = vi.fn()
 const pick = vi.fn()
+const sendElementPick =
+  vi.fn<(payload: Omit<ElementPickPayload, 'offset'>) => void>()
+const sendTextSelection =
+  vi.fn<(payload: Omit<TextSelectionPayload, 'offset'>) => void>()
+
+/** Flushes the microtasks in `getOwnFramePath`'s resolution chain. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function installActiveFrameAgent() {
+  installFrameAgent({
+    isToolActive: true,
+    sendElementPick,
+    sendTextSelection,
+  } as unknown as FrameAgent)
+}
 
 beforeAll(() => {
   attachInspectionDetection()
+  attachTextSelectionDetection()
 })
 
 beforeEach(() => {
@@ -27,7 +64,12 @@ beforeEach(() => {
 afterEach(() => {
   hover.mockClear()
   pick.mockClear()
+  sendElementPick.mockClear()
+  sendTextSelection.mockClear()
+  showChildOverlays.mockClear()
+  clearChildOverlays.mockClear()
   delete window.__K6_STUDIO_INSPECTION__
+  installFrameAgent(null)
   document.body.innerHTML = ''
 })
 
@@ -37,7 +79,15 @@ afterAll(() => {
 
 function dispatch(type: string, target: Element, init: MouseEventInit = {}) {
   target.dispatchEvent(
-    new MouseEvent(type, { bubbles: true, composed: true, ...init })
+    // Real clicks are cancelable; without it, jsdom's label activation
+    // behavior forwards a click to the wrapped control even after
+    // `preventDefault()`, since jsdom only honors that on cancelable events.
+    new MouseEvent(type, {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+      ...init,
+    })
   )
 }
 
@@ -114,8 +164,8 @@ describe('attachInspectionDetection with no top-frame bridge', () => {
     installFrameAgent(null)
   })
 
-  it('prevents the default click action when the tool is active in an ancestor frame', () => {
-    installFrameAgent({ isToolActive: true } as unknown as FrameAgent)
+  it('prevents the default click action when the tool is active in an ancestor frame', async () => {
+    installActiveFrameAgent()
 
     const button = document.createElement('button')
     document.body.append(button)
@@ -129,6 +179,10 @@ describe('attachInspectionDetection with no top-frame bridge', () => {
 
     expect(event.defaultPrevented).toBe(true)
     expect(pick).not.toHaveBeenCalled()
+
+    // The swallowed click also relays a serialized pick asynchronously; flush
+    // it here so the pending send doesn't resolve during a later test.
+    await flush()
   })
 
   it('does not prevent the default click action when no frame agent is installed', () => {
@@ -161,5 +215,227 @@ describe('attachInspectionDetection with no top-frame bridge', () => {
 
     expect(event.defaultPrevented).toBe(false)
     expect(pick).not.toHaveBeenCalled()
+  })
+})
+
+describe('attachInspectionDetection with no top-frame bridge and an active frame agent', () => {
+  beforeEach(() => {
+    // The outer suite's beforeEach installs an inspection bridge; these tests
+    // exercise the cross-origin path where the bridge is unreachable but the
+    // frame agent reports the tool as active.
+    delete window.__K6_STUDIO_INSPECTION__
+    installActiveFrameAgent()
+  })
+
+  it('draws a local hover overlay for the hovered element', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('mouseover', button)
+
+    expect(showChildOverlays).toHaveBeenCalledWith(
+      [expect.objectContaining({ top: 0, left: 0, width: 0, height: 0 })],
+      { kind: 'hover' }
+    )
+    expect(clearChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears the hover overlay instead of drawing one over an iframe', () => {
+    const iframe = document.createElement('iframe')
+    document.body.append(iframe)
+
+    dispatch('mouseover', iframe)
+
+    expect(clearChildOverlays).toHaveBeenCalledWith({ kind: 'hover' })
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('clears the hover overlay on mouseover once the tool is no longer active', () => {
+    installFrameAgent({ isToolActive: false } as unknown as FrameAgent)
+
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('mouseover', button)
+
+    expect(clearChildOverlays).toHaveBeenCalledWith({ kind: 'hover' })
+    expect(showChildOverlays).not.toHaveBeenCalled()
+  })
+
+  it('sends a serialized pick for a label-wrapped checkbox and clears the hover overlay', async () => {
+    const label = document.createElement('label')
+    label.id = 'label'
+    const checkbox = document.createElement('input')
+    checkbox.type = 'checkbox'
+    checkbox.id = 'checkbox'
+    checkbox.checked = true
+    label.append(checkbox, document.createTextNode('Accept'))
+    document.body.append(label)
+
+    dispatch('click', label, { clientX: 5, clientY: 6 })
+
+    await flush()
+
+    expect(clearChildOverlays).toHaveBeenCalledWith({ kind: 'hover' })
+    expect(sendElementPick).toHaveBeenCalledTimes(1)
+
+    const payload = sendElementPick.mock.calls[0]![0]
+
+    expect(payload.elements.map((state) => state.target.selectors.css)).toEqual(
+      serializeElementChain(label).map((state) => state.target.selectors.css)
+    )
+    expect(payload.associatedControl).toEqual(serializeElementState(checkbox))
+    expect(payload.position).toEqual({ left: 5, top: 6 })
+    expect(payload.framePath).toEqual([])
+  })
+
+  it('does not pick an iframe element', async () => {
+    const iframe = document.createElement('iframe')
+    document.body.append(iframe)
+
+    dispatch('click', iframe, { clientX: 5, clientY: 6 })
+
+    await flush()
+
+    expect(sendElementPick).not.toHaveBeenCalled()
+  })
+
+  it('does not send a pick when the tool is not active', async () => {
+    installFrameAgent({ isToolActive: false } as unknown as FrameAgent)
+
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('click', button, { clientX: 5, clientY: 6 })
+
+    await flush()
+
+    expect(sendElementPick).not.toHaveBeenCalled()
+  })
+
+  it('does not send a pick when the top-frame bridge is reachable', async () => {
+    window.__K6_STUDIO_INSPECTION__ = { hover, pick }
+
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    dispatch('click', button, { clientX: 5, clientY: 6 })
+
+    await flush()
+
+    expect(pick).toHaveBeenCalledWith(button, 5, 6)
+    expect(sendElementPick).not.toHaveBeenCalled()
+  })
+})
+
+describe('attachTextSelectionDetection', () => {
+  function select(range: Range) {
+    const selection = window.getSelection()
+
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+  }
+
+  function triggerSelection() {
+    document.dispatchEvent(new Event('selectstart'))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+  }
+
+  afterEach(() => {
+    delete window.__K6_STUDIO_TEXT_SELECTION__
+    window.getSelection()?.removeAllRanges()
+  })
+
+  it('reports a selection to the top frame through the bridge when it is reachable', () => {
+    const bridgeSelect = vi.fn()
+    window.__K6_STUDIO_TEXT_SELECTION__ = { select: bridgeSelect }
+
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'Hello world'
+    document.body.append(paragraph)
+
+    const range = document.createRange()
+    range.selectNodeContents(paragraph)
+    select(range)
+
+    triggerSelection()
+
+    expect(bridgeSelect).toHaveBeenCalledWith(range, paragraph)
+    expect(sendTextSelection).not.toHaveBeenCalled()
+  })
+
+  describe('with no top-frame bridge and an active frame agent', () => {
+    beforeEach(() => {
+      delete window.__K6_STUDIO_INSPECTION__
+      installActiveFrameAgent()
+    })
+
+    it('sends a serialized text selection', async () => {
+      const paragraph = document.createElement('p')
+      paragraph.id = 'paragraph'
+      paragraph.textContent = 'Hello world'
+      document.body.append(paragraph)
+
+      const range = document.createRange()
+      range.selectNodeContents(paragraph)
+
+      // jsdom doesn't compute layout, so `Range` has no geometry methods of
+      // its own; stub them the way `serializeElementState`'s own tests stub
+      // `getBoundingClientRect` on an element.
+      const highlightRect = { top: 1, left: 2, width: 3, height: 4 } as DOMRect
+      range.getClientRects = () => [highlightRect] as unknown as DOMRectList
+      range.getBoundingClientRect = () =>
+        ({ top: 5, left: 6, width: 7, height: 8 }) as DOMRect
+
+      select(range)
+
+      triggerSelection()
+
+      await flush()
+
+      expect(sendTextSelection).toHaveBeenCalledTimes(1)
+
+      const payload = sendTextSelection.mock.calls[0]![0]
+
+      expect(payload.text).toBe('Hello world')
+      expect(
+        payload.elements.map((state) => state.target.selectors.css)
+      ).toEqual(
+        serializeElementChain(paragraph).map(
+          (state) => state.target.selectors.css
+        )
+      )
+      expect(payload.framePath).toEqual([])
+      expect(payload.highlights).toEqual([
+        { top: 1, left: 2, width: 3, height: 4 },
+      ])
+      expect(payload.bounds).toEqual({ top: 5, left: 6, width: 7, height: 8 })
+    })
+
+    it('does not send anything when there is no active selection', async () => {
+      triggerSelection()
+
+      await flush()
+
+      expect(sendTextSelection).not.toHaveBeenCalled()
+    })
+
+    it('does not send anything when the tool is not active', async () => {
+      installFrameAgent({ isToolActive: false } as unknown as FrameAgent)
+
+      const paragraph = document.createElement('p')
+      paragraph.textContent = 'Hello world'
+      document.body.append(paragraph)
+
+      const range = document.createRange()
+      range.selectNodeContents(paragraph)
+      select(range)
+
+      triggerSelection()
+
+      await flush()
+
+      expect(sendTextSelection).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -102,3 +102,64 @@ describe('isTopFrameToolActive with a frame agent', () => {
     expect(isTopFrameToolActive()).toBe(false)
   })
 })
+
+describe('attachInspectionDetection with no top-frame bridge', () => {
+  beforeEach(() => {
+    // The outer suite's beforeEach installs an inspection bridge; these tests
+    // exercise the cross-origin path where the bridge is unreachable.
+    delete window.__K6_STUDIO_INSPECTION__
+  })
+
+  afterEach(() => {
+    installFrameAgent(null)
+  })
+
+  it('prevents the default click action when the tool is active in an ancestor frame', () => {
+    installFrameAgent({ isToolActive: true } as unknown as FrameAgent)
+
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    })
+    button.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(pick).not.toHaveBeenCalled()
+  })
+
+  it('does not prevent the default click action when no frame agent is installed', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    })
+    button.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(pick).not.toHaveBeenCalled()
+  })
+
+  it('does not prevent the default click action when the frame agent tool is inactive', () => {
+    installFrameAgent({ isToolActive: false } as unknown as FrameAgent)
+
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    })
+    button.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(pick).not.toHaveBeenCalled()
+  })
+})

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -93,8 +93,9 @@ export function readSelection(
  * Runs in child frames so the top-frame inspector can pick elements inside
  * iframes. Detection has to happen in each frame because DOM events don't cross
  * iframe boundaries; matched elements are forwarded to the top frame with a
- * direct call (frames are same-process with web security disabled, so the live
- * element reference passes across the boundary).
+ * direct call, which only works for same-origin frames since it passes a live
+ * element reference. Cross-origin frames can't reach the top frame's bridge
+ * (see `getTopFrameBridge`) and so no-op here (tier 3 follow-up).
  */
 export function attachInspectionDetection() {
   document.addEventListener('mouseover', (event) => {

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -1,5 +1,7 @@
 import { isElement, isHTMLIFrameElement } from '@/utils/dom/realm'
 
+import { getFrameAgent } from '../messaging/frames'
+
 /**
  * Bridge the top-frame element inspector exposes so that detection running in
  * child frames can report hovered/picked elements to it. It is only present
@@ -44,13 +46,17 @@ function getTextSelectionBridge(): TextSelectionBridge | undefined {
 }
 
 /**
- * True when the top frame has an inspector or text-selection tool active. Child
- * frames keep their own UI store where `tool` is never set, so they detect an
- * active tool through the top frame's bridge to avoid recording inspector picks
- * and text selections as real interactions.
+ * True when a tool is active in the top frame. Same-origin child frames read
+ * the top frame's bridges directly; cross-origin frames can't, so they rely on
+ * the tool state broadcast over the frame agent. Used to avoid recording
+ * inspector picks and text selections as real interactions.
  */
 export function isTopFrameToolActive(): boolean {
-  return getBridge() !== undefined || getTextSelectionBridge() !== undefined
+  return (
+    getBridge() !== undefined ||
+    getTextSelectionBridge() !== undefined ||
+    getFrameAgent()?.isToolActive === true
+  )
 }
 
 /**

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -1,5 +1,7 @@
 import { Bounds } from '@/components/Browser/types'
+import { getElementRoles } from '@/utils/dom/aria'
 import { isElement, isHTMLIFrameElement } from '@/utils/dom/realm'
+import { getElementDetails } from '@/utils/dom/selectors'
 
 import { getOwnFramePath } from '../frames'
 import { getFrameAgent } from '../messaging/frames'
@@ -11,7 +13,6 @@ import {
 
 import { clearChildOverlays, showChildOverlays } from './childOverlays'
 import { findAssociatedControl } from './ElementInspector/ElementMenu.utils'
-import { toTrackedElement } from './ElementInspector/utils'
 
 const HOVER_STYLE = { kind: 'hover' } as const
 
@@ -120,14 +121,20 @@ function toBounds(rect: DOMRect): Bounds {
 /**
  * The associated control for `element`, serialized the same way the live
  * top-frame menu computes it (`findAssociatedControl`), so a checkbox picked
- * by its wrapping label resolves to the checkbox rather than the label. Built
- * from a plain `Element` since there is no live `TrackedElement` when the
- * bridge is unreachable.
+ * by its wrapping label resolves to the checkbox rather than the label. The
+ * argument is built by hand rather than through `toTrackedElement`: that
+ * helper also computes top-frame bounds, which reads the top window's scroll
+ * position and throws a SecurityError in the cross-origin frames this path
+ * runs in.
  */
 function resolveAssociatedControl(
   element: Element
 ): SerializedElementState | null {
-  const control = findAssociatedControl(toTrackedElement(element))
+  const control = findAssociatedControl({
+    element,
+    target: getElementDetails(element),
+    roles: [...getElementRoles(element)],
+  })
 
   return control ? serializeElementState(control.element) : null
 }

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -126,11 +126,11 @@ export function attachInspectionDetection() {
       const bridge = getBridge()
 
       if (bridge === undefined) {
-        // No same-origin path to the top frame's inspector. If the inspector
-        // is active in an ancestor frame, the frame agent still knows via the
-        // broadcast tool state, so the real page click is swallowed even
-        // though there is no bridge to report the pick to.
-        if (getFrameAgent()?.isToolActive === true) {
+        // No same-origin path to the top frame's inspector. A tool can still
+        // be active in an ancestor frame (known here via the frame agent's
+        // broadcast state), so the real page click is swallowed even though
+        // there is no bridge to report the pick to.
+        if (isTopFrameToolActive()) {
           event.preventDefault()
           event.stopPropagation()
         }

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -95,7 +95,9 @@ export function readSelection(
  * iframe boundaries; matched elements are forwarded to the top frame with a
  * direct call, which only works for same-origin frames since it passes a live
  * element reference. Cross-origin frames can't reach the top frame's bridge
- * (see `getTopFrameBridge`) and so no-op here (tier 3 follow-up).
+ * (see `getTopFrameBridge`), so picking still no-ops there, but the click is
+ * swallowed whenever the frame agent reports the tool is active, so the page's
+ * real click handler doesn't fire underneath the inspector.
  */
 export function attachInspectionDetection() {
   document.addEventListener('mouseover', (event) => {
@@ -124,6 +126,15 @@ export function attachInspectionDetection() {
       const bridge = getBridge()
 
       if (bridge === undefined) {
+        // No same-origin path to the top frame's inspector. If the inspector
+        // is active in an ancestor frame, the frame agent still knows via the
+        // broadcast tool state, so the real page click is swallowed even
+        // though there is no bridge to report the pick to.
+        if (getFrameAgent()?.isToolActive === true) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+
         return
       }
 

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -1,6 +1,19 @@
+import { Bounds } from '@/components/Browser/types'
 import { isElement, isHTMLIFrameElement } from '@/utils/dom/realm'
 
+import { getOwnFramePath } from '../frames'
 import { getFrameAgent } from '../messaging/frames'
+import {
+  SerializedElementState,
+  serializeElementChain,
+  serializeElementState,
+} from '../serialization'
+
+import { clearChildOverlays, showChildOverlays } from './childOverlays'
+import { findAssociatedControl } from './ElementInspector/ElementMenu.utils'
+import { toTrackedElement } from './ElementInspector/utils'
+
+const HOVER_STYLE = { kind: 'hover' } as const
 
 /**
  * Bridge the top-frame element inspector exposes so that detection running in
@@ -90,6 +103,36 @@ export function readSelection(
 }
 
 /**
+ * Maps a DOMRect to a plain, structured-clone- and Zod-friendly object. Used
+ * for both the local hover overlay and the payloads relayed to the top frame,
+ * since a `DOMRect` instance itself isn't what `BoundsSchema` (nor the plain
+ * `Bounds` overlay type) expects.
+ */
+function toBounds(rect: DOMRect): Bounds {
+  return {
+    top: rect.top,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+  }
+}
+
+/**
+ * The associated control for `element`, serialized the same way the live
+ * top-frame menu computes it (`findAssociatedControl`), so a checkbox picked
+ * by its wrapping label resolves to the checkbox rather than the label. Built
+ * from a plain `Element` since there is no live `TrackedElement` when the
+ * bridge is unreachable.
+ */
+function resolveAssociatedControl(
+  element: Element
+): SerializedElementState | null {
+  const control = findAssociatedControl(toTrackedElement(element))
+
+  return control ? serializeElementState(control.element) : null
+}
+
+/**
  * Runs in child frames so the top-frame inspector can pick elements inside
  * iframes. Detection has to happen in each frame because DOM events don't cross
  * iframe boundaries; matched elements are forwarded to the top frame with a
@@ -97,27 +140,50 @@ export function readSelection(
  * element reference. Cross-origin frames can't reach the top frame's bridge
  * (see `getTopFrameBridge`), so picking still no-ops there, but the click is
  * swallowed whenever the frame agent reports the tool is active, so the page's
- * real click handler doesn't fire underneath the inspector.
+ * real click handler doesn't fire underneath the inspector. In that case the
+ * pick is instead serialized and relayed to the top frame over the frame
+ * agent, and a local hover overlay stands in for the live highlight the
+ * bridge would otherwise draw.
  */
 export function attachInspectionDetection() {
   document.addEventListener('mouseover', (event) => {
     const bridge = getBridge()
 
-    if (bridge === undefined) {
+    if (bridge !== undefined) {
+      const [target] = event.composedPath()
+
+      if (!isElement(target)) {
+        return
+      }
+
+      // The inspector running inside the iframe reports the actual element
+      // under the cursor, so don't highlight the iframe element itself; clear
+      // the hover instead so a prior highlight can't linger over it (this
+      // also avoids an expensive selector computation on the often deeply
+      // nested iframe element).
+      bridge.hover(isHTMLIFrameElement(target) ? null : target)
+
+      return
+    }
+
+    if (!isTopFrameToolActive()) {
+      // Cheap per-event clear instead of a subscription: as soon as the tool
+      // goes inactive, the next mouseover in this frame drops any hover
+      // overlay left over from while it was active.
+      clearChildOverlays(HOVER_STYLE)
+
       return
     }
 
     const [target] = event.composedPath()
 
-    if (!isElement(target)) {
+    if (!isElement(target) || isHTMLIFrameElement(target)) {
+      clearChildOverlays(HOVER_STYLE)
+
       return
     }
 
-    // The inspector running inside the iframe reports the actual element under
-    // the cursor, so don't highlight the iframe element itself; clear the hover
-    // instead so a prior highlight can't linger over it (this also avoids an
-    // expensive selector computation on the often deeply nested iframe element).
-    bridge.hover(isHTMLIFrameElement(target) ? null : target)
+    showChildOverlays([toBounds(target.getBoundingClientRect())], HOVER_STYLE)
   })
 
   document.addEventListener(
@@ -129,11 +195,36 @@ export function attachInspectionDetection() {
         // No same-origin path to the top frame's inspector. A tool can still
         // be active in an ancestor frame (known here via the frame agent's
         // broadcast state), so the real page click is swallowed even though
-        // there is no bridge to report the pick to.
-        if (isTopFrameToolActive()) {
-          event.preventDefault()
-          event.stopPropagation()
+        // there is no bridge to report the pick to directly; the pick is
+        // relayed to the top frame over the frame agent instead.
+        if (!isTopFrameToolActive()) {
+          return
         }
+
+        event.preventDefault()
+        event.stopPropagation()
+        clearChildOverlays(HOVER_STYLE)
+
+        const [target] = event.composedPath()
+
+        // Don't pick the iframe element itself; the inspector inside it
+        // picks the real element under the cursor.
+        if (!isElement(target) || isHTMLIFrameElement(target)) {
+          return
+        }
+
+        const elements = serializeElementChain(target)
+        const associatedControl = resolveAssociatedControl(target)
+        const position = { left: event.clientX, top: event.clientY }
+
+        void getOwnFramePath().then((framePath) => {
+          getFrameAgent()?.sendElementPick({
+            elements,
+            associatedControl,
+            framePath,
+            position,
+          })
+        })
 
         return
       }
@@ -163,13 +254,15 @@ export function attachInspectionDetection() {
 /**
  * Runs in child frames so the top-frame text-selection tool can assert on text
  * selected inside an iframe. Selection state is per-document, so the selection
- * is read here and forwarded to the top frame.
+ * is read here and forwarded to the top frame, either directly through the
+ * bridge (same-origin) or, when it's unreachable, serialized and relayed over
+ * the frame agent.
  */
 export function attachTextSelectionDetection() {
   let isSelecting = false
 
   document.addEventListener('selectstart', () => {
-    if (getTextSelectionBridge() !== undefined) {
+    if (isTopFrameToolActive()) {
       isSelecting = true
     }
   })
@@ -183,14 +276,41 @@ export function attachTextSelectionDetection() {
 
     const bridge = getTextSelectionBridge()
 
-    if (bridge === undefined) {
+    if (bridge !== undefined) {
+      const selection = readSelection(document)
+
+      if (selection !== null) {
+        bridge.select(selection.range, selection.commonAncestor)
+      }
+
+      return
+    }
+
+    if (!isTopFrameToolActive()) {
       return
     }
 
     const selection = readSelection(document)
 
-    if (selection !== null) {
-      bridge.select(selection.range, selection.commonAncestor)
+    if (selection === null) {
+      return
     }
+
+    const { range, commonAncestor } = selection
+
+    const text = range.toString()
+    const elements = serializeElementChain(commonAncestor)
+    const highlights = [...range.getClientRects()].map(toBounds)
+    const bounds = toBounds(range.getBoundingClientRect())
+
+    void getOwnFramePath().then((framePath) => {
+      getFrameAgent()?.sendTextSelection({
+        text,
+        elements,
+        framePath,
+        highlights,
+        bounds,
+      })
+    })
   })
 }

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -145,12 +145,10 @@ function resolveAssociatedControl(
  * iframe boundaries; matched elements are forwarded to the top frame with a
  * direct call, which only works for same-origin frames since it passes a live
  * element reference. Cross-origin frames can't reach the top frame's bridge
- * (see `getTopFrameBridge`), so picking still no-ops there, but the click is
- * swallowed whenever the frame agent reports the tool is active, so the page's
- * real click handler doesn't fire underneath the inspector. In that case the
- * pick is instead serialized and relayed to the top frame over the frame
- * agent, and a local hover overlay stands in for the live highlight the
- * bridge would otherwise draw.
+ * (see `getTopFrameBridge`); there the click is swallowed whenever the frame
+ * agent reports the tool is active, the pick is serialized and relayed to the
+ * top frame over the frame agent, and a local hover overlay stands in for the
+ * live highlight the bridge would otherwise draw.
  */
 export function attachInspectionDetection() {
   document.addEventListener('mouseover', (event) => {

--- a/src/recorder/launchers/cdp/index.ts
+++ b/src/recorder/launchers/cdp/index.ts
@@ -29,14 +29,15 @@ const DEBUGGER_PORT = 9222
 
 const BROWSER_CDP_ARGS = [
   '--disable-back-forward-cache',
-  // Disable web security to allow our script to be executed in sandboxed iframes.
-  '--disable-web-security',
+  // Allows each frame's ws:// connection to the recorder from https pages.
   '--allow-running-insecure-content',
   // Keep cross-origin iframes in the parent's process so the injected recording
-  // script runs inside them and can walk up to the top frame. Disabling the
-  // IsolateOrigins/site-per-process features (see FEATURES_TO_DISABLE) is not
-  // enough on its own in current Chrome; the site-isolation trials must also be
-  // turned off.
+  // script runs inside them. Disabling the IsolateOrigins/site-per-process
+  // features (see FEATURES_TO_DISABLE) is not enough on its own in current
+  // Chrome; the site-isolation trials must also be turned off. Web security
+  // stays ON: cross-origin frames coordinate over postMessage (FrameAgent)
+  // instead of direct DOM access, so the browser keeps sending Origin headers
+  // (SPA IdP logins depend on them, e.g. Entra ID AADSTS9002327).
   '--disable-site-isolation-trials',
 ]
 

--- a/src/recorder/launchers/utils.ts
+++ b/src/recorder/launchers/utils.ts
@@ -51,8 +51,8 @@ const FEATURES_TO_DISABLE = [
   'OptimizationHints',
   // Keep cross-origin iframes in the same process as their parent so that the
   // recording script (injected via CDP) runs inside them and can walk up to the
-  // top frame. Combined with --disable-web-security this lets us record events
-  // and compute frame paths across origins.
+  // top frame. Web security stays on; cross-origin frames coordinate over the
+  // FrameAgent postMessage protocol.
   'IsolateOrigins',
   'site-per-process',
 ]

--- a/src/schemas/recording/browser/v2/index.ts
+++ b/src/schemas/recording/browser/v2/index.ts
@@ -21,7 +21,7 @@ const ElementSelectorSchema = z.object({
   role: RoleElementSelectorSchema.optional(),
 })
 
-const BrowserEventTargetSchema = z.object({
+export const BrowserEventTargetSchema = z.object({
   selectors: ElementSelectorSchema,
   aria: AriaDetailsSchema.optional(),
 })

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -35,6 +35,16 @@ if (
   HTMLElement.prototype.releasePointerCapture = vi.fn()
 }
 
+if (typeof globalThis.CSS === 'undefined' || !globalThis.CSS.escape) {
+  // jsdom does not implement the CSS Object Model's `CSS.escape`, which
+  // `@medv/finder` (used to generate element selectors) relies on. Real
+  // browsers provide it, so this only backfills the test environment.
+  globalThis.CSS = {
+    ...globalThis.CSS,
+    escape: (value: string) => value.replace(/([^\w-])/g, '\\$1'),
+  } as typeof CSS
+}
+
 if (typeof window !== 'undefined') {
   // jsdom logs "Not implemented: window.getComputedStyle(elt, pseudoElt)" when
   // pseudo-element styles are requested (e.g. by Playwright's injectedScript

--- a/src/utils/dom/frameChain.ts
+++ b/src/utils/dom/frameChain.ts
@@ -8,9 +8,9 @@
  * collected so far would resolve a locator against the wrong, shallower frame.
  * Best-effort callers (e.g. pixel offsets) wrap the call in try/catch.
  *
- * Reading `window.frameElement` across origins relies on the recorder and
- * validator launching the browser with web security and site isolation
- * disabled, and on session replay rebuilding iframes as same-origin nodes.
+ * Reading `window.frameElement` across origins only works for same-origin
+ * chains; cross-origin callers fall back to the recorder's postMessage
+ * protocol. Session replay rebuilds iframes as same-origin nodes.
  */
 export function forEachOwningFrame(
   start: Window | null,

--- a/src/utils/dom/layout.ts
+++ b/src/utils/dom/layout.ts
@@ -9,9 +9,10 @@ import { forEachOwningFrame } from './frameChain'
  * Accumulated offset of `frameWindow`'s frame relative to `rootWindow`'s
  * viewport, or the top frame's viewport when `rootWindow` is null. Zero when the
  * element is already in the root frame. Walks up the iframe chain adding each
- * owning `<iframe>`'s position, which is readable across origins because the
- * recorder disables web security and site isolation. Used to translate element
- * rects and points that originate inside (possibly nested) iframes.
+ * owning `<iframe>`'s position; this is best-effort since the owning element is
+ * only reliably readable for same-origin frames (see `forEachOwningFrame`).
+ * Used to translate element rects and points that originate inside (possibly
+ * nested) iframes.
  */
 export function getFrameOffset(
   frameWindow: Window | null,

--- a/src/utils/dom/realm.ts
+++ b/src/utils/dom/realm.ts
@@ -85,3 +85,9 @@ export function isHTMLIFrameElement(
 ): node is HTMLIFrameElement {
   return isHtmlElement(node, 'iframe')
 }
+
+export function isHTMLFrameElement(
+  node: Node | null | undefined
+): node is HTMLFrameElement {
+  return isHtmlElement(node, 'frame')
+}


### PR DESCRIPTION
## Description

The recording browser has been launched with `--disable-web-security` since v1.10 (#871), and the validator passes the same flag to the k6 browser. The flag makes Chrome omit the `Origin` header on cross-origin requests, which breaks sign-in with any IdP that validates it. Entra ID rejects SPA token redemption outright:

```
ServerError: invalid_request: 9002327 - AADSTS9002327: Tokens issued for the
'Single-Page Application' client-type may only be redeemed via cross-origin requests.
```

So with browser event capture on (the default), users behind SSO could not sign in during a recording at all. The flag also made recordings unfaithful in general: CORS, `Origin`, and SameSite semantics were altered, so pages could take different code paths while being recorded than they do for real users.

This removes the flag from both launchers. The iframe recording features that relied on it (the flag let scripts reach across origins directly) keep working through a new postMessage protocol between frames: same-origin iframes keep the existing synchronous mechanisms, while cross-origin iframes now resolve their frame paths, receive tool state, and forward serialized picks and text selections through a per-frame `FrameAgent`. Element highlighting inverted direction: each frame matches highlight requests against its own frame chain and draws locally, instead of the top frame reaching into child documents. Browser test session replay records each frame with rrweb's `recordCrossOriginIframes` and flushes pending events on `pagehide`, so cross-origin iframe content shows up in the replay preview.

### Known limitations

- Iframes with `sandbox` but without `allow-scripts` are no longer recorded (no page JS runs in them either; their HTTP traffic is still captured).
- Cross-origin iframes hosted inside shadow DOM don't resolve frame paths yet.
- If an ancestor frame never answers a frame path request, events from that frame record without a frame path after a 1s timeout.

## How to Test

SSO login (the bug):

1. Start a recording of an app behind Entra ID or another SPA IdP, with browser event capture on.
2. Sign in. Previously this failed with `AADSTS9002327`; now the token request carries `Origin` and succeeds.

Cross-origin iframe tools:

1. Record a page that embeds a cross-origin iframe (any CodeSandbox demo page works, the app preview is a cross-origin embed).
2. Click inside the iframe: the recorded event carries the iframe's frame path.
3. With the text-selection tool, select text inside the iframe: the assertion popover opens with the text prefilled.
4. With the inspector, hover (local highlight) and click an element inside the iframe: the element menu opens and assertions use the picked element's state.
5. Hover a recorded event in the drawer: the element highlights inside the iframe.

Validator and replay:

1. Generate a browser test with a `frameLocator` chain into the cross-origin iframe and validate it.
2. The test passes, and the replay preview in the browser test editor renders the iframe's content.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

<!-- Resolves #ISSUE-ID -->