### PR TITLE
internal(fix): Unable to validate test in browser test editor

### DIFF
--- a/src/views/BrowserTestEditor/BrowserTestEditorControls.tsx
+++ b/src/views/BrowserTestEditor/BrowserTestEditorControls.tsx
@@ -78,13 +78,23 @@ export function BrowserTestEditorControls({
       </Flex>
       <Flex gap="4" align="center" pl="2">
         {session.state === 'running' && (
-          <Button variant="ghost" onClick={onStopDebugging}>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              onStopDebugging()
+            }}
+          >
             <Spinner />
             Stop
           </Button>
         )}
         {session.state !== 'running' && (
-          <Button variant="ghost" onClick={onStartDebugging}>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              onStartDebugging()
+            }}
+          >
             <CircleCheckBigIcon /> Validate
           </Button>
         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes an issue where an event object was being passed to `startDebugging` instead of a `scenarioName`. This meant that the event object was being passed through to the IPC layer and caused serialization to fail.

## How to Test

Open a browser test and click "Validate". It should no longer crash.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/k6-studio/issues/...> -->

<!-- Does it resolve an issue? -->

<!-- Resolves #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
