### PR TITLE
internal(feat): Prompt user about unsaved changes in browser test editor

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -151,7 +151,7 @@ const createWindow = async () => {
 
     if (
       fileExtension &&
-      ['.k6g', '.js', '.ts'].includes(fileExtension) &&
+      ['.k6g', '.k6b', '.js', '.ts'].includes(fileExtension) &&
       !k6StudioState.wasAppClosedByClient
     ) {
       event.preventDefault()

--- a/src/views/BrowserTestEditor/BrowserTestEditor.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditor.tsx
@@ -9,11 +9,13 @@ import { HighlightLocatorProvider } from '@/components/HighlightLocatorProvider'
 import { HtmlInspector } from '@/components/HtmlInspector'
 import { View } from '@/components/Layout/View'
 import { Group, Panel, Separator } from '@/components/primitives/ResizablePanel'
+import { UnsavedChangesDialog } from '@/components/UnsavedChangesDialog'
 import {
   LogsSection,
   useConsoleFilter,
 } from '@/components/Validator/LogsSection'
 import { useSaveFile } from '@/hooks/useSaveFile'
+import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt'
 import { getViewPath } from '@/routeMap'
 import {
   AnyBrowserAction,
@@ -120,6 +122,11 @@ export function BrowserTestEditor({
   const handleSave = () => {
     void saveFile({ saveAs: false })
   }
+
+  const unsavedChangesPrompt = useUnsavedChangesPrompt({
+    isDirty,
+    onSave: () => saveFile({ saveAs: false }),
+  })
 
   const handleAddAction = (action: AnyBrowserAction) => {
     onChange({
@@ -273,6 +280,7 @@ export function BrowserTestEditor({
                 </Flex>
               </Tabs.Root>
             </Flex>
+            <UnsavedChangesDialog {...unsavedChangesPrompt} />
           </View>
         </ValidationProvider>
       </PlayerContextProvider>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds the unsaved changes prompt when navigating/closing the app to the browser test editor.

## How to Test

Edit a browser test and:

* Try to switch to another file
* Close the app
* Cancel by pressing the X

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
