### PR TITLE
fix: New tabs opened as noopener popups hang during recording

### DIFF
--- a/src/recorder/launchers/cdp/browser.ts
+++ b/src/recorder/launchers/cdp/browser.ts
@@ -87,7 +87,7 @@ export class BrowserSession extends EventEmitter<BrowserSessionEventMap> {
       })
     }
 
-    await page.attach()
+    await page.attach({ waitingForDebugger: data.waitingForDebugger })
   }
 
   #handleDetachedFromTarget = ({

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ChromeCommand,
+  ChromeDevToolsClient,
+  Transport,
+} from '@/utils/cdp/client'
+
+import { Page } from './page'
+import { Script } from './script'
+
+class FakeTransport implements Transport {
+  calls: ChromeCommand[] = []
+
+  // Mimics a popup opened with noopener/noreferrer: while such a page is
+  // paused waiting for the debugger, Chrome doesn't respond to any session
+  // command until Runtime.runIfWaitingForDebugger has been sent.
+  #holdResponsesUntilResume: boolean
+  #heldResponses: Array<() => void> = []
+
+  constructor(holdResponsesUntilResume: boolean) {
+    this.#holdResponsesUntilResume = holdResponsesUntilResume
+  }
+
+  call<Return>(command: ChromeCommand): Promise<Return> {
+    this.calls.push(command)
+
+    const result = {} as Return
+
+    if (!this.#holdResponsesUntilResume) {
+      return Promise.resolve(result)
+    }
+
+    if (command.method === 'Runtime.runIfWaitingForDebugger') {
+      this.#heldResponses.splice(0).forEach((respond) => respond())
+
+      return Promise.resolve(result)
+    }
+
+    const { promise, resolve } = Promise.withResolvers<Return>()
+
+    this.#heldResponses.push(() => resolve(result))
+
+    return promise
+  }
+
+  on() {
+    return () => {}
+  }
+
+  off() {}
+
+  dispose() {}
+}
+
+function setup(holdResponsesUntilResume = false) {
+  const transport = new FakeTransport(holdResponsesUntilResume)
+  const client = new ChromeDevToolsClient(transport)
+  const page = new Page('tab-1', client, new Script('script-content'))
+
+  return { transport, page }
+}
+
+function scriptCalls(transport: FakeTransport) {
+  return transport.calls.filter(
+    (call) => call.method === 'Page.addScriptToEvaluateOnNewDocument'
+  )
+}
+
+describe('Page.attach', () => {
+  it(
+    'registers scripts before resuming a paused popup that holds command responses until resume',
+    { timeout: 1000 },
+    async () => {
+      const { transport, page } = setup(true)
+
+      await page.attach({ waitingForDebugger: true })
+
+      const methods = transport.calls.map((call) => call.method)
+
+      expect(
+        methods.lastIndexOf('Page.addScriptToEvaluateOnNewDocument')
+      ).toBeLessThan(methods.indexOf('Runtime.runIfWaitingForDebugger'))
+    }
+  )
+
+  // A paused target only has its empty initial document, and executing the
+  // recording script there wedges the renderer of noopener/noreferrer popups.
+  it.each([
+    { waitingForDebugger: false, runImmediately: true },
+    { waitingForDebugger: true, runImmediately: false },
+  ])(
+    'injects scripts with runImmediately: $runImmediately when waitingForDebugger is $waitingForDebugger',
+    async ({ waitingForDebugger, runImmediately }) => {
+      const { transport, page } = setup()
+
+      await page.attach({ waitingForDebugger })
+
+      const calls = scriptCalls(transport)
+
+      expect(calls).toHaveLength(2)
+      calls.forEach((call) => {
+        expect(call.params).toMatchObject({ runImmediately })
+      })
+    }
+  )
+})

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -135,29 +135,49 @@ export class Page extends EventEmitter<PageEventMap> {
     })
   }
 
