### PR TITLE
build: Update test build version to be one minor ahead of stable release

### DIFF
--- a/update_version.py
+++ b/update_version.py
@@ -1,17 +1,39 @@
-import os
 import json
-
+import os
+import re
+import subprocess
 
 version = os.environ['PACKAGE_VERSION']
 
+# package.json on a branch can lag behind the latest published release (e.g. a
+# long-lived branch cut before a release-please version bump merged to main).
+# Bumping relative to that stale value can land on a version that's already
+# released, and a prerelease suffix like "-abc" sorts *below* the plain release
+# in semver, not above it. So we bump relative to the latest published tag
+# instead, which always reflects what's actually been released.
+tags = subprocess.run(
+    ['git', 'ls-remote', '--tags', 'origin'],
+    capture_output=True, text=True, check=True,
+).stdout
+
+released_versions = [
+    tuple(int(part) for part in match.groups())
+    for match in (re.search(r'refs/tags/v(\d+)\.(\d+)\.(\d+)$', line) for line in tags.splitlines())
+    if match
+]
+major, minor, patch = max(released_versions)
+
+# Increment the minor version so that this is considered a later version than the
+# latest release. This stops the auto updater from re-installing the latest release
+# since the patched version is considered a newer version.
+updated_version = f'{major}.{minor + 1}.0-{version}'
 
 with open('package.json', 'r') as f:
     data = json.loads(f.read())
 
+data['version'] = updated_version
 
 with open('package.json', 'w') as f:
-    updated_version = f'{data["version"]}-{version}'
-    data['version'] = updated_version
     f.write(json.dumps(data, indent=2))
 
 print(f'Updated package.json version to {updated_version}')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Test builds are currently always considered as older versions than the latest stable release because a suffixed version is a lower version than a non-suffixed. This will trigger the auto-updater to re-install the latest stable, meaning that if you close the app you will lose the test build and have to install it again.

This PR updates the test build logic to always put the test build version one minor version ahead of the stable release. To do this, we now use `git ls-remote` to fetch the latest version tag and update the package version accordingly (we can't trust `package.version` to be the latest version because a release might happen after the branch is created.)

## How to Test

Do a test build and verify that the version is the latest stable release with minor incremented by 1.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
