### PR TITLE
fix: API requests fail with 502 when server closes idle keep-alive connections

### DIFF
--- a/src/main/proxy.test.ts
+++ b/src/main/proxy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProxySettings } from '../types/settings'
+
+import { buildProxyArgs } from './proxy'
+
+vi.mock('electron', () => ({
+  app: { getAppPath: vi.fn(), getPath: vi.fn() },
+  BrowserWindow: vi.fn(),
+}))
+
+vi.mock('electron-log/main', () => ({
+  default: { error: vi.fn() },
+}))
+
+vi.mock('find-process', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('tree-kill', () => ({
+  default: vi.fn(),
+}))
+
+const regularSettings: ProxySettings = {
+  mode: 'regular',
+  port: 6000,
+  automaticallyFindPort: true,
+  sslInsecure: false,
+}
+
+const options = {
+  proxyScript: '/resources/json_output.py',
+  certificatesPath: '/resources/certificates',
+}
+
+describe('buildProxyArgs', () => {
+  it('builds args for regular mode', () => {
+    expect(buildProxyArgs(regularSettings, options)).toEqual([
+      '-q',
+      '-s',
+      '/resources/json_output.py',
+      '--set',
+      'confdir=/resources/certificates',
+      '--listen-port',
+      '6000',
+      '--mode',
+      'regular',
+      '--set',
+      'validate_inbound_headers=false',
+      '--set',
+      'connection_strategy=lazy',
+    ])
+  })
+
+  it('appends --ssl-insecure when enabled', () => {
+    const args = buildProxyArgs(
+      { ...regularSettings, sslInsecure: true },
+      options
+    )
+
+    expect(args).toContain('--ssl-insecure')
+  })
+
+  it('builds upstream mode with auth', () => {
+    const args = buildProxyArgs(
+      {
+        mode: 'upstream',
+        port: 6000,
+        automaticallyFindPort: true,
+        sslInsecure: false,
+        url: 'http://upstream:8080',
+        requiresAuth: true,
+        username: 'user',
+        password: 'pass',
+      },
+      options
+    )
+
+    expect(args).toContain('upstream:http://upstream:8080')
+    expect(args).toContain('--upstream-auth')
+    expect(args).toContain('user:pass')
+  })
+})

--- a/src/main/proxy.ts
+++ b/src/main/proxy.ts
@@ -57,35 +57,10 @@ export const launchProxy = (
   // add .exe on windows
   proxyPath += getPlatform() === 'win' ? '.exe' : ''
 
-  const proxyArgs = [
-    '-q',
-    '-s',
-    toNativePath(proxyScript),
-    '--set',
-    `confdir=${toNativePath(certificatesPath)}`,
-    '--listen-port',
-    `${proxySettings.port}`,
-    '--mode',
-    getProxyMode(proxySettings),
-    '--set',
-    'validate_inbound_headers=false',
-  ]
-
-  if (proxySettings.sslInsecure) {
-    proxyArgs.push('--ssl-insecure')
-  }
-
-  if (proxySettings.mode === 'upstream' && proxySettings.requiresAuth) {
-    const { username, password } = proxySettings
-    proxyArgs.push('--upstream-auth', `${username}:${password}`)
-  }
-
-  if (proxySettings.mode === 'upstream' && proxySettings.certificatePath) {
-    proxyArgs.push(
-      '--set',
-      `ssl_verify_upstream_trusted_ca=${toNativePath(proxySettings.certificatePath)}`
-    )
-  }
+  const proxyArgs = buildProxyArgs(proxySettings, {
+    proxyScript,
+    certificatesPath,
+  })
 
   const proxy = spawn(toNativePath(proxyPath), proxyArgs)
 
@@ -130,6 +105,53 @@ export const launchProxy = (
   })
 
   return proxy
+}
+
+export const buildProxyArgs = (
+  proxySettings: ProxySettings,
+  {
+    proxyScript,
+    certificatesPath,
+  }: { proxyScript: string; certificatesPath: string }
+) => {
+  const proxyArgs = [
+    '-q',
+    '-s',
+    toNativePath(proxyScript),
+    '--set',
+    `confdir=${toNativePath(certificatesPath)}`,
+    '--listen-port',
+    `${proxySettings.port}`,
+    '--mode',
+    getProxyMode(proxySettings),
+    '--set',
+    'validate_inbound_headers=false',
+    // Open server connections only when a request is pending. With the
+    // default eager strategy, mitmproxy pins one upstream socket to each
+    // browser preconnect. Servers that close idle keep-alive connections
+    // within seconds leave those tunnels half-dead, and requests sent on
+    // them fail with "502 server closed connection".
+    '--set',
+    'connection_strategy=lazy',
+  ]
+
+  if (proxySettings.sslInsecure) {
+    proxyArgs.push('--ssl-insecure')
+  }
+
+  if (proxySettings.mode === 'upstream' && proxySettings.requiresAuth) {
+    const { username, password } = proxySettings
+    proxyArgs.push('--upstream-auth', `${username}:${password}`)
+  }
+
+  if (proxySettings.mode === 'upstream' && proxySettings.certificatePath) {
+    proxyArgs.push(
+      '--set',
+      `ssl_verify_upstream_trusted_ca=${toNativePath(proxySettings.certificatePath)}`
+    )
+  }
+
+  return proxyArgs
 }
 
 const getProxyMode = (proxySettings: ProxySettings) => {


### PR DESCRIPTION
## Description

Recording a page can produce `502 Bad Gateway` ("server closed connection") responses for XHR requests that work fine outside the recorder. mitmproxy's default eager connection strategy pins one upstream socket to each browser connection at connect time. Chrome preconnects several sockets at page load, and origins that close idle keep-alive connections after a few seconds leave those sockets dead on the upstream side, so requests sent a moment later fail with 502 instead of reconnecting. Retries grab another stale socket from the pool and fail the same way.

This switches the proxy to `connection_strategy=lazy`, which opens and reopens server connections only when a request is pending. Argument building is extracted into `buildProxyArgs` to make it testable.

## How to Test

1. `pnpm test src/main/proxy.test.ts`
2. Verified against an affected production site: recording previously left the page stuck with all its API calls failing with 502 on every retry, with the flag the page records normally and all flows are captured.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)