-  async attach() {
-    await this.#client.page.enable()
+  async attach({ waitingForDebugger }: { waitingForDebugger: boolean }) {
+    // A target paused waiting for the debugger (e.g. a popup opened with
+    // noopener/noreferrer, which gets a new browsing context group) doesn't
+    // process session commands until Runtime.runIfWaitingForDebugger is sent,
+    // so awaiting any response before requesting resume would deadlock and
+    // leave the tab paused with a spinner forever. All commands are therefore
+    // dispatched up front and only then awaited. The transport sends messages
+    // in call order, so the scripts are still registered before the page
+    // resumes.
+    //
+    // Scripts run immediately only in targets that already have a document
+    // (the tab the recording starts in). A paused target only has its empty
+    // initial document, and executing the recording script there wedges the
+    // renderer of noopener/noreferrer popups in a busy loop that blocks their
+    // first real navigation.
+    const runImmediately = !waitingForDebugger
 
-    // Force main-world context creation for every frame up front. Without it,
-    // injecting our scripts into a frame that has no context yet (e.g. a
-    // sandboxed iframe without allow-scripts) makes Chromium create the
-    // context mid-injection and re-enter its script bookkeeping, hitting a
-    // use-after-free that kills the whole tab with "Aw, Snap! Error code: 5".
-    // Chromium fixed one variant of this in
-    // https://chromium-review.googlesource.com/c/chromium/src/+/7978579 but it
-    // still reproduces on Chrome 151 with our two consecutive injections.
-    await this.#client.runtime.enable()
+    await Promise.all([
+      this.#client.page.enable(),
 
-    await this.#client.page.setBypassCSP(true)
+      // Force main-world context creation for every frame up front. Without
+      // it, injecting our scripts into a frame that has no context yet (e.g.
+      // a sandboxed iframe without allow-scripts) makes Chromium create the
+      // context mid-injection and re-enter its script bookkeeping, hitting a
+      // use-after-free that kills the whole tab with "Aw, Snap! Error code:
+      // 5". Chromium fixed one variant of this in
+      // https://chromium-review.googlesource.com/c/chromium/src/+/7978579 but
+      // it still reproduces on Chrome 151 with our two consecutive
+      // injections.
+      this.#client.runtime.enable(),
 
-    await this.#client.page.addScriptToEvaluateOnNewDocument({
-      source: `window.__K6_STUDIO_TAB_ID__ = "${this.#id}";`,
-      runImmediately: true,
-    })
+      this.#client.page.setBypassCSP(true),
 
-    await this.#script.inject(this.#client)
+      this.#client.page.addScriptToEvaluateOnNewDocument({
+        source: `window.__K6_STUDIO_TAB_ID__ = "${this.#id}";`,
+        runImmediately,
+      }),
+      this.#script.inject(this.#client, runImmediately),
 
-    await this.#client.runtime.runIfWaitingForDebugger()
+      // Must stay dispatched last so the commands above are queued before the
+      // page resumes.
+      this.#client.runtime.runIfWaitingForDebugger(),
+    ])
 
     return this
   }

--- a/src/recorder/launchers/cdp/script.ts
+++ b/src/recorder/launchers/cdp/script.ts
@@ -20,7 +20,9 @@ export class Script extends EventEmitter<ScriptEventMap> {
     this.#content = content
   }
 
-  async inject(client: ChromeDevToolsClient, runImmediately = true) {
+  // Must dispatch the CDP call without awaiting anything first: Page.attach
+  // relies on this call being queued before Runtime.runIfWaitingForDebugger.
+  async inject(client: ChromeDevToolsClient, runImmediately: boolean) {
     const { identifier } = await client.page.addScriptToEvaluateOnNewDocument({
       source: this.#content,
       runImmediately,


### PR DESCRIPTION
## Description

During recording, clicking a link that opens a new tab leaves that tab stuck on a loading spinner forever. This affects every `target="_blank"` link (Chrome treats them as `noopener` since v88) and `window.open` calls with `noopener`/`noreferrer`, so most external links on recorded sites.

Two things combine to cause the hang. A popup without an opener lands in a new browsing context group, and while it's paused by `waitForDebuggerOnStart` Chrome doesn't respond to any of its session commands until `Runtime.runIfWaitingForDebugger` is sent, so awaiting each attach command in sequence deadlocks on the first one and the resume never goes out. On top of that, executing the recording script with `runImmediately: true` in such a popup's initial empty document wedges the renderer in a busy loop that blocks its first navigation.

`Page.attach` now dispatches all commands up front and only then awaits them (the transport sends in call order, so scripts are still registered before the page resumes), and scripts run immediately only in targets that aren't paused waiting for the debugger.

Note: the recording toolbar can be missing on some opened pages (e.g. `grafana.com/legal/terms/`). That's a pre-existing, unrelated bug where the page removes the injected toolbar mount after hydration; fix coming in a separate PR.

## How to Test

1. Start a recording with `https://grafana.com` as the starting URL
2. Click "Terms of Service" in the page header (opens a new tab)
3. Before this change the new tab spins forever; now it loads and its requests show up in the recorder

<img width="1474" height="534" alt="screencapture 2026-08-05 at 14 19 04@2x" src="https://github.com/user-attachments/assets/ec48a158-24e4-489d-8695-d2187e617fd3" />


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.