### PR TITLE
fix: Unicode payloads become corrupted after stopping a recording

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -30,8 +30,14 @@ function atobUTF8(base64Str: string) {
     bytes[i] = binaryStr.charCodeAt(i)
   }
 
-  // decode bytes as UTF-8
-  return new TextDecoder('utf-8').decode(bytes)
+  try {
+    return new TextDecoder('utf-8', {
+      fatal: true,
+      ignoreBOM: true,
+    }).decode(bytes)
+  } catch {
+    return binaryStr
+  }
 }
 
 export function safeBtoa(content: string) {

--- a/src/utils/proxyDataToHar.test.ts
+++ b/src/utils/proxyDataToHar.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import { BrowserEvent } from '@/schemas/recording'
+import {
+  createProxyDataWithoutResponse,
+  createRequest,
+} from '@/test/factories/proxyData'
+import { safeBtoa } from '@/utils/format'
 
 import { proxyDataToHar } from './proxyDataToHar'
 
@@ -43,5 +48,60 @@ describe('proxyDataToHar browser events', () => {
     proxyDataToHar([], events)
 
     expect(events.map((event) => event.eventId)).toEqual(['c', 'a'])
+  })
+})
+
+describe('proxyDataToHar', () => {
+  it('preserves binary request payloads', () => {
+    const binaryContent = String.fromCharCode(
+      0x89,
+      0x50,
+      0x4e,
+      0x47,
+      0x0d,
+      0x0a,
+      0x1a,
+      0x0a
+    )
+
+    const proxyData = createProxyDataWithoutResponse({
+      request: createRequest({
+        method: 'POST',
+        headers: [['content-type', 'application/octet-stream']],
+        content: btoa(binaryContent),
+      }),
+    })
+
+    const recording = proxyDataToHar([proxyData], [])
+    const text = recording.log.entries?.[0]?.request.postData?.text
+
+    expect(text).toBeDefined()
+    expect(Array.from(text!, (char) => char.charCodeAt(0))).toEqual([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ])
+  })
+
+  it('preserves Unicode characters in request payloads', () => {
+    const original = JSON.stringify({
+      name: 'Nguyễn Văn A',
+      message: 'kiểm thử tiếng Việt',
+      cyrillic: 'Привет мир',
+      emoji: '✅ café',
+    })
+
+    const proxyData = createProxyDataWithoutResponse({
+      request: createRequest({
+        method: 'POST',
+        headers: [['content-type', 'application/json; charset=utf-8']],
+        content: safeBtoa(original),
+      }),
+    })
+
+    const har = proxyDataToHar([proxyData], [])
+
+    const entry = har.log.entries?.[0]
+
+    expect(entry).toBeDefined()
+    expect(entry?.request.postData?.text).toBe(original)
   })
 })

--- a/src/utils/proxyDataToHar.ts
+++ b/src/utils/proxyDataToHar.ts
@@ -2,6 +2,7 @@ import { BrowserEvent, Recording } from '@/schemas/recording'
 import { GroupedProxyData, ProxyData, Request, Response } from '@/types'
 import { HarEntry, HarPage } from '@/types/recording'
 
+import { safeAtob } from './format'
 import { groupProxyData } from './groups'
 import { getContentTypeWithCharsetHeader } from './headers'
 
@@ -105,7 +106,7 @@ function createPostData(request: Request): HarEntry['request']['postData'] {
   }
   const contentTypeHeader =
     getContentTypeWithCharsetHeader(request.headers) ?? ''
-  const content = atob(request.content ?? '')
+  const content = safeAtob(request.content ?? '')
 
   // Extract params for urlencoded form
   if (contentTypeHeader.includes('application/x-www-form-urlencoded')) {
@@ -122,7 +123,7 @@ function createPostData(request: Request): HarEntry['request']['postData'] {
 
   return {
     mimeType: getContentTypeWithCharsetHeader(request.headers) ?? '',
-    text: atob(request.content ?? ''),
+    text: safeAtob(request.content ?? ''),
   }
 }
 


### PR DESCRIPTION
## Description

Fix Unicode corruption in recorded HTTP request payloads.

Request bodies were decoded with `atob()` during HAR serialization, which corrupted multi-byte UTF-8 characters. This change uses the existing UTF-8-safe decoder and adds a regression test for mixed Unicode payloads.

## How to Test

Run:

```bash
pnpm test -- --run src/utils/proxyDataToHar.test.ts
```

### Manually

- Record a POST request with Unicode characters in the payload.
- Stop the recording.
- Reopen the request and verify that the payload is unchanged.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Resolves #1322