### PR TITLE
fix: Prevent recorder tab crash on pages with sandboxed iframes

### DIFF
--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -137,6 +137,8 @@ export class Page extends EventEmitter<PageEventMap> {
 
   async attach() {
     await this.#client.page.enable()
+    // TEMP EXPERIMENT: Runtime.enable suppresses renderer crash on sandboxed iframes
+    await this.#client.runtime.enable()
     await this.#client.page.setBypassCSP(true)
 
     await this.#client.page.addScriptToEvaluateOnNewDocument({

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -137,8 +137,17 @@ export class Page extends EventEmitter<PageEventMap> {
 
   async attach() {
     await this.#client.page.enable()
-    // TEMP EXPERIMENT: Runtime.enable suppresses renderer crash on sandboxed iframes
+
+    // Force main-world context creation for every frame up front. Without it,
+    // injecting our scripts into a frame that has no context yet (e.g. a
+    // sandboxed iframe without allow-scripts) makes Chromium create the
+    // context mid-injection and re-enter its script bookkeeping, hitting a
+    // use-after-free that kills the whole tab with "Aw, Snap! Error code: 5".
+    // Chromium fixed one variant of this in
+    // https://chromium-review.googlesource.com/c/chromium/src/+/7978579 but it
+    // still reproduces on Chrome 151 with our two consecutive injections.
     await this.#client.runtime.enable()
+
     await this.#client.page.setBypassCSP(true)
 
     await this.#client.page.addScriptToEvaluateOnNewDocument({


### PR DESCRIPTION
## Description

Recording a page that embeds a sandboxed iframe without `allow-scripts` (common with third-party chat and consent widgets) can kill the browser tab within seconds with "Aw, Snap! Something went wrong while displaying this webpage. Error code: 5".

Injecting our recording scripts into a frame that has no JavaScript context yet makes Chromium create the context mid-injection and re-enter its evaluate-on-new-document bookkeeping, hitting a use-after-free that traps the whole renderer ([partially fixed upstream](https://chromium-review.googlesource.com/c/chromium/src/+/7978579), still reproducible on Chrome 151). Enabling the Runtime domain before injection forces context creation for every frame up front, so the injection path never creates contexts and the re-entrancy never happens. This is also why the crash disappeared whenever DevTools was open, attaching DevTools enables Runtime.

## How to Test

The crash does not reproduce in dev mode (the use-after-free needs the memory layout of a packaged build), so use a packaged build:

1. Record a site whose page creates a sandboxed iframe without `allow-scripts` via `document.write` (many chat widgets do this).
2. Without this change the tab crashes within seconds of the page loading. With it, the page loads and the recording captures requests and browser events normally.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)