### PR TITLE
fix: Recording toolbar disappears on pages that remove the injected mount

### DIFF
--- a/src/recorder/browser/view/index.tsx
+++ b/src/recorder/browser/view/index.tsx
@@ -8,6 +8,7 @@ import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 
 import { GlobalStyles } from './GlobalStyles'
 import { InBrowserControls } from './InBrowserControls'
+import { createMount } from './mount'
 import { SettingsProvider, SettingsStorage } from './SettingsProvider'
 import { StudioClientProvider } from './StudioClientProvider'
 import { isUsingTool } from './utils'
@@ -115,58 +116,6 @@ export function initializeView(
   const abortController = new AbortController()
 
   let shadowRoot: ShadowRoot | null = null
-
-  function createMount() {
-    const mount = document.createElement('div')
-
-    document.body.appendChild(mount)
-
-    // Our mount needs to stay at the end of the body, otherwise it will interfere
-    // with the selector algorithm. For example, take the following DOM:
-    //
-    // ```
-    // <body>
-    //   <div>User element</div>
-    //   <div id="ksix-studio-mount"></div>
-    //   <div>Dynamically added later</div>
-    // </body>
-    // ```
-    //
-    // If the user was highlighting the dynamically added element, the selector generator
-    // could generate a selector like `body > div:nth-child(3)`. But running the generated
-    // script would always result in an error because the mount is only present when recording
-    // and the correct selector should have been `body > div:nth-child(2)`.
-    //
-    // So we use a MutationObserver to continuously check if the mount is still the last
-    // element in the body. If it isn't, we move it to the end of the body.
-    const positionObserver = new MutationObserver(() => {
-      if (mount.nextSibling === null) {
-        return
-      }
-
-      document.body.appendChild(mount)
-    })
-
-    positionObserver.observe(document.body, {
-      childList: true,
-    })
-
-    // Some UI frameworks use the `inert` attribute to disable interaction with
-    // elements outside of a modal. We remove this attribute so that the recording
-    // controls are always accessible.
-    const attributeObserver = new MutationObserver(() => {
-      if (mount.hasAttribute('inert')) {
-        mount.removeAttribute('inert')
-      }
-    })
-
-    attributeObserver.observe(mount, {
-      attributes: true,
-      attributeFilter: ['inert'],
-    })
-
-    return mount
-  }
 
   function createShadowRoot(mount: Element) {
     shadowRoot = mount.attachShadow({

--- a/src/recorder/browser/view/mount.test.ts
+++ b/src/recorder/browser/view/mount.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { keepMountAtEndOfBody } from './mount'
+
+let dispose: (() => void) | null = null
+
+function setup() {
+  const mount = document.createElement('div')
+
+  document.body.replaceChildren(document.createElement('main'), mount)
+
+  dispose = keepMountAtEndOfBody(mount)
+
+  return mount
+}
+
+async function expectLastBodyChild(mount: Element) {
+  await vi.waitFor(() => {
+    expect(document.body.lastElementChild).toBe(mount)
+  })
+}
+
+describe('keepMountAtEndOfBody', () => {
+  afterEach(() => {
+    dispose?.()
+    dispose = null
+  })
+
+  it('moves the mount back to the end when the page appends elements after it', async () => {
+    const mount = setup()
+
+    document.body.appendChild(document.createElement('footer'))
+
+    await expectLastBodyChild(mount)
+  })
+
+  it('re-appends the mount when the page removes it', async () => {
+    const mount = setup()
+
+    // e.g. React hydrating the whole body treats the mount as a mismatch and
+    // removes it.
+    mount.remove()
+
+    await expectLastBodyChild(mount)
+  })
+
+  it('re-appends the mount when the page replaces the body contents', async () => {
+    const mount = setup()
+
+    document.body.replaceChildren(document.createElement('main'))
+
+    await expectLastBodyChild(mount)
+  })
+})

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -1,0 +1,71 @@
+/**
+ * Creates the element that hosts the recorder UI inside the recorded page and
+ * defends it against the page's own DOM manipulation.
+ */
+export function createMount() {
+  const mount = document.createElement('div')
+
+  document.body.appendChild(mount)
+
+  keepMountAtEndOfBody(mount)
+
+  // Some UI frameworks use the `inert` attribute to disable interaction with
+  // elements outside of a modal. We remove this attribute so that the recording
+  // controls are always accessible.
+  const attributeObserver = new MutationObserver(() => {
+    if (mount.hasAttribute('inert')) {
+      mount.removeAttribute('inert')
+    }
+  })
+
+  attributeObserver.observe(mount, {
+    attributes: true,
+    attributeFilter: ['inert'],
+  })
+
+  return mount
+}
+
+/**
+ * Keeps the given mount element attached as the last element of
+ * `document.body`.
+ *
+ * The mount needs to stay at the end of the body, otherwise it will interfere
+ * with the selector algorithm. For example, take the following DOM:
+ *
+ * ```
+ * <body>
+ *   <div>User element</div>
+ *   <div id="ksix-studio-mount"></div>
+ *   <div>Dynamically added later</div>
+ * </body>
+ * ```
+ *
+ * If the user was highlighting the dynamically added element, the selector
+ * generator could generate a selector like `body > div:nth-child(3)`. But
+ * running the generated script would always result in an error because the
+ * mount is only present when recording and the correct selector should have
+ * been `body > div:nth-child(2)`.
+ *
+ * Pages can also remove the mount outright, e.g. React hydrating the whole
+ * body treats it as a hydration mismatch and deletes it (grafana.com legal
+ * pages do this). In both cases we move the mount back to the end of the body
+ * so the recording controls stay available.
+ */
+export function keepMountAtEndOfBody(mount: Element) {
+  function ensureAtEndOfBody() {
+    if (document.body.lastElementChild !== mount) {
+      document.body.appendChild(mount)
+    }
+  }
+
+  const positionObserver = new MutationObserver(ensureAtEndOfBody)
+
+  positionObserver.observe(document.body, {
+    childList: true,
+  })
+
+  return function dispose() {
+    positionObserver.disconnect()
+  }
+}


### PR DESCRIPTION
## Description

On some pages the recording toolbar never shows up, e.g. `grafana.com/legal/terms/`. The recording script injects and initializes fine there, but the page removes the toolbar's mount element from the body right after it's added (React hydrating the full body treats the unexpected div as a hydration mismatch and deletes it).

The observer that keeps the mount at the end of the body only handled the reorder case, something being appended after the mount. A removed mount also reports `nextSibling === null`, so removal was treated as "already in place" and the toolbar was gone until the next navigation. The mount-keeping logic now lives in `view/mount.ts` and moves the mount back whenever it isn't the body's last element, which covers reorder, removal, and reparenting. It also compares against `lastElementChild` instead of `lastChild`, so stray text nodes no longer trigger mount moves (each move clears and re-applies the toolbar styles).

## How to Test

1. Start a recording with `https://grafana.com` as the starting URL
2. Click "Terms of Service" in the page header (opens a new tab)
3. Before this change the opened page has no recording toolbar until you navigate elsewhere; now the toolbar is there

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.