### PR TITLE
internal(fix): Unable to create recordings or browser tests

### DIFF
--- a/src/handlers/browserTest/create.ts
+++ b/src/handlers/browserTest/create.ts
@@ -3,6 +3,7 @@ import { BROWSER_TESTS_PATH } from '@/constants/workspace'
 import {
   type AnyBrowserAction,
   BrowserTestFile,
+  BrowserTestFileCodec,
   defaultBrowserTestOptions,
 } from '@/schemas/browserTest'
 import { trackEvent } from '@/services/usageTracking'
@@ -19,7 +20,7 @@ export async function createBrowserTest(
   }
 
   const filePath = await createFileWithUniqueName({
-    data: JSON.stringify(browserTest, null, 2),
+    data: BrowserTestFileCodec.encode(browserTest),
     directory: BROWSER_TESTS_PATH,
     ext: K6_BROWSER_TEST_FILE_EXTENSION,
     prefix: 'Browser',

--- a/src/handlers/generator/create.ts
+++ b/src/handlers/generator/create.ts
@@ -12,13 +12,9 @@ export async function createGenerator(recordingPath?: string): Promise<string> {
   const generator = createNewGeneratorFile(recordingPath)
 
   const filePath = await createFileWithUniqueName({
-    data: JSON.stringify(
-      serializeGenerator(
-        path.join(GENERATORS_PATH, `Generator${K6_GENERATOR_FILE_EXTENSION}`),
-        generator
-      ),
-      null,
-      2
+    data: serializeGenerator(
+      path.join(GENERATORS_PATH, `Generator${K6_GENERATOR_FILE_EXTENSION}`),
+      generator
     ),
     directory: GENERATORS_PATH,
     ext: K6_GENERATOR_FILE_EXTENSION,

--- a/src/handlers/generator/index.ts
+++ b/src/handlers/generator/index.ts
@@ -21,10 +21,7 @@ export function initialize() {
     async (_, generator: GeneratorFileData, filePath: string) => {
       console.log(`${GeneratorHandler.Save} event received`)
 
-      await writeFile(
-        filePath,
-        JSON.stringify(serializeGenerator(filePath, generator), null, 2)
-      )
+      await writeFile(filePath, serializeGenerator(filePath, generator))
 
       trackGeneratorUpdated(generator)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a regression from a previous refactor. The issue was caused by a change in serialization leading to generators were serialized twice (basically `JSON.stringify(JSON.stringify(data))`.

## How to Test

Create a HTTP test and a browser test.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
