### PR TITLE
fix: Recording and session replay break on legacy pages

### DIFF
--- a/scripts/cdp/generateCdpClient.ts
+++ b/scripts/cdp/generateCdpClient.ts
@@ -425,16 +425,19 @@ function generateEventFunctions({ domain, events = [] }: cdp.Domain) {
           '+',
           params.name
         )
-        const listener = new ExpressionBuilder(identifier('listener')).as(
-          typeRef('ChromeEventListener')
-        )
+
+        // The transport is shared by every session, so the session-filtering
+        // wrapper is what gets registered, not the raw listener.
+        const filteredListener = new ExpressionBuilder(
+          identifier('filteredListener')
+        ).as(typeRef('ChromeEventListener'))
 
         return [
           ...body,
           new ExpressionBuilder($this())
             .member('transport')
             .member(name)
-            .call([eventName, listener])
+            .call([eventName, filteredListener])
             .returned(),
         ]
       })

--- a/scripts/cdp/generateCdpClient.ts
+++ b/scripts/cdp/generateCdpClient.ts
@@ -354,26 +354,46 @@ function generateEventFunctions({ domain, events = [] }: cdp.Domain) {
     return []
   }
 
+  // A client bound to a session only forwards the events of that session. A
+  // root client has no session id and forwards everything, including events
+  // that carry one. Dropping those would break the browser-level client, which
+  // receives Target.attachedToTarget with the session id of the parent target
+  // when a popup is auto-attached in flat session mode.
+  //
+  // Wrappers are tracked per listener and per event name, so registering the
+  // same listener for two events keeps both wrappers and `off` can find the
+  // one it needs to unregister.
   const onFunctionBody = parse(`
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
 
       listener(event)
     }
 
-    this.listeners.set(listener as ChromeEventListener, filteredListener as ChromeEventListener)
+    const listenersByName: Map<string, ChromeEventListener> =
+      this.listeners.get(listener as ChromeEventListener) ?? new Map()
+
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
   `)
 
   const offFunctionBody = parse(`
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+
+    if (listenersByName === undefined) {
+      return
+    }
+
+    const filteredListener = listenersByName.get(name)
 
     if (filteredListener === undefined) {
       return
     }
 
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
   `)
 
   function eventFn(
@@ -426,7 +446,7 @@ function generateEventFunctions({ domain, events = [] }: cdp.Domain) {
           params.name
         )
 
-        // The transport is shared by every session, so the session-filtering
+        // The transport is shared by every session, so the session-aware
         // wrapper is what gets registered, not the raw listener.
         const filteredListener = new ExpressionBuilder(
           identifier('filteredListener')
@@ -576,7 +596,14 @@ async function generate() {
         b.type(t.union([SESSION_ID_TYPE, t.undefined()])).init()
       )
       .field('listeners', (b) =>
-        b.type(typeRef('WeakMap', [listenerType, listenerType])).init()
+        b
+          .type(
+            typeRef('WeakMap', [
+              listenerType,
+              typeRef('Map', [t.string(), listenerType]),
+            ])
+          )
+          .init()
       )
       .construct((b, self) => {
         return b

--- a/scripts/cdp/generateCdpClient.ts
+++ b/scripts/cdp/generateCdpClient.ts
@@ -371,9 +371,9 @@ function generateEventFunctions({ domain, events = [] }: cdp.Domain) {
 
       listener(event)
     }
-
-    const listenersByName: Map<string, ChromeEventListener> =
-      this.listeners.get(listener as ChromeEventListener) ?? new Map()
+ 
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ?? new Map<string, ChromeEventListener>()
 
     listenersByName.set(name, filteredListener as ChromeEventListener)
 

--- a/scripts/cdp/generateCdpClient.ts
+++ b/scripts/cdp/generateCdpClient.ts
@@ -354,15 +354,10 @@ function generateEventFunctions({ domain, events = [] }: cdp.Domain) {
     return []
   }
 
-  // A client bound to a session only forwards the events of that session. A
-  // root client has no session id and forwards everything, including events
-  // that carry one. Dropping those would break the browser-level client, which
-  // receives Target.attachedToTarget with the session id of the parent target
-  // when a popup is auto-attached in flat session mode.
-  //
-  // Wrappers are tracked per listener and per event name, so registering the
-  // same listener for two events keeps both wrappers and `off` can find the
-  // one it needs to unregister.
+  // Clients are either for the entire browser or for a specific session (think of it like
+  // the browser process vs. a specific tab). All clients will receive all events, so if the
+  // client is tied to a specific session then we need to ignore events that don't belong to
+  // that session.
   const onFunctionBody = parse(`
     const filteredListener: typeof listener = (event) => {
       if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {

--- a/src/main/runner/shims/browser/replay.test.ts
+++ b/src/main/runner/shims/browser/replay.test.ts
@@ -272,7 +272,7 @@ describe('session replay in-page script', () => {
     expect(vi.mocked(record)).not.toHaveBeenCalled()
   })
 
-  // Prototype.js 1.6 (still served by legacy intranets) predates native JSON
+  // Prototype.js 1.6 (still served by legacy sites) predates native JSON
   // and adds toJSON methods that return already-serialized text to the shared
   // prototypes. JSON.stringify honors them, double-encoding every array and
   // string, and the tracking server then rejects the whole batch: the replay

--- a/src/main/runner/shims/browser/replay.test.ts
+++ b/src/main/runner/shims/browser/replay.test.ts
@@ -1,6 +1,6 @@
 import { EventType } from '@rrweb/types'
 import { record } from 'rrweb'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { parseReplayEvent } from '../../rrweb'
 import { BrowserReplayEvent } from '../../schema'
@@ -278,7 +278,7 @@ describe('session replay in-page script', () => {
   // string, and the tracking server then rejects the whole batch: the replay
   // shows up blank while the test itself passes.
   describe('on a page that pollutes prototypes with toJSON', () => {
-    function pollute() {
+    beforeEach(() => {
       // What Prototype 1.6.0.3 does, reduced to the serialization behavior.
       Object.defineProperty(Array.prototype, 'toJSON', {
         value: function toJSON(this: unknown[]) {
@@ -287,6 +287,8 @@ describe('session replay in-page script', () => {
         writable: true,
         configurable: true,
       })
+      // String pollution stays untouched by the drain: JSON.stringify only
+      // consults it for boxed strings, which never enter the event graph.
       Object.defineProperty(String.prototype, 'toJSON', {
         value: function toJSON(this: string) {
           return `"${this.toString()}"`
@@ -294,83 +296,57 @@ describe('session replay in-page script', () => {
         writable: true,
         configurable: true,
       })
+    })
 
-      return function restore() {
-        Reflect.deleteProperty(Array.prototype, 'toJSON')
-        Reflect.deleteProperty(String.prototype, 'toJSON')
-      }
-    }
+    afterEach(() => {
+      Reflect.deleteProperty(Array.prototype, 'toJSON')
+      Reflect.deleteProperty(String.prototype, 'toJSON')
+    })
 
     it('still serializes the batch as an array of events', async () => {
-      const unpollute = pollute()
+      await importReplayScript()
 
-      try {
-        await importReplayScript()
+      emitEvent(createEvent(1, { text: 'typed into the page' }))
 
-        emitEvent(createEvent(1, { text: 'typed into the page' }))
+      const batch = drainedBatch()
 
-        const batch = drainedBatch()
-
-        expect(Array.isArray(batch.events)).toBe(true)
-        expect(batch.events).toContainEqual(
-          createEvent(1, { text: 'typed into the page' })
-        )
-      } finally {
-        unpollute()
-      }
+      expect(Array.isArray(batch.events)).toBe(true)
+      expect(batch.events).toContainEqual(
+        createEvent(1, { text: 'typed into the page' })
+      )
     })
 
     it('leaves the page pollution in place after draining', async () => {
-      const unpollute = pollute()
+      await importReplayScript()
 
-      try {
-        await importReplayScript()
+      drain()
 
-        drain()
-
-        // The page's own code relies on its patched prototypes, so the drain
-        // must put them back exactly as they were.
-        expect(
-          Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON')
-        ).toBeDefined()
-        expect(
-          Object.getOwnPropertyDescriptor(String.prototype, 'toJSON')
-        ).toBeDefined()
-      } finally {
-        unpollute()
-      }
+      // The page's own code relies on its patched prototypes, so the drain
+      // must put them back exactly as they were.
+      expect(
+        Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON')
+      ).toBeDefined()
+      expect(
+        Object.getOwnPropertyDescriptor(String.prototype, 'toJSON')
+      ).toBeDefined()
     })
 
     // Prototype.js also replaces Array.from with a version that ignores the
     // map function argument. rrweb inlines stylesheets with
     // Array.from(rules, stringifyRule).join(''), which then joins raw CSSRule
     // objects into "[object CSSStyleRule]..." and every replay renders
-    // unstyled. The script runs before page scripts, so it pins the native
-    // Array.from against later replacement.
+    // unstyled. The script pins Array.from against later replacement.
     it('keeps Array.from working when the page later replaces it', async () => {
-      const nativeFrom = Array.from
-
       await importReplayScript()
 
-      try {
-        // What Prototype 1.6 does: a replacement that drops the map function.
-        const brokenFrom = (arrayLike: ArrayLike<unknown>) =>
-          nativeFrom(arrayLike)
+      // Plain assignment like Prototype's `Array.from = $A`, replacing it
+      // with a version that drops the map function. Must neither throw nor
+      // take effect.
+      expect(() => {
+        Object.assign(Array, { from: () => [] })
+      }).not.toThrow()
 
-        // Plain assignment like Prototype's `Array.from = $A`. Must neither
-        // throw nor take effect.
-        expect(() => {
-          Object.assign(Array, { from: brokenFrom })
-        }).not.toThrow()
-
-        expect(Array.from([1, 2], (value) => value * 2)).toEqual([2, 4])
-      } finally {
-        Reflect.defineProperty(Array, 'from', {
-          value: nativeFrom,
-          writable: true,
-          configurable: true,
-        })
-      }
+      expect(Array.from([1, 2], (value) => value * 2)).toEqual([2, 4])
     })
   })
 })

--- a/src/main/runner/shims/browser/replay.test.ts
+++ b/src/main/runner/shims/browser/replay.test.ts
@@ -340,5 +340,37 @@ describe('session replay in-page script', () => {
         unpollute()
       }
     })
+
+    // Prototype.js also replaces Array.from with a version that ignores the
+    // map function argument. rrweb inlines stylesheets with
+    // Array.from(rules, stringifyRule).join(''), which then joins raw CSSRule
+    // objects into "[object CSSStyleRule]..." and every replay renders
+    // unstyled. The script runs before page scripts, so it pins the native
+    // Array.from against later replacement.
+    it('keeps Array.from working when the page later replaces it', async () => {
+      const nativeFrom = Array.from
+
+      await importReplayScript()
+
+      try {
+        // What Prototype 1.6 does: a replacement that drops the map function.
+        const brokenFrom = (arrayLike: ArrayLike<unknown>) =>
+          nativeFrom(arrayLike)
+
+        // Plain assignment like Prototype's `Array.from = $A`. Must neither
+        // throw nor take effect.
+        expect(() => {
+          Object.assign(Array, { from: brokenFrom })
+        }).not.toThrow()
+
+        expect(Array.from([1, 2], (value) => value * 2)).toEqual([2, 4])
+      } finally {
+        Reflect.defineProperty(Array, 'from', {
+          value: nativeFrom,
+          writable: true,
+          configurable: true,
+        })
+      }
+    })
   })
 })

--- a/src/main/runner/shims/browser/replay.test.ts
+++ b/src/main/runner/shims/browser/replay.test.ts
@@ -271,4 +271,74 @@ describe('session replay in-page script', () => {
     expect(replayWindow.__K6_DRAIN_EVENTS__).toBeUndefined()
     expect(vi.mocked(record)).not.toHaveBeenCalled()
   })
+
+  // Prototype.js 1.6 (still served by legacy intranets) predates native JSON
+  // and adds toJSON methods that return already-serialized text to the shared
+  // prototypes. JSON.stringify honors them, double-encoding every array and
+  // string, and the tracking server then rejects the whole batch: the replay
+  // shows up blank while the test itself passes.
+  describe('on a page that pollutes prototypes with toJSON', () => {
+    function pollute() {
+      // What Prototype 1.6.0.3 does, reduced to the serialization behavior.
+      Object.defineProperty(Array.prototype, 'toJSON', {
+        value: function toJSON(this: unknown[]) {
+          return `[${this.map((item) => JSON.stringify(item)).join(', ')}]`
+        },
+        writable: true,
+        configurable: true,
+      })
+      Object.defineProperty(String.prototype, 'toJSON', {
+        value: function toJSON(this: string) {
+          return `"${this.toString()}"`
+        },
+        writable: true,
+        configurable: true,
+      })
+
+      return function restore() {
+        Reflect.deleteProperty(Array.prototype, 'toJSON')
+        Reflect.deleteProperty(String.prototype, 'toJSON')
+      }
+    }
+
+    it('still serializes the batch as an array of events', async () => {
+      const unpollute = pollute()
+
+      try {
+        await importReplayScript()
+
+        emitEvent(createEvent(1, { text: 'typed into the page' }))
+
+        const batch = drainedBatch()
+
+        expect(Array.isArray(batch.events)).toBe(true)
+        expect(batch.events).toContainEqual(
+          createEvent(1, { text: 'typed into the page' })
+        )
+      } finally {
+        unpollute()
+      }
+    })
+
+    it('leaves the page pollution in place after draining', async () => {
+      const unpollute = pollute()
+
+      try {
+        await importReplayScript()
+
+        drain()
+
+        // The page's own code relies on its patched prototypes, so the drain
+        // must put them back exactly as they were.
+        expect(
+          Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON')
+        ).toBeDefined()
+        expect(
+          Object.getOwnPropertyDescriptor(String.prototype, 'toJSON')
+        ).toBeDefined()
+      } finally {
+        unpollute()
+      }
+    })
+  })
 })

--- a/src/main/runner/shims/browser/replay.test.ts
+++ b/src/main/runner/shims/browser/replay.test.ts
@@ -348,5 +348,35 @@ describe('session replay in-page script', () => {
 
       expect(Array.from([1, 2], (value) => value * 2)).toEqual([2, 4])
     })
+
+    // Self-hosted polyfill bundles install Array.from with an unconditional
+    // Object.defineProperty, which throws against a pin the page cannot
+    // reconfigure and leaves an uncaught TypeError on a page that only breaks
+    // while session replay is on. The polyfill takes the property over: an
+    // unstyled replay is a better outcome than a broken page.
+    it('lets the page redefine Array.from with defineProperty', async () => {
+      await importReplayScript()
+
+      const nativeFrom = Array.from
+      const polyfilled = () => []
+
+      try {
+        expect(() => {
+          Object.defineProperty(Array, 'from', {
+            value: polyfilled,
+            writable: true,
+            configurable: true,
+          })
+        }).not.toThrow()
+
+        expect(Array.from).toBe(polyfilled)
+      } finally {
+        Reflect.defineProperty(Array, 'from', {
+          value: nativeFrom,
+          writable: true,
+          configurable: true,
+        })
+      }
+    })
   })
 })

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -17,7 +17,10 @@ declare global {
 const trackingServerUrl = window.__K6_SESSION_REPLAY_TRACKING_SERVER_URL__
 
 // None of these have a toJSON method natively, so one found there is the
-// page's (Date is left alone: its toJSON is native and JSON-compatible).
+// page's. Date is excluded even though Prototype.js replaces its toJSON too:
+// no Date instances ever enter the event graph (timestamps are numbers), and
+// deleting Date's toJSON on pages that leave it native would turn dates
+// into {}.
 const POLLUTABLE_PROTOTYPES: object[] = [
   Array.prototype,
   String.prototype,

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -27,6 +27,32 @@ const POLLUTABLE_PROTOTYPES: object[] = [
 ]
 
 /**
+ * Keeps `Array.from` native for the page's lifetime. Pre-JSON frameworks like
+ * Prototype.js 1.6 replace it with a version that ignores the map function
+ * argument, which breaks rrweb's stylesheet inlining
+ * (`Array.from(rules, stringifyRule).join('')` joins raw CSSRule objects into
+ * "[object CSSStyleRule]...") and renders every replay unstyled. This script
+ * runs before any page script, so the native is still available to pin. The
+ * setter silently ignores the page's later assignment: such frameworks call
+ * their own helper internally and only alias it onto `Array.from`, so the
+ * page keeps working.
+ */
+function pinNativeArrayFrom() {
+  const nativeFrom = Array.from
+
+  try {
+    Object.defineProperty(Array, 'from', {
+      configurable: false,
+      get: () => nativeFrom,
+      set: () => {},
+    })
+  } catch {
+    // Not configurable: either already pinned by another copy of this script
+    // or locked down by the page. Nothing to do either way.
+  }
+}
+
+/**
  * JSON.stringify that ignores toJSON methods the page added to the shared
  * prototypes. Pre-JSON frameworks like Prototype.js 1.6 add toJSON methods
  * that return already-serialized text, which double-encodes every array and
@@ -80,6 +106,8 @@ function createPageId() {
 // Events are buffered here and pulled from the k6 process, see the drain
 // function in replayDrain.ts for why they can't be pushed with fetch.
 if (trackingServerUrl !== null && isTopLevelFrame()) {
+  pinNativeArrayFrom()
+
   const pageId = createPageId()
 
   // The k6 side serializes pulls per page and needs a stable id for that: the

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -37,15 +37,20 @@ const POLLUTABLE_PROTOTYPES: object[] = [Array.prototype, Object.prototype]
  * covers pages that replace `Array.from` after load. The setter silently
  * discards such replacements: these frameworks call their own helper
  * internally and only alias it onto `Array.from`, so the page keeps working
- * (and rrweb's recovery assignment no-ops the same way).
+ * (and rrweb's recovery assignment no-ops the same way). The pin itself stays
+ * configurable, so a page that installs its own `Array.from` with
+ * `Object.defineProperty` (what self-hosted polyfill bundles do, without
+ * feature detection) replaces the pin instead of throwing. Giving up the pin
+ * costs an unstyled replay, throwing would break the page under test.
  */
 function pinNativeArrayFrom() {
   const nativeFrom = Array.from
 
-  // Fails only when another copy of this script already pinned it or the
-  // page locked the property down. Nothing to do either way.
+  // Fails only when the page locked the property down, and there is nothing
+  // to do about that. A second copy of this script re-pins the native it
+  // reads back through the getter.
   Reflect.defineProperty(Array, 'from', {
-    configurable: false,
+    configurable: true,
     get: () => nativeFrom,
     set: () => {},
   })

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -16,43 +16,39 @@ declare global {
 
 const trackingServerUrl = window.__K6_SESSION_REPLAY_TRACKING_SERVER_URL__
 
-// None of these have a toJSON method natively, so one found there is the
-// page's. Date is excluded even though Prototype.js replaces its toJSON too:
-// no Date instances ever enter the event graph (timestamps are numbers), and
-// deleting Date's toJSON on pages that leave it native would turn dates
-// into {}.
-const POLLUTABLE_PROTOTYPES: object[] = [
-  Array.prototype,
-  String.prototype,
-  Number.prototype,
-  Boolean.prototype,
-  Object.prototype,
-]
+// JSON.stringify consults toJSON on object values only, and rrweb event
+// graphs are plain objects, arrays, and primitives, so these two are the only
+// prototypes whose pollution can reach the payload (String, Number, and
+// Boolean toJSON fire for boxed primitives only, and Date instances never
+// enter the graph). Neither has a toJSON natively, so one found there is the
+// page's.
+const POLLUTABLE_PROTOTYPES: object[] = [Array.prototype, Object.prototype]
 
 /**
- * Keeps `Array.from` native for the page's lifetime. Pre-JSON frameworks like
- * Prototype.js 1.6 replace it with a version that ignores the map function
- * argument, which breaks rrweb's stylesheet inlining
+ * Keeps `Array.from` working for the page's lifetime. Pre-JSON frameworks
+ * like Prototype.js 1.6 replace it with a version that ignores the map
+ * function argument, which breaks rrweb's stylesheet inlining
  * (`Array.from(rules, stringifyRule).join('')` joins raw CSSRule objects into
- * "[object CSSStyleRule]...") and renders every replay unstyled. This script
- * runs before any page script, so the native is still available to pin. The
- * setter silently ignores the page's later assignment: such frameworks call
- * their own helper internally and only alias it onto `Array.from`, so the
- * page keeps working.
+ * "[object CSSStyleRule]...") and renders every replay unstyled. The pin
+ * captures whatever `Array.from` is when this script starts: the native at
+ * document_start, or on popup re-injection (evaluated after page scripts,
+ * see sessionReplay.ts) the native that rrweb's module-eval guard just
+ * recovered from a clean iframe. That guard is one-shot, so only the pin
+ * covers pages that replace `Array.from` after load. The setter silently
+ * discards such replacements: these frameworks call their own helper
+ * internally and only alias it onto `Array.from`, so the page keeps working
+ * (and rrweb's recovery assignment no-ops the same way).
  */
 function pinNativeArrayFrom() {
   const nativeFrom = Array.from
 
-  try {
-    Object.defineProperty(Array, 'from', {
-      configurable: false,
-      get: () => nativeFrom,
-      set: () => {},
-    })
-  } catch {
-    // Not configurable: either already pinned by another copy of this script
-    // or locked down by the page. Nothing to do either way.
-  }
+  // Fails only when another copy of this script already pinned it or the
+  // page locked the property down. Nothing to do either way.
+  Reflect.defineProperty(Array, 'from', {
+    configurable: false,
+    get: () => nativeFrom,
+    set: () => {},
+  })
 }
 
 /**

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -16,6 +16,50 @@ declare global {
 
 const trackingServerUrl = window.__K6_SESSION_REPLAY_TRACKING_SERVER_URL__
 
+// None of these have a toJSON method natively, so one found there is the
+// page's (Date is left alone: its toJSON is native and JSON-compatible).
+const POLLUTABLE_PROTOTYPES: object[] = [
+  Array.prototype,
+  String.prototype,
+  Number.prototype,
+  Boolean.prototype,
+  Object.prototype,
+]
+
+/**
+ * JSON.stringify that ignores toJSON methods the page added to the shared
+ * prototypes. Pre-JSON frameworks like Prototype.js 1.6 add toJSON methods
+ * that return already-serialized text, which double-encodes every array and
+ * string in the batch and gets it rejected by the tracking server. This runs
+ * in the page's own world (the k6 browser module can only inject there), so
+ * the pollution can't be avoided, only sidestepped: the methods are removed
+ * for the duration of the (synchronous) stringify and restored right after,
+ * so the page never observes the gap.
+ */
+function stringifyIgnoringPageToJSON(value: unknown): string {
+  const removed: Array<{ prototype: object; descriptor: PropertyDescriptor }> =
+    []
+
+  for (const prototype of POLLUTABLE_PROTOTYPES) {
+    const descriptor = Reflect.getOwnPropertyDescriptor(prototype, 'toJSON')
+
+    if (
+      descriptor !== undefined &&
+      Reflect.deleteProperty(prototype, 'toJSON')
+    ) {
+      removed.push({ prototype, descriptor })
+    }
+  }
+
+  try {
+    return JSON.stringify(value)
+  } finally {
+    for (const { prototype, descriptor } of removed) {
+      Reflect.defineProperty(prototype, 'toJSON', descriptor)
+    }
+  }
+}
+
 function isTopLevelFrame() {
   try {
     return window.parent === window
@@ -87,7 +131,7 @@ if (trackingServerUrl !== null && isTopLevelFrame()) {
     // Serialized here so the k6 runtime receives a single string instead of
     // rebuilding the whole event graph on its side. JSON.stringify escapes
     // newlines, which keeps the two header separators unambiguous.
-    return `${pageId}\n${nextBatchId}\n${JSON.stringify(events)}`
+    return `${pageId}\n${nextBatchId}\n${stringifyIgnoringPageToJSON(events)}`
   }
 
   record({

--- a/src/main/runner/shims/browser/replay.ts
+++ b/src/main/runner/shims/browser/replay.ts
@@ -25,23 +25,10 @@ const trackingServerUrl = window.__K6_SESSION_REPLAY_TRACKING_SERVER_URL__
 const POLLUTABLE_PROTOTYPES: object[] = [Array.prototype, Object.prototype]
 
 /**
- * Keeps `Array.from` working for the page's lifetime. Pre-JSON frameworks
- * like Prototype.js 1.6 replace it with a version that ignores the map
- * function argument, which breaks rrweb's stylesheet inlining
- * (`Array.from(rules, stringifyRule).join('')` joins raw CSSRule objects into
- * "[object CSSStyleRule]...") and renders every replay unstyled. The pin
- * captures whatever `Array.from` is when this script starts: the native at
- * document_start, or on popup re-injection (evaluated after page scripts,
- * see sessionReplay.ts) the native that rrweb's module-eval guard just
- * recovered from a clean iframe. That guard is one-shot, so only the pin
- * covers pages that replace `Array.from` after load. The setter silently
- * discards such replacements: these frameworks call their own helper
- * internally and only alias it onto `Array.from`, so the page keeps working
- * (and rrweb's recovery assignment no-ops the same way). The pin itself stays
- * configurable, so a page that installs its own `Array.from` with
- * `Object.defineProperty` (what self-hosted polyfill bundles do, without
- * feature detection) replaces the pin instead of throwing. Giving up the pin
- * costs an unstyled replay, throwing would break the page under test.
+ * Pre-JSON frameworks like Prototype.js 1.6 replace Array.from with a version
+ * that doesn't support the map function argument. rrweb uses the `map` argument
+ * when recording stylesheets so we need to restore the native function, otherwise
+ * stylesheets will be recorded as `"[object CSSStyleRule]..."`.
  */
 function pinNativeArrayFrom() {
   const nativeFrom = Array.from
@@ -57,19 +44,16 @@ function pinNativeArrayFrom() {
 }
 
 /**
- * JSON.stringify that ignores toJSON methods the page added to the shared
- * prototypes. Pre-JSON frameworks like Prototype.js 1.6 add toJSON methods
- * that return already-serialized text, which double-encodes every array and
- * string in the batch and gets it rejected by the tracking server. This runs
- * in the page's own world (the k6 browser module can only inject there), so
- * the pollution can't be avoided, only sidestepped: the methods are removed
- * for the duration of the (synchronous) stringify and restored right after,
- * so the page never observes the gap.
+ * Pre-JSON frameworks like Prototype.js 1.6 adds toJSON methods to the prototypes
+ * of Array and Object. These methods returns an already serialized version of the object,
+ * so passing it to JSON.stringify would double-serialize it. This function serializes
+ * values without calling toJSON on the prototype of Object and Array.
  */
 function stringifyIgnoringPageToJSON(value: unknown): string {
   const removed: Array<{ prototype: object; descriptor: PropertyDescriptor }> =
     []
 
+  // Remove toJSON from the prototypes so that JSON.stringify doesn't call them
   for (const prototype of POLLUTABLE_PROTOTYPES) {
     const descriptor = Reflect.getOwnPropertyDescriptor(prototype, 'toJSON')
 
@@ -84,6 +68,7 @@ function stringifyIgnoringPageToJSON(value: unknown): string {
   try {
     return JSON.stringify(value)
   } finally {
+    // Restore the prototypes to their original state so that the page can continue
     for (const { prototype, descriptor } of removed) {
       Reflect.defineProperty(prototype, 'toJSON', descriptor)
     }

--- a/src/recorder/browser/index.test.ts
+++ b/src/recorder/browser/index.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RecorderRuntime } from './index'
+
+const createClient = vi.fn()
+const configureStorage = vi.fn()
+const initializeView = vi.fn()
+const trackTabFocus = vi.fn()
+const startRecording = vi.fn()
+
+vi.mock('./routing', () => ({
+  createClient: () => createClient() as never,
+}))
+vi.mock('./storage', () => ({
+  configureStorage: (client: unknown) => configureStorage(client) as never,
+}))
+vi.mock('./view', () => ({
+  initializeView: (client: unknown, storage: unknown) =>
+    initializeView(client, storage) as never,
+}))
+vi.mock('./window', () => ({
+  trackTabFocus: (client: unknown) => trackTabFocus(client) as never,
+}))
+vi.mock('./recording', () => ({
+  startRecording: (client: unknown, storage: unknown) =>
+    startRecording(client, storage) as never,
+}))
+vi.mock('./view/inspection', () => ({
+  attachInspectionDetection: () => {},
+  attachTextSelectionDetection: () => {},
+}))
+
+async function runEntrypoint() {
+  vi.resetModules()
+
+  await import('./index')
+}
+
+describe('recorder entrypoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    delete window.__K6_STUDIO_RECORDER_RUNTIME__
+
+    createClient.mockReturnValue({ fake: 'client' })
+    configureStorage.mockReturnValue({ fake: 'storage' })
+  })
+
+  it('creates the runtime and remembers it on the window', async () => {
+    await runEntrypoint()
+
+    expect(createClient).toHaveBeenCalledOnce()
+    expect(trackTabFocus).toHaveBeenCalledOnce()
+    expect(window.__K6_STUDIO_RECORDER_RUNTIME__).toEqual({
+      client: { fake: 'client' },
+      storage: { fake: 'storage' },
+    })
+  })
+
+  // Re-injection after document.open() runs a fresh copy of the whole script
+  // in the same realm. The previous copy's connection and timers survived the
+  // document swap, so creating new ones would accumulate a socket, keepalive
+  // timers, and a focus poll on every document.open().
+  it('reuses the previous runtime when re-injected into the same realm', async () => {
+    const runtime = {
+      client: { fake: 'existing-client' },
+      storage: { fake: 'existing-storage' },
+    } as unknown as RecorderRuntime
+
+    window.__K6_STUDIO_RECORDER_RUNTIME__ = runtime
+
+    await runEntrypoint()
+
+    expect(createClient).not.toHaveBeenCalled()
+    expect(configureStorage).not.toHaveBeenCalled()
+    expect(trackTabFocus).not.toHaveBeenCalled()
+
+    // The per-document work must still run with the surviving runtime.
+    expect(initializeView).toHaveBeenCalledWith(runtime.client, runtime.storage)
+    expect(startRecording).toHaveBeenCalledWith(runtime.client, runtime.storage)
+  })
+})

--- a/src/recorder/browser/index.test.ts
+++ b/src/recorder/browser/index.test.ts
@@ -5,8 +5,11 @@ import type { RecorderRuntime } from './index'
 const createClient = vi.fn()
 const configureStorage = vi.fn()
 const initializeView = vi.fn()
+const disposeView = vi.fn()
 const trackTabFocus = vi.fn()
+const disposeTabFocus = vi.fn()
 const startRecording = vi.fn()
+const disposeRecording = vi.fn()
 
 vi.mock('./routing', () => ({
   createClient: () => createClient() as never,
@@ -44,6 +47,9 @@ describe('recorder entrypoint', () => {
 
     createClient.mockReturnValue({ fake: 'client' })
     configureStorage.mockReturnValue({ fake: 'storage' })
+    initializeView.mockReturnValue(disposeView)
+    trackTabFocus.mockReturnValue(disposeTabFocus)
+    startRecording.mockReturnValue(disposeRecording)
   })
 
   it('creates the runtime and remembers it on the window', async () => {
@@ -51,7 +57,7 @@ describe('recorder entrypoint', () => {
 
     expect(createClient).toHaveBeenCalledOnce()
     expect(trackTabFocus).toHaveBeenCalledOnce()
-    expect(window.__K6_STUDIO_RECORDER_RUNTIME__).toEqual({
+    expect(window.__K6_STUDIO_RECORDER_RUNTIME__).toMatchObject({
       client: { fake: 'client' },
       storage: { fake: 'storage' },
     })
@@ -59,12 +65,13 @@ describe('recorder entrypoint', () => {
 
   // Re-injection after document.open() runs a fresh copy of the whole script
   // in the same realm. The previous copy's connection and timers survived the
-  // document swap, so creating new ones would accumulate a socket, keepalive
-  // timers, and a focus poll on every document.open().
-  it('reuses the previous runtime when re-injected into the same realm', async () => {
+  // document swap, so creating new ones would accumulate a socket and
+  // keepalive timers on every document.open().
+  it('reuses the previous connection when re-injected into the same realm', async () => {
     const runtime = {
       client: { fake: 'existing-client' },
       storage: { fake: 'existing-storage' },
+      disposeDocument: vi.fn(),
     } as unknown as RecorderRuntime
 
     window.__K6_STUDIO_RECORDER_RUNTIME__ = runtime
@@ -73,10 +80,38 @@ describe('recorder entrypoint', () => {
 
     expect(createClient).not.toHaveBeenCalled()
     expect(configureStorage).not.toHaveBeenCalled()
-    expect(trackTabFocus).not.toHaveBeenCalled()
 
     // The per-document work must still run with the surviving runtime.
     expect(initializeView).toHaveBeenCalledWith(runtime.client, runtime.storage)
     expect(startRecording).toHaveBeenCalledWith(runtime.client, runtime.storage)
+    expect(trackTabFocus).toHaveBeenCalledWith(runtime.client)
+  })
+
+  // When two re-injections land in the same document (e.g. two rapid
+  // document.open() calls), the earlier copy's recording listeners are still
+  // live and would record every interaction twice. Each copy therefore
+  // disposes its predecessor's per-document setup before starting its own.
+  it('disposes the previous copy before setting up', async () => {
+    const disposeDocument = vi.fn()
+
+    window.__K6_STUDIO_RECORDER_RUNTIME__ = {
+      client: { fake: 'existing-client' },
+      storage: { fake: 'existing-storage' },
+      disposeDocument,
+    } as unknown as RecorderRuntime
+
+    await runEntrypoint()
+
+    expect(disposeDocument).toHaveBeenCalledOnce()
+  })
+
+  it('exposes a disposeDocument that tears down its own setup', async () => {
+    await runEntrypoint()
+
+    window.__K6_STUDIO_RECORDER_RUNTIME__?.disposeDocument()
+
+    expect(disposeView).toHaveBeenCalledOnce()
+    expect(disposeTabFocus).toHaveBeenCalledOnce()
+    expect(disposeRecording).toHaveBeenCalledOnce()
   })
 })

--- a/src/recorder/browser/index.test.ts
+++ b/src/recorder/browser/index.test.ts
@@ -10,6 +10,11 @@ const trackTabFocus = vi.fn()
 const disposeTabFocus = vi.fn()
 const startRecording = vi.fn()
 const disposeRecording = vi.fn()
+const isInFrame = vi.fn<() => boolean>()
+const attachInspectionDetection = vi.fn<() => () => void>()
+const disposeInspection = vi.fn()
+const attachTextSelectionDetection = vi.fn<() => () => void>()
+const disposeTextSelection = vi.fn()
 
 vi.mock('./routing', () => ({
   createClient: () => createClient() as never,
@@ -29,8 +34,11 @@ vi.mock('./recording', () => ({
     startRecording(client, storage) as never,
 }))
 vi.mock('./view/inspection', () => ({
-  attachInspectionDetection: () => {},
-  attachTextSelectionDetection: () => {},
+  attachInspectionDetection: () => attachInspectionDetection(),
+  attachTextSelectionDetection: () => attachTextSelectionDetection(),
+}))
+vi.mock('./utils', () => ({
+  isInFrame: () => isInFrame(),
 }))
 
 async function runEntrypoint() {
@@ -50,6 +58,9 @@ describe('recorder entrypoint', () => {
     initializeView.mockReturnValue(disposeView)
     trackTabFocus.mockReturnValue(disposeTabFocus)
     startRecording.mockReturnValue(disposeRecording)
+    isInFrame.mockReturnValue(false)
+    attachInspectionDetection.mockReturnValue(disposeInspection)
+    attachTextSelectionDetection.mockReturnValue(disposeTextSelection)
   })
 
   it('creates the runtime and remembers it on the window', async () => {
@@ -112,6 +123,24 @@ describe('recorder entrypoint', () => {
 
     expect(disposeView).toHaveBeenCalledOnce()
     expect(disposeTabFocus).toHaveBeenCalledOnce()
+    expect(disposeRecording).toHaveBeenCalledOnce()
+  })
+
+  // Child frames run inspection detection instead of the recorder UI. Its
+  // listeners survive a same-document race just like the recording ones, so
+  // they have to be torn down by the copy that replaces this one.
+  it('disposes child-frame detection along with the rest of the document', async () => {
+    isInFrame.mockReturnValue(true)
+
+    await runEntrypoint()
+
+    expect(trackTabFocus).not.toHaveBeenCalled()
+    expect(initializeView).not.toHaveBeenCalled()
+
+    window.__K6_STUDIO_RECORDER_RUNTIME__?.disposeDocument()
+
+    expect(disposeInspection).toHaveBeenCalledOnce()
+    expect(disposeTextSelection).toHaveBeenCalledOnce()
     expect(disposeRecording).toHaveBeenCalledOnce()
   })
 })

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -1,5 +1,6 @@
+import { BrowserExtensionClient } from './messaging'
 import { startRecording } from './recording'
-import { client } from './routing'
+import { createClient } from './routing'
 import { configureStorage } from './storage'
 import { isInFrame } from './utils'
 import { initializeView } from './view'
@@ -7,19 +8,49 @@ import {
   attachInspectionDetection,
   attachTextSelectionDetection,
 } from './view/inspection'
+import { SettingsStorage } from './view/SettingsProvider'
 import { trackTabFocus } from './window'
 
-// CDP injects this script into every frame. We capture events in all frames so
-// that interactions inside iframes are recorded, but the recorder UI and tab
-// focus tracking only make sense in the top frame. Child frames instead forward
-// element inspection to the top frame's inspector.
-const storage = configureStorage(client)
+export interface RecorderRuntime {
+  client: BrowserExtensionClient
+  storage: SettingsStorage
+}
 
+declare global {
+  interface Window {
+    __K6_STUDIO_RECORDER_RUNTIME__?: RecorderRuntime
+  }
+}
+
+// CDP injects this script into every frame, and injects it AGAIN into the
+// same realm when a page replaces its document with document.open() (see the
+// documentOpened handler in src/recorder/launchers/cdp/page.ts). The realm's
+// long-lived pieces survive that replacement: the WebSocket connection, its
+// keepalive timers, and the tab focus poll. Creating them anew on every
+// re-injection would accumulate a connection and timers per document.open(),
+// so they are created once per realm and reused. Everything per-document
+// (the UI, the recording listeners) is genuinely destroyed with the old
+// document and is set up again below.
+const runtime = window.__K6_STUDIO_RECORDER_RUNTIME__
+const isReinjection = runtime !== undefined
+
+const client = runtime?.client ?? createClient()
+const storage = runtime?.storage ?? configureStorage(client)
+
+window.__K6_STUDIO_RECORDER_RUNTIME__ = { client, storage }
+
+// We capture events in all frames so that interactions inside iframes are
+// recorded, but the recorder UI and tab focus tracking only make sense in the
+// top frame. Child frames instead forward element inspection to the top
+// frame's inspector.
 if (isInFrame()) {
   attachInspectionDetection()
   attachTextSelectionDetection()
 } else {
-  trackTabFocus(client)
+  if (!isReinjection) {
+    trackTabFocus(client)
+  }
+
   initializeView(client, storage)
 }
 

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -56,8 +56,8 @@ const disposers: Array<() => void> = []
 // top frame. Child frames instead forward element inspection to the top
 // frame's inspector.
 if (isInFrame()) {
-  attachInspectionDetection()
-  attachTextSelectionDetection()
+  disposers.push(attachInspectionDetection())
+  disposers.push(attachTextSelectionDetection())
 } else {
   disposers.push(trackTabFocus(client))
   disposers.push(initializeView(client, storage))

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -14,6 +14,12 @@ import { trackTabFocus } from './window'
 export interface RecorderRuntime {
   client: BrowserExtensionClient
   storage: SettingsStorage
+
+  /**
+   * Tears down the per-document setup of the copy that created this runtime:
+   * recording listeners, the UI's React tree, and focus tracking.
+   */
+  disposeDocument: () => void
 }
 
 declare global {
@@ -25,19 +31,25 @@ declare global {
 // CDP injects this script into every frame, and injects it AGAIN into the
 // same realm when a page replaces its document with document.open() (see the
 // documentOpened handler in src/recorder/launchers/cdp/page.ts). The realm's
-// long-lived pieces survive that replacement: the WebSocket connection, its
-// keepalive timers, and the tab focus poll. Creating them anew on every
-// re-injection would accumulate a connection and timers per document.open(),
-// so they are created once per realm and reused. Everything per-document
-// (the UI, the recording listeners) is genuinely destroyed with the old
-// document and is set up again below.
-const runtime = window.__K6_STUDIO_RECORDER_RUNTIME__
-const isReinjection = runtime !== undefined
+// long-lived pieces survive that replacement: the WebSocket connection and
+// its keepalive timers. Creating them anew on every re-injection would
+// accumulate a connection per document.open(), so they are created once per
+// realm and reused.
+//
+// Everything per-document is disposed and set up again: document.open()
+// erases the previous copy's window listeners, but when two copies race into
+// the SAME document (e.g. two rapid document.open() calls whose re-injections
+// both land after the last one), the earlier copy's listeners are still live
+// and every interaction would be recorded twice. The previous copy's React
+// tree also stays subscribed to the reused client until unmounted.
+const previous = window.__K6_STUDIO_RECORDER_RUNTIME__
 
-const client = runtime?.client ?? createClient()
-const storage = runtime?.storage ?? configureStorage(client)
+previous?.disposeDocument()
 
-window.__K6_STUDIO_RECORDER_RUNTIME__ = { client, storage }
+const client = previous?.client ?? createClient()
+const storage = previous?.storage ?? configureStorage(client)
+
+const disposers: Array<() => void> = []
 
 // We capture events in all frames so that interactions inside iframes are
 // recorded, but the recorder UI and tab focus tracking only make sense in the
@@ -47,11 +59,16 @@ if (isInFrame()) {
   attachInspectionDetection()
   attachTextSelectionDetection()
 } else {
-  if (!isReinjection) {
-    trackTabFocus(client)
-  }
-
-  initializeView(client, storage)
+  disposers.push(trackTabFocus(client))
+  disposers.push(initializeView(client, storage))
 }
 
-startRecording(client, storage)
+disposers.push(startRecording(client, storage))
+
+window.__K6_STUDIO_RECORDER_RUNTIME__ = {
+  client,
+  storage,
+  disposeDocument: () => {
+    disposers.forEach((dispose) => dispose())
+  },
+}

--- a/src/recorder/browser/index.ts
+++ b/src/recorder/browser/index.ts
@@ -14,38 +14,22 @@ import { trackTabFocus } from './window'
 export interface RecorderRuntime {
   client: BrowserExtensionClient
   storage: SettingsStorage
-
-  /**
-   * Tears down the per-document setup of the copy that created this runtime:
-   * recording listeners, the UI's React tree, and focus tracking.
-   */
   disposeDocument: () => void
 }
 
 declare global {
   interface Window {
+    // The runtime is injected in every iframe and whenever the document is replaced
+    // using `document.open()`. This property holds the current runtime.
     __K6_STUDIO_RECORDER_RUNTIME__?: RecorderRuntime
   }
 }
 
-// CDP injects this script into every frame, and injects it AGAIN into the
-// same realm when a page replaces its document with document.open() (see the
-// documentOpened handler in src/recorder/launchers/cdp/page.ts). The realm's
-// long-lived pieces survive that replacement: the WebSocket connection and
-// its keepalive timers. Creating them anew on every re-injection would
-// accumulate a connection per document.open(), so they are created once per
-// realm and reused.
-//
-// Everything per-document is disposed and set up again: document.open()
-// erases the previous copy's window listeners, but when two copies race into
-// the SAME document (e.g. two rapid document.open() calls whose re-injections
-// both land after the last one), the earlier copy's listeners are still live
-// and every interaction would be recorded twice. The previous copy's React
-// tree also stays subscribed to the reused client until unmounted.
 const previous = window.__K6_STUDIO_RECORDER_RUNTIME__
 
 previous?.disposeDocument()
 
+// Connection and storage are not affected by document replacement, so reuse them if they exist.
 const client = previous?.client ?? createClient()
 const storage = previous?.storage ?? configureStorage(client)
 

--- a/src/recorder/browser/manager.ts
+++ b/src/recorder/browser/manager.ts
@@ -18,6 +18,8 @@ export class WindowEventManager {
   #reset: TimeoutHandle | null = null
   #history: Array<Event> = []
 
+  #disposers: Array<() => void> = []
+
   get history(): ReadonlyArray<Event> {
     return this.#history
   }
@@ -64,23 +66,35 @@ export class WindowEventManager {
     type: K,
     listener: (ev: WindowEventMap[K], manager: WindowEventManager) => void
   ) {
-    window.addEventListener(
-      type,
-      (ev) => {
-        this.#addToHistory(ev)
+    const capturingListener = (ev: WindowEventMap[K]) => {
+      this.#addToHistory(ev)
 
-        if (shouldSkipEvent(ev)) {
-          return
-        }
+      if (shouldSkipEvent(ev)) {
+        return
+      }
 
-        if (this.#isBlocked(ev)) {
-          return
-        }
+      if (this.#isBlocked(ev)) {
+        return
+      }
 
-        listener(ev, this)
-      },
-      { capture: true }
-    )
+      listener(ev, this)
+    }
+
+    window.addEventListener(type, capturingListener, { capture: true })
+
+    this.#disposers.push(() => {
+      window.removeEventListener(type, capturingListener, { capture: true })
+    })
+  }
+
+  /**
+   * Removes every listener the manager attached. Needed when a second copy of
+   * the script takes over a document whose window still has this copy's
+   * listeners, which would otherwise record every interaction twice.
+   */
+  dispose() {
+    this.#disposers.forEach((dispose) => dispose())
+    this.#disposers = []
   }
 
   #addToHistory(ev: Event) {

--- a/src/recorder/browser/manager.ts
+++ b/src/recorder/browser/manager.ts
@@ -87,11 +87,6 @@ export class WindowEventManager {
     })
   }
 
-  /**
-   * Removes every listener the manager attached. Needed when a second copy of
-   * the script takes over a document whose window still has this copy's
-   * listeners, which would otherwise record every interaction twice.
-   */
   dispose() {
     this.#disposers.forEach((dispose) => dispose())
     this.#disposers = []

--- a/src/recorder/browser/messaging/index.test.ts
+++ b/src/recorder/browser/messaging/index.test.ts
@@ -88,6 +88,22 @@ describe('BrowserExtensionClient', () => {
     expect(consoleError).toHaveBeenCalledOnce()
   })
 
+  // The message can carry recorded user input, including passwords, and main
+  // process console output becomes a Sentry breadcrumb on the reported event.
+  it('does not log the contents of an invalid message', () => {
+    const { transport } = createClient()
+
+    receive(transport, {
+      type: 'message',
+      data: {
+        type: 'record-events',
+        events: JSON.stringify([{ type: 'input-change', value: 'hunter2' }]),
+      },
+    })
+
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain('hunter2')
+  })
+
   it('does not notify onInvalidMessage for valid messages', () => {
     const onInvalidMessage = vi.fn<(error: z.ZodError) => void>()
     const { client, transport } = createClient({ onInvalidMessage })

--- a/src/recorder/browser/messaging/index.test.ts
+++ b/src/recorder/browser/messaging/index.test.ts
@@ -9,19 +9,15 @@ import {
 } from 'vitest'
 import { z } from 'zod/v4'
 
-import { Transport } from './transports/transport'
+import { NullTransport } from './transports/null'
 
 import { BrowserExtensionClient, BrowserExtensionClientOptions } from './index'
 
-class FakeTransport extends Transport {
-  send(): void {}
-
-  /**
-   * Simulates the remote end of the transport sending us a raw envelope.
-   */
-  receive(data: unknown) {
-    this.emit('message', { data })
-  }
+/**
+ * Simulates the remote end of the transport sending us a raw envelope.
+ */
+function receive(transport: NullTransport, data: unknown) {
+  transport.emit('message', { data })
 }
 
 // The shape the in-page recorder sent when a page polluted Array.prototype
@@ -47,7 +43,7 @@ describe('BrowserExtensionClient', () => {
   let consoleError: MockInstance<typeof console.error>
 
   function createClient(options?: BrowserExtensionClientOptions) {
-    const transport = new FakeTransport()
+    const transport = new NullTransport()
     const client = new BrowserExtensionClient('test-client', transport, options)
 
     clients.push(client)
@@ -70,7 +66,7 @@ describe('BrowserExtensionClient', () => {
     const onInvalidMessage = vi.fn<(error: z.ZodError) => void>()
     const { transport } = createClient({ onInvalidMessage })
 
-    transport.receive(doubleEncodedEnvelope)
+    receive(transport, doubleEncodedEnvelope)
 
     expect(onInvalidMessage).toHaveBeenCalledOnce()
 
@@ -88,7 +84,7 @@ describe('BrowserExtensionClient', () => {
   it('logs invalid messages when no callback was given', () => {
     const { transport } = createClient()
 
-    expect(() => transport.receive(doubleEncodedEnvelope)).not.toThrow()
+    expect(() => receive(transport, doubleEncodedEnvelope)).not.toThrow()
     expect(consoleError).toHaveBeenCalledOnce()
   })
 
@@ -99,7 +95,7 @@ describe('BrowserExtensionClient', () => {
 
     client.on('load-events', onLoadEvents)
 
-    transport.receive(validEnvelope)
+    receive(transport, validEnvelope)
 
     expect(onLoadEvents).toHaveBeenCalledOnce()
     expect(onInvalidMessage).not.toHaveBeenCalled()

--- a/src/recorder/browser/messaging/index.test.ts
+++ b/src/recorder/browser/messaging/index.test.ts
@@ -1,0 +1,107 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from 'vitest'
+import { z } from 'zod/v4'
+
+import { Transport } from './transports/transport'
+
+import { BrowserExtensionClient, BrowserExtensionClientOptions } from './index'
+
+class FakeTransport extends Transport {
+  send(): void {}
+
+  /**
+   * Simulates the remote end of the transport sending us a raw envelope.
+   */
+  receive(data: unknown) {
+    this.emit('message', { data })
+  }
+}
+
+// The shape the in-page recorder sent when a page polluted Array.prototype
+// with a toJSON method: `events` arrives double-encoded as a string.
+const doubleEncodedEnvelope = {
+  type: 'message',
+  data: {
+    type: 'record-events',
+    events: JSON.stringify([{ type: 'click' }]),
+  },
+}
+
+const validEnvelope = {
+  type: 'message',
+  data: {
+    type: 'load-events',
+  },
+}
+
+describe('BrowserExtensionClient', () => {
+  const clients: BrowserExtensionClient[] = []
+
+  let consoleError: MockInstance<typeof console.error>
+
+  function createClient(options?: BrowserExtensionClientOptions) {
+    const transport = new FakeTransport()
+    const client = new BrowserExtensionClient('test-client', transport, options)
+
+    clients.push(client)
+
+    return { client, transport }
+  }
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    clients.forEach((client) => client.dispose())
+    clients.length = 0
+
+    vi.restoreAllMocks()
+  })
+
+  it('notifies onInvalidMessage when a message fails validation', () => {
+    const onInvalidMessage = vi.fn<(error: z.ZodError) => void>()
+    const { transport } = createClient({ onInvalidMessage })
+
+    transport.receive(doubleEncodedEnvelope)
+
+    expect(onInvalidMessage).toHaveBeenCalledOnce()
+
+    const [error] = onInvalidMessage.mock.calls[0] ?? []
+
+    expect(error).toBeInstanceOf(z.ZodError)
+    expect(error?.issues).toEqual([
+      expect.objectContaining({
+        code: 'invalid_type',
+        path: ['data', 'events'],
+      }),
+    ])
+  })
+
+  it('logs invalid messages when no callback was given', () => {
+    const { transport } = createClient()
+
+    expect(() => transport.receive(doubleEncodedEnvelope)).not.toThrow()
+    expect(consoleError).toHaveBeenCalledOnce()
+  })
+
+  it('does not notify onInvalidMessage for valid messages', () => {
+    const onInvalidMessage = vi.fn<(error: z.ZodError) => void>()
+    const { client, transport } = createClient({ onInvalidMessage })
+    const onLoadEvents = vi.fn()
+
+    client.on('load-events', onLoadEvents)
+
+    transport.receive(validEnvelope)
+
+    expect(onLoadEvents).toHaveBeenCalledOnce()
+    expect(onInvalidMessage).not.toHaveBeenCalled()
+  })
+})

--- a/src/recorder/browser/messaging/index.ts
+++ b/src/recorder/browser/messaging/index.ts
@@ -77,7 +77,10 @@ export class BrowserExtensionClient extends EventEmitter<BrowserExtensionClientE
       const parsed = BrowserExtensionClientMessageSchema.safeParse(data)
 
       if (!parsed.success) {
-        console.error(`[${name}] received invalid message:`, parsed.error, data)
+        // Never log the message itself: it can carry recorded user input,
+        // including passwords, and in the main process console output becomes
+        // a Sentry breadcrumb on the event onInvalidMessage reports.
+        console.error(`[${name}] received invalid message:`, parsed.error)
 
         options.onInvalidMessage?.(parsed.error)
 

--- a/src/recorder/browser/messaging/index.ts
+++ b/src/recorder/browser/messaging/index.ts
@@ -40,6 +40,15 @@ type BrowserExtensionClientEvents = {
 export type BrowserExtensionEvent =
   BrowserExtensionClientEvents[keyof BrowserExtensionClientEvents]
 
+export interface BrowserExtensionClientOptions {
+  /**
+   * Called when an incoming message fails validation, so that the owner of the
+   * client can report it. Messages that don't validate are dropped, which costs
+   * us recorded events, so we want to know when it happens.
+   */
+  onInvalidMessage?: (error: z.ZodError) => void
+}
+
 /**
  * A single interface to handle asynchronous communication between the different parts of the extension,
  * e.g. from content script to background script, from background script to k6 Studio, etc.
@@ -55,7 +64,11 @@ export class BrowserExtensionClient extends EventEmitter<BrowserExtensionClientE
   #transport: Transport
   #keepAlive: Parameters<typeof clearInterval>[0] = undefined
 
-  constructor(name: string, transport: Transport = new NullTransport()) {
+  constructor(
+    name: string,
+    transport: Transport = new NullTransport(),
+    options: BrowserExtensionClientOptions = {}
+  ) {
     super()
 
     this.#transport = transport
@@ -65,6 +78,8 @@ export class BrowserExtensionClient extends EventEmitter<BrowserExtensionClientE
 
       if (!parsed.success) {
         console.error(`[${name}] received invalid message:`, parsed.error, data)
+
+        options.onInvalidMessage?.(parsed.error)
 
         return
       }

--- a/src/recorder/browser/recording.ts
+++ b/src/recorder/browser/recording.ts
@@ -270,4 +270,8 @@ export function startRecording(
       tab: getTabId(),
     })
   })
+
+  return function dispose() {
+    manager.dispose()
+  }
 }

--- a/src/recorder/browser/routing.ts
+++ b/src/recorder/browser/routing.ts
@@ -2,26 +2,33 @@ import { BrowserExtensionClient } from './messaging'
 import { BufferedTransport } from './messaging/transports/buffered'
 import { WebSocketTransport } from './messaging/transports/webSocket'
 
-const frontend = new BrowserExtensionClient('frontend')
+/**
+ * Connects the in-page recorder to k6 Studio. The WebSocket connects eagerly
+ * and reconnects forever, so the caller must create at most one client per
+ * realm (see the runtime reuse in index.ts).
+ */
+export function createClient(): BrowserExtensionClient {
+  const frontend = new BrowserExtensionClient('frontend')
 
-const studio = new BrowserExtensionClient(
-  'recorder',
-  new BufferedTransport(new WebSocketTransport('ws://127.0.0.1:7554'))
-)
+  const studio = new BrowserExtensionClient(
+    'recorder',
+    new BufferedTransport(new WebSocketTransport('ws://127.0.0.1:7554'))
+  )
 
-frontend.forward('record-events', [studio])
-frontend.forward('navigate', [studio])
-frontend.forward('load-events', [studio])
-frontend.forward('stop-recording', [studio])
-frontend.forward('reload-extension', [studio])
-frontend.forward('focus-tab', [studio])
+  frontend.forward('record-events', [studio])
+  frontend.forward('navigate', [studio])
+  frontend.forward('load-events', [studio])
+  frontend.forward('stop-recording', [studio])
+  frontend.forward('reload-extension', [studio])
+  frontend.forward('focus-tab', [studio])
 
-frontend.forward('load-settings', [studio])
-frontend.forward('save-settings', [studio])
+  frontend.forward('load-settings', [studio])
+  frontend.forward('save-settings', [studio])
 
-studio.forward('events-recorded', [frontend])
-studio.forward('events-loaded', [frontend])
-studio.forward('highlight-elements', [frontend])
-studio.forward('sync-settings', [frontend])
+  studio.forward('events-recorded', [frontend])
+  studio.forward('events-loaded', [frontend])
+  studio.forward('highlight-elements', [frontend])
+  studio.forward('sync-settings', [frontend])
 
-export { frontend as client }
+  return frontend
+}

--- a/src/recorder/browser/view/ErrorBoundary.test.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.test.tsx
@@ -68,13 +68,16 @@ describe('ErrorBoundary', () => {
     )
   })
 
-  it('warns without a name when none was given', () => {
+  it('warns with a generic name when none was given', () => {
     render(
       <ErrorBoundary>
         <Bomb />
       </ErrorBoundary>
     )
 
-    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('In-browser UI'),
+      expect.any(Error)
+    )
   })
 })

--- a/src/recorder/browser/view/ErrorBoundary.test.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ErrorBoundary } from './ErrorBoundary'
+
+function Bomb(): never {
+  throw new Error('Function.prototype.bind is not a function')
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // React logs every error it catches at error level, which would bury the
+    // rest of the test output.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders its children when nothing throws', () => {
+    render(
+      <ErrorBoundary name="Toolbox">
+        <div>toolbox</div>
+      </ErrorBoundary>
+    )
+
+    expect(screen.queryByText('toolbox')).not.toBeNull()
+  })
+
+  it('renders nothing when a child throws while rendering', () => {
+    const { container } = render(
+      <ErrorBoundary name="Toolbox">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('keeps sibling features mounted when one of them crashes', () => {
+    render(
+      <>
+        <ErrorBoundary name="Toolbox">
+          <Bomb />
+        </ErrorBoundary>
+        <ErrorBoundary name="Event drawer">
+          <div>event drawer</div>
+        </ErrorBoundary>
+      </>
+    )
+
+    expect(screen.queryByText('event drawer')).not.toBeNull()
+  })
+
+  it('warns once with the name of the crashed feature and the error', () => {
+    render(
+      <ErrorBoundary name="Toolbox">
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Toolbox'),
+      expect.any(Error)
+    )
+  })
+
+  it('warns without a name when none was given', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    expect(console.warn).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/recorder/browser/view/ErrorBoundary.test.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.test.tsx
@@ -80,4 +80,19 @@ describe('ErrorBoundary', () => {
       expect.any(Error)
     )
   })
+
+  // A crashed tool disappears, but the tool selection lives outside the
+  // boundary. Without a reset hook the store would keep suppressing event
+  // recording while the user sees no tool UI at all.
+  it('notifies onError when a child crashes', () => {
+    const onError = vi.fn()
+
+    render(
+      <ErrorBoundary name="Element inspector" onError={onError}>
+        <Bomb />
+      </ErrorBoundary>
+    )
+
+    expect(onError).toHaveBeenCalledOnce()
+  })
 })

--- a/src/recorder/browser/view/ErrorBoundary.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  name?: string
+  children?: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+}
+
+/**
+ * Keeps a crashing feature from taking down the rest of the in-browser UI.
+ * Recorded pages can break our components in ways we don't control, e.g. by
+ * replacing built-ins that our dependencies rely on.
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return {
+      hasError: true,
+    }
+  }
+
+  componentDidCatch(error: Error) {
+    // This lands in the recorded page's console, so it's logged as a warning
+    // to avoid it being mistaken for a failure of the page itself.
+    console.warn(
+      `[k6 Studio] ${this.props.name ?? 'In-browser UI'} crashed and was removed from the page.`,
+      error
+    )
+  }
+
+  render() {
+    // Recorded pages get no fallback UI, hiding the feature is less intrusive.
+    if (this.state.hasError) {
+      return null
+    }
+
+    return this.props.children
+  }
+}

--- a/src/recorder/browser/view/ErrorBoundary.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.tsx
@@ -30,7 +30,10 @@ export class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error) {
     // This lands in the recorded page's console, so it's logged as a warning
-    // to avoid it being mistaken for a failure of the page itself.
+    // to avoid it being mistaken for a failure of the page itself. It is also
+    // the ONLY record of the crash: the render root in view/index.tsx mutes
+    // React's own error logging (onCaughtError) on the assumption that this
+    // warning exists.
     console.warn(
       `[k6 Studio] ${this.props.name ?? 'In-browser UI'} crashed and was removed from the page.`,
       error

--- a/src/recorder/browser/view/ErrorBoundary.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.tsx
@@ -3,6 +3,12 @@ import { Component, ReactNode } from 'react'
 interface ErrorBoundaryProps {
   name?: string
   children?: ReactNode
+
+  /**
+   * Called when a child crashes, so state living outside the boundary that
+   * assumes the child is visible (e.g. the selected tool) can be reset.
+   */
+  onError?: () => void
 }
 
 interface ErrorBoundaryState {
@@ -38,6 +44,8 @@ export class ErrorBoundary extends Component<
       `[k6 Studio] ${this.props.name ?? 'In-browser UI'} crashed and was removed from the page.`,
       error
     )
+
+    this.props.onError?.()
   }
 
   render() {

--- a/src/recorder/browser/view/ErrorBoundary.tsx
+++ b/src/recorder/browser/view/ErrorBoundary.tsx
@@ -3,11 +3,6 @@ import { Component, ReactNode } from 'react'
 interface ErrorBoundaryProps {
   name?: string
   children?: ReactNode
-
-  /**
-   * Called when a child crashes, so state living outside the boundary that
-   * assumes the child is visible (e.g. the selected tool) can be reset.
-   */
   onError?: () => void
 }
 
@@ -15,11 +10,6 @@ interface ErrorBoundaryState {
   hasError: boolean
 }
 
-/**
- * Keeps a crashing feature from taking down the rest of the in-browser UI.
- * Recorded pages can break our components in ways we don't control, e.g. by
- * replacing built-ins that our dependencies rely on.
- */
 export class ErrorBoundary extends Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -35,11 +25,6 @@ export class ErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error) {
-    // This lands in the recorded page's console, so it's logged as a warning
-    // to avoid it being mistaken for a failure of the page itself. It is also
-    // the ONLY record of the crash: the render root in view/index.tsx mutes
-    // React's own error logging (onCaughtError) on the assumption that this
-    // warning exists.
     console.warn(
       `[k6 Studio] ${this.props.name ?? 'In-browser UI'} crashed and was removed from the page.`,
       error

--- a/src/recorder/browser/view/InBrowserControls.tsx
+++ b/src/recorder/browser/view/InBrowserControls.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 
 import { ElementInspector } from './ElementInspector'
+import { ErrorBoundary } from './ErrorBoundary'
 import { EventDrawer } from './EventDrawer'
 import { useRecordedEvents } from './hooks/useRecordedEvents'
 import { RemoteHighlights } from './RemoteHighlights'
@@ -45,24 +46,40 @@ export function InBrowserControls() {
 
   return (
     <>
-      <RemoteHighlights />
-      {tool === 'inspect' && <ElementInspector onClose={handleDeselectTool} />}
-      {tool === 'assert-text' && (
-        <TextSelectionPopover onClose={handleDeselectTool} />
+      <ErrorBoundary name="Remote highlights">
+        <RemoteHighlights />
+      </ErrorBoundary>
+      {/*
+        The boundaries sit inside the conditionals so that selecting a tool
+        again mounts a fresh one, giving a crashed tool another chance.
+      */}
+      {tool === 'inspect' && (
+        <ErrorBoundary name="Element inspector">
+          <ElementInspector onClose={handleDeselectTool} />
+        </ErrorBoundary>
       )}
-      <ToolBox
-        isDrawerOpen={isDrawerOpen}
-        recordedEventCount={recordedEvents.length}
-        tool={tool}
-        onSelectTool={handleSelectTool}
-        onStopRecording={handleStopRecording}
-        onToggleDrawer={handleToggleDrawer}
-      />
-      <EventDrawer
-        open={isDrawerOpen}
-        events={recordedEvents}
-        onOpenChange={handleToggleDrawer}
-      />
+      {tool === 'assert-text' && (
+        <ErrorBoundary name="Text selection">
+          <TextSelectionPopover onClose={handleDeselectTool} />
+        </ErrorBoundary>
+      )}
+      <ErrorBoundary name="Toolbox">
+        <ToolBox
+          isDrawerOpen={isDrawerOpen}
+          recordedEventCount={recordedEvents.length}
+          tool={tool}
+          onSelectTool={handleSelectTool}
+          onStopRecording={handleStopRecording}
+          onToggleDrawer={handleToggleDrawer}
+        />
+      </ErrorBoundary>
+      <ErrorBoundary name="Event drawer">
+        <EventDrawer
+          open={isDrawerOpen}
+          events={recordedEvents}
+          onOpenChange={handleToggleDrawer}
+        />
+      </ErrorBoundary>
     </>
   )
 }

--- a/src/recorder/browser/view/InBrowserControls.tsx
+++ b/src/recorder/browser/view/InBrowserControls.tsx
@@ -51,15 +51,18 @@ export function InBrowserControls() {
       </ErrorBoundary>
       {/*
         The boundaries sit inside the conditionals so that selecting a tool
-        again mounts a fresh one, giving a crashed tool another chance.
+        again mounts a fresh one, giving a crashed tool another chance. A
+        crashed tool also deselects itself: leaving it selected would keep
+        suppressing event recording (shouldSkipEvent) with no tool UI in
+        sight.
       */}
       {tool === 'inspect' && (
-        <ErrorBoundary name="Element inspector">
+        <ErrorBoundary name="Element inspector" onError={handleDeselectTool}>
           <ElementInspector onClose={handleDeselectTool} />
         </ErrorBoundary>
       )}
       {tool === 'assert-text' && (
-        <ErrorBoundary name="Text selection">
+        <ErrorBoundary name="Text selection" onError={handleDeselectTool}>
           <TextSelectionPopover onClose={handleDeselectTool} />
         </ErrorBoundary>
       )}

--- a/src/recorder/browser/view/InBrowserControls.tsx
+++ b/src/recorder/browser/view/InBrowserControls.tsx
@@ -51,10 +51,7 @@ export function InBrowserControls() {
       </ErrorBoundary>
       {/*
         The boundaries sit inside the conditionals so that selecting a tool
-        again mounts a fresh one, giving a crashed tool another chance. A
-        crashed tool also deselects itself: leaving it selected would keep
-        suppressing event recording (shouldSkipEvent) with no tool UI in
-        sight.
+        again mounts a fresh one, giving a crashed tool another chance.
       */}
       {tool === 'inspect' && (
         <ErrorBoundary name="Element inspector" onError={handleDeselectTool}>

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -26,7 +26,7 @@ describe('initializeView', () => {
   // no-op. Calling initializeView twice mimics the second copy: the guard is
   // in the DOM (the mount marker), which is all a separate script copy would
   // share with us.
-  it('initializes the in-browser UI only once per document', () => {
+  it('mounts the in-browser UI only once per document', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const client = new BrowserExtensionClient('test')
 

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 import { configureStorage } from '@/recorder/browser/storage'
@@ -16,7 +16,40 @@ function mountHosts() {
   return [...document.body.children].filter((element) => element.shadowRoot)
 }
 
+function setup() {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  const client = new BrowserExtensionClient('test')
+  const disposers: Array<() => void> = []
+
+  const initialize = () => {
+    const dispose = initializeView(client, configureStorage(client))
+
+    disposers.push(dispose)
+
+    return dispose
+  }
+
+  return {
+    warn,
+    initialize,
+    cleanup: () => {
+      // Stop the mount observers before the test environment is torn down,
+      // and remove the mounts so the next test starts from a clean document.
+      disposers.forEach((dispose) => dispose())
+      document.body.replaceChildren()
+      warn.mockRestore()
+      client.dispose()
+    },
+  }
+}
+
 describe('initializeView', () => {
+  let cleanup = () => {}
+
+  afterEach(() => {
+    cleanup()
+  })
+
   // The same document can be initialized from more than one copy of the
   // script (e.g. one injected into the initial empty document and one
   // injected when the real document commits into the same context). Two
@@ -27,21 +60,36 @@ describe('initializeView', () => {
   // in the DOM (the mount marker), which is all a separate script copy would
   // share with us.
   it('mounts the in-browser UI only once per document', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const client = new BrowserExtensionClient('test')
+    const context = setup()
 
-    const disposeFirst = initializeView(client, configureStorage(client))
-    const disposeSecond = initializeView(client, configureStorage(client))
+    cleanup = context.cleanup
+
+    context.initialize()
+    context.initialize()
 
     expect(mountHosts()).toHaveLength(1)
-    expect(warn).toHaveBeenCalledWith(
+    expect(context.warn).toHaveBeenCalledWith(
       expect.stringContaining('already initialized')
     )
+  })
 
-    // Stop the mount observers before the test environment is torn down.
-    disposeFirst()
-    disposeSecond()
-    warn.mockRestore()
-    client.dispose()
+  // A page that rewrites itself from its own serialized body reproduces the
+  // mount marker as a dead copy: shadow roots do not serialize, so the copy
+  // has no UI behind it. It must not block a fresh injection from mounting,
+  // and it must be removed so it can't skew generated nth-child selectors.
+  it('mounts over a stale serialized copy of a previous mount', () => {
+    const context = setup()
+
+    cleanup = context.cleanup
+
+    const staleMount = document.createElement('div')
+
+    staleMount.setAttribute('data-ksix-studio-mount', 'true')
+    document.body.appendChild(staleMount)
+
+    context.initialize()
+
+    expect(mountHosts()).toHaveLength(1)
+    expect(staleMount.isConnected).toBe(false)
   })
 })

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -92,4 +92,28 @@ describe('initializeView', () => {
     expect(mountHosts()).toHaveLength(1)
     expect(staleMount.isConnected).toBe(false)
   })
+
+  // When two copies of the script land in the same document, the second one
+  // disposes the first copy's view before initializing its own (see the
+  // runtime handover in src/recorder/browser/index.ts). The disposed view must
+  // leave nothing behind that the mount guard would mistake for a live UI,
+  // otherwise that document never gets its toolbar back.
+  it('mounts again after a previous initialization was disposed', () => {
+    const context = setup()
+
+    cleanup = context.cleanup
+
+    const dispose = context.initialize()
+    const [disposedHost] = mountHosts()
+
+    dispose()
+
+    context.initialize()
+
+    expect(mountHosts()).toHaveLength(1)
+    expect(disposedHost?.isConnected).toBe(false)
+    expect(context.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('already initialized')
+    )
+  })
 })

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -12,6 +12,14 @@ vi.mock('./InBrowserControls', () => ({
   InBrowserControls: () => null,
 }))
 
+const { stopMonitoring } = vi.hoisted(() => ({ stopMonitoring: vi.fn() }))
+
+// The monitor keeps polling on its own timers, so whether dispose stops it is
+// only visible from the outside.
+vi.mock('./monitor', () => ({
+  monitorDocumentChange: () => stopMonitoring,
+}))
+
 function mountHosts() {
   return [...document.body.children].filter((element) => element.shadowRoot)
 }
@@ -48,6 +56,7 @@ describe('initializeView', () => {
 
   afterEach(() => {
     cleanup()
+    stopMonitoring.mockClear()
   })
 
   // The same document can be initialized from more than one copy of the
@@ -115,5 +124,21 @@ describe('initializeView', () => {
     expect(context.warn).not.toHaveBeenCalledWith(
       expect.stringContaining('already initialized')
     )
+  })
+
+  // The monitor re-initializes the view when the document is swapped, so a
+  // monitor that outlives its view starts a second view from the disposed
+  // copy's closure. That view's dispose handle is then held by a copy nobody
+  // calls again, and the mount guard blocks every later injection for good.
+  it('stops monitoring for a document change when disposed', () => {
+    const context = setup()
+
+    cleanup = context.cleanup
+
+    const dispose = context.initialize()
+
+    dispose()
+
+    expect(stopMonitoring).toHaveBeenCalled()
   })
 })

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { BrowserExtensionClient } from '@/recorder/browser/messaging'
+
+import { DEFAULT_SETTINGS, SettingsStorage } from './SettingsProvider'
+
+import { initializeView } from './index'
+
+// The real controls pull in portals and animation frames that keep mutating
+// the DOM after the test ends. The guard under test lives in initializeView
+// itself, so the UI can be inert.
+vi.mock('./InBrowserControls', () => ({
+  InBrowserControls: () => null,
+}))
+
+function createStorage(): SettingsStorage {
+  return {
+    getCurrent: () => DEFAULT_SETTINGS,
+    load: () => Promise.resolve(DEFAULT_SETTINGS),
+    save: () => Promise.resolve(),
+    onUpdate: () => () => {},
+  }
+}
+
+function mountHosts() {
+  return [...document.body.children].filter((element) => element.shadowRoot)
+}
+
+describe('initializeView', () => {
+  // The same document can be initialized from more than one copy of the
+  // script (e.g. one injected into the initial empty document and one
+  // injected when the real document commits into the same context). Two
+  // initialized mounts would fight over the end of the body through
+  // keepMountAtEndOfBody, locking the renderer in an infinite
+  // MutationObserver loop, so any initialization after the first must be a
+  // no-op. Calling initializeView twice mimics the second copy: the guard is
+  // in the DOM (the mount marker), which is all a separate script copy would
+  // share with us.
+  it('initializes the in-browser UI only once per document', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const client = new BrowserExtensionClient('test')
+
+    const disposeFirst = initializeView(client, createStorage())
+    const disposeSecond = initializeView(client, createStorage())
+
+    expect(mountHosts()).toHaveLength(1)
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('already initialized')
+    )
+
+    // Let React's commit settle, then stop the mount observers so nothing
+    // fires into the torn-down test environment.
+    await new Promise((resolve) => setTimeout(resolve, 50))
+
+    disposeFirst()
+    disposeSecond()
+    warn.mockRestore()
+    client.dispose()
+  })
+})

--- a/src/recorder/browser/view/index.test.tsx
+++ b/src/recorder/browser/view/index.test.tsx
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { BrowserExtensionClient } from '@/recorder/browser/messaging'
-
-import { DEFAULT_SETTINGS, SettingsStorage } from './SettingsProvider'
+import { configureStorage } from '@/recorder/browser/storage'
 
 import { initializeView } from './index'
 
@@ -12,15 +11,6 @@ import { initializeView } from './index'
 vi.mock('./InBrowserControls', () => ({
   InBrowserControls: () => null,
 }))
-
-function createStorage(): SettingsStorage {
-  return {
-    getCurrent: () => DEFAULT_SETTINGS,
-    load: () => Promise.resolve(DEFAULT_SETTINGS),
-    save: () => Promise.resolve(),
-    onUpdate: () => () => {},
-  }
-}
 
 function mountHosts() {
   return [...document.body.children].filter((element) => element.shadowRoot)
@@ -36,22 +26,19 @@ describe('initializeView', () => {
   // no-op. Calling initializeView twice mimics the second copy: the guard is
   // in the DOM (the mount marker), which is all a separate script copy would
   // share with us.
-  it('initializes the in-browser UI only once per document', async () => {
+  it('initializes the in-browser UI only once per document', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const client = new BrowserExtensionClient('test')
 
-    const disposeFirst = initializeView(client, createStorage())
-    const disposeSecond = initializeView(client, createStorage())
+    const disposeFirst = initializeView(client, configureStorage(client))
+    const disposeSecond = initializeView(client, configureStorage(client))
 
     expect(mountHosts()).toHaveLength(1)
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('already initialized')
     )
 
-    // Let React's commit settle, then stop the mount observers so nothing
-    // fires into the torn-down test environment.
-    await new Promise((resolve) => setTimeout(resolve, 50))
-
+    // Stop the mount observers before the test environment is torn down.
     disposeFirst()
     disposeSecond()
     warn.mockRestore()

--- a/src/recorder/browser/view/index.tsx
+++ b/src/recorder/browser/view/index.tsx
@@ -9,55 +9,11 @@ import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 import { ErrorBoundary } from './ErrorBoundary'
 import { GlobalStyles } from './GlobalStyles'
 import { InBrowserControls } from './InBrowserControls'
+import { monitorDocumentChange } from './monitor'
 import { createMount, isDocumentMounted, removeStaleMounts } from './mount'
 import { SettingsProvider, SettingsStorage } from './SettingsProvider'
 import { StudioClientProvider } from './StudioClientProvider'
 import { isUsingTool } from './utils'
-
-// When using CDP, some pages will open with an empty document with readyState "completed"
-// the first time that a page is loaded. This means our UI is injected into the empty document,
-// then the document is replaced with the actual content, making our UI disappear.
-//
-// It's not entirely clear why this happens and there doesn't seem to be any events firing that
-// we can rely on. So instead, we use use a brute-force polling mechanism to monitor if the document
-// reference changes during the opening stages of the page. It's not pretty but it works.
-//
-// This covers only the initial empty-document swap (a navigation commit that
-// replaces the Document object). The other way a page loses our UI is
-// document.open(), which reuses the same Document object and so is invisible
-// to this poll; that case is handled from the main process, which re-injects
-// the whole script on CDP's Page.documentOpened event (see the documentOpened
-// handler in src/recorder/launchers/cdp/page.ts).
-function monitorDocumentChange(onChange: () => void) {
-  // During this short period of time the document will have the URL "about:blank", so if it's
-  // different then we can skip this check entirely.
-  if (document.location.href !== 'about:blank') {
-    return
-  }
-
-  const abortController = new AbortController()
-  const currentDocument = document
-
-  setTimeout(function checkDocumentInstance() {
-    if (abortController.signal.aborted) {
-      return
-    }
-
-    if (document === currentDocument) {
-      setTimeout(checkDocumentInstance, 1)
-
-      return
-    }
-
-    onChange()
-  }, 1)
-
-  // We only need to monitor the first few seconds or so. If nothing has changed
-  // by then, there's no point in wasting CPU cycles.
-  setTimeout(() => {
-    abortController.abort()
-  }, 5000)
-}
 
 // We use a MutationObservers to try and load the UI as soon as the body
 // element has been added. Otherwise we have to wait for content to be
@@ -235,7 +191,7 @@ export function initializeView(
     }
   }
 
-  monitorDocumentChange(() => {
+  const stopMonitoring = monitorDocumentChange(() => {
     console.log('Document instance changed, re-initializing UI.')
 
     disposeReinitialized = initializeView(client, storage)
@@ -349,6 +305,14 @@ export function initializeView(
     // Cancels an initialization that hasn't happened yet (initialize() bails
     // once the controller is aborted) and tears down one that has.
     abortController.abort()
+
+    // The monitor runs on its own controller, because the one above is aborted
+    // by initialize() as its single-initialization latch, long before the
+    // empty-document swap the monitor waits for. Stopping it here, before the
+    // teardown below, keeps a late poll from re-initializing a view whose
+    // dispose handle would land in this dead copy's disposeReinitialized.
+    stopMonitoring()
+
     disposeInitialized()
     disposeReinitialized()
   }

--- a/src/recorder/browser/view/index.tsx
+++ b/src/recorder/browser/view/index.tsx
@@ -8,7 +8,7 @@ import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 
 import { GlobalStyles } from './GlobalStyles'
 import { InBrowserControls } from './InBrowserControls'
-import { createMount } from './mount'
+import { createMount, isDocumentMounted } from './mount'
 import { SettingsProvider, SettingsStorage } from './SettingsProvider'
 import { StudioClientProvider } from './StudioClientProvider'
 import { isUsingTool } from './utils'
@@ -115,6 +115,11 @@ export function initializeView(
 ) {
   const abortController = new AbortController()
 
+  // Stops the mount's defending observers. Production never disposes (the
+  // UI lives for the document's lifetime), but tests must, so that observer
+  // callbacks don't fire into a torn-down environment.
+  let disposeMount = () => {}
+
   let shadowRoot: ShadowRoot | null = null
 
   function createShadowRoot(mount: Element) {
@@ -143,7 +148,18 @@ export function initializeView(
 
     abortController.abort()
 
-    const mount = createMount()
+    // Another copy of the script beat us to this document. See
+    // MOUNT_MARKER_ATTRIBUTE for why a second mount must never be created.
+    if (isDocumentMounted()) {
+      console.warn('[k6 Studio] In-browser UI is already initialized.')
+
+      return
+    }
+
+    const { mount, dispose } = createMount()
+
+    disposeMount = dispose
+
     const root = createShadowRoot(mount)
 
     /**
@@ -167,7 +183,12 @@ export function initializeView(
       speedy: false,
     })
 
-    createRoot(root).render(
+    createRoot(root, {
+      // Our error boundaries already warn once for every crash they catch.
+      // React would log the same crash again at error level, in a console that
+      // belongs to the recorded page rather than to us.
+      onCaughtError: () => {},
+    }).render(
       <CacheProvider value={globalCache}>
         <GlobalStyles />
         <StudioClientProvider client={client}>
@@ -278,4 +299,8 @@ export function initializeView(
   window.addEventListener('focusout', bypassFocusEvent, true)
   window.addEventListener('focus', bypassFocusEvent, true)
   window.addEventListener('blur', bypassFocusEvent, true)
+
+  return function dispose() {
+    disposeMount()
+  }
 }

--- a/src/recorder/browser/view/index.tsx
+++ b/src/recorder/browser/view/index.tsx
@@ -20,6 +20,13 @@ import { isUsingTool } from './utils'
 // It's not entirely clear why this happens and there doesn't seem to be any events firing that
 // we can rely on. So instead, we use use a brute-force polling mechanism to monitor if the document
 // reference changes during the opening stages of the page. It's not pretty but it works.
+//
+// This covers only the initial empty-document swap (a navigation commit that
+// replaces the Document object). The other way a page loses our UI is
+// document.open(), which reuses the same Document object and so is invisible
+// to this poll; that case is handled from the main process, which re-injects
+// the whole script on CDP's Page.documentOpened event (see the documentOpened
+// handler in src/recorder/launchers/cdp/page.ts).
 function monitorDocumentChange(onChange: () => void) {
   // During this short period of time the document will have the URL "about:blank", so if it's
   // different then we can skip this check entirely.
@@ -148,8 +155,8 @@ export function initializeView(
 
     abortController.abort()
 
-    // Another copy of the script beat us to this document. See
-    // MOUNT_MARKER_ATTRIBUTE for why a second mount must never be created.
+    // Another initializer beat us to this document. See the mount marker in
+    // mount.ts for why a second mount must never be created.
     if (isDocumentMounted()) {
       console.warn('[k6 Studio] In-browser UI is already initialized.')
 

--- a/src/recorder/browser/view/index.tsx
+++ b/src/recorder/browser/view/index.tsx
@@ -6,9 +6,10 @@ import { ContainerProvider } from '@/components/primitives/ContainerProvider'
 import { Theme } from '@/components/primitives/Theme'
 import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 
+import { ErrorBoundary } from './ErrorBoundary'
 import { GlobalStyles } from './GlobalStyles'
 import { InBrowserControls } from './InBrowserControls'
-import { createMount, isDocumentMounted } from './mount'
+import { createMount, isDocumentMounted, removeStaleMounts } from './mount'
 import { SettingsProvider, SettingsStorage } from './SettingsProvider'
 import { StudioClientProvider } from './StudioClientProvider'
 import { isUsingTool } from './utils'
@@ -122,10 +123,13 @@ export function initializeView(
 ) {
   const abortController = new AbortController()
 
-  // Stops the mount's defending observers. Production never disposes (the
-  // UI lives for the document's lifetime), but tests must, so that observer
-  // callbacks don't fire into a torn-down environment.
-  let disposeMount = () => {}
+  // Tears down what initialize() set up: the mount observers, the React root
+  // (so its client/storage subscriptions are released), and the bypass
+  // listeners. Replaced once initialize() has run.
+  let disposeInitialized = () => {}
+
+  // Dispose handle of the re-initialization monitorDocumentChange may start.
+  let disposeReinitialized = () => {}
 
   let shadowRoot: ShadowRoot | null = null
 
@@ -163,9 +167,11 @@ export function initializeView(
       return
     }
 
-    const { mount, dispose } = createMount()
+    // A page that rewrote itself from its own serialized body can carry dead
+    // copies of a previous mount's marker.
+    removeStaleMounts()
 
-    disposeMount = dispose
+    const { mount, dispose: disposeMount } = createMount()
 
     const root = createShadowRoot(mount)
 
@@ -190,12 +196,14 @@ export function initializeView(
       speedy: false,
     })
 
-    createRoot(root, {
+    const reactRoot = createRoot(root, {
       // Our error boundaries already warn once for every crash they catch.
       // React would log the same crash again at error level, in a console that
       // belongs to the recorded page rather than to us.
       onCaughtError: () => {},
-    }).render(
+    })
+
+    reactRoot.render(
       <CacheProvider value={globalCache}>
         <GlobalStyles />
         <StudioClientProvider client={client}>
@@ -203,19 +211,34 @@ export function initializeView(
             <ContainerProvider container={root}>
               <CacheProvider value={shadowCache}>
                 <Theme root={false} includeColors />
-                <InBrowserControls />
+                {/*
+                  InBrowserControls' own hooks run above its per-feature
+                  boundaries. Without this outer boundary a crash there would
+                  bypass them all and unmount the whole UI.
+                */}
+                <ErrorBoundary>
+                  <InBrowserControls />
+                </ErrorBoundary>
               </CacheProvider>
             </ContainerProvider>
           </SettingsProvider>
         </StudioClientProvider>
       </CacheProvider>
     )
+
+    const removeBypassListeners = attachBypassListeners()
+
+    disposeInitialized = () => {
+      removeBypassListeners()
+      reactRoot.unmount()
+      disposeMount()
+    }
   }
 
   monitorDocumentChange(() => {
     console.log('Document instance changed, re-initializing UI.')
 
-    initializeView(client, storage)
+    disposeReinitialized = initializeView(client, storage)
   })
 
   if (document.readyState === 'loading') {
@@ -299,15 +322,34 @@ export function initializeView(
     event.stopImmediatePropagation()
   }
 
-  window.addEventListener('click', bypassRecordedPage, true)
-  window.addEventListener('pointerdown', bypassRecordedPage, true)
-  window.addEventListener('pointerup', bypassRecordedPage, true)
-  window.addEventListener('focusin', bypassFocusEvent, true)
-  window.addEventListener('focusout', bypassFocusEvent, true)
-  window.addEventListener('focus', bypassFocusEvent, true)
-  window.addEventListener('blur', bypassFocusEvent, true)
+  // Only useful once our UI exists: every listener starts with an
+  // isInsideBrowserUI check, so on the path where the mount guard bails they
+  // would just tax every interaction on the page.
+  function attachBypassListeners() {
+    window.addEventListener('click', bypassRecordedPage, true)
+    window.addEventListener('pointerdown', bypassRecordedPage, true)
+    window.addEventListener('pointerup', bypassRecordedPage, true)
+    window.addEventListener('focusin', bypassFocusEvent, true)
+    window.addEventListener('focusout', bypassFocusEvent, true)
+    window.addEventListener('focus', bypassFocusEvent, true)
+    window.addEventListener('blur', bypassFocusEvent, true)
+
+    return () => {
+      window.removeEventListener('click', bypassRecordedPage, true)
+      window.removeEventListener('pointerdown', bypassRecordedPage, true)
+      window.removeEventListener('pointerup', bypassRecordedPage, true)
+      window.removeEventListener('focusin', bypassFocusEvent, true)
+      window.removeEventListener('focusout', bypassFocusEvent, true)
+      window.removeEventListener('focus', bypassFocusEvent, true)
+      window.removeEventListener('blur', bypassFocusEvent, true)
+    }
+  }
 
   return function dispose() {
-    disposeMount()
+    // Cancels an initialization that hasn't happened yet (initialize() bails
+    // once the controller is aborted) and tears down one that has.
+    abortController.abort()
+    disposeInitialized()
+    disposeReinitialized()
   }
 }

--- a/src/recorder/browser/view/inspection.test.ts
+++ b/src/recorder/browser/view/inspection.test.ts
@@ -1,42 +1,56 @@
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { attachInspectionDetection } from './inspection'
+import {
+  attachInspectionDetection,
+  attachTextSelectionDetection,
+} from './inspection'
 
 const hover = vi.fn()
 const pick = vi.fn()
+const select = vi.fn()
 
-beforeAll(() => {
-  attachInspectionDetection()
-})
+let disposeInspection: () => void
+let disposeTextSelection: () => void
 
 beforeEach(() => {
+  disposeInspection = attachInspectionDetection()
+  disposeTextSelection = attachTextSelectionDetection()
+
   window.__K6_STUDIO_INSPECTION__ = { hover, pick }
+  window.__K6_STUDIO_TEXT_SELECTION__ = { select }
 })
 
 afterEach(() => {
+  // Disposing twice is safe, so tests that dispose early don't need a guard.
+  disposeInspection()
+  disposeTextSelection()
+
   hover.mockClear()
   pick.mockClear()
-  delete window.__K6_STUDIO_INSPECTION__
-  document.body.innerHTML = ''
-})
+  select.mockClear()
 
-afterAll(() => {
   delete window.__K6_STUDIO_INSPECTION__
+  delete window.__K6_STUDIO_TEXT_SELECTION__
+
+  document.getSelection()?.removeAllRanges()
+  document.body.innerHTML = ''
 })
 
 function dispatch(type: string, target: Element, init: MouseEventInit = {}) {
   target.dispatchEvent(
     new MouseEvent(type, { bubbles: true, composed: true, ...init })
   )
+}
+
+function selectContents(element: Element) {
+  const range = document.createRange()
+  range.selectNodeContents(element)
+
+  const selection = document.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+
+  return range
 }
 
 describe('attachInspectionDetection', () => {
@@ -74,5 +88,48 @@ describe('attachInspectionDetection', () => {
     dispatch('click', iframe, { clientX: 5, clientY: 6 })
 
     expect(pick).not.toHaveBeenCalled()
+  })
+
+  it('stops reporting once disposed', () => {
+    const button = document.createElement('button')
+    document.body.append(button)
+
+    disposeInspection()
+
+    dispatch('mouseover', button)
+
+    expect(hover).not.toHaveBeenCalled()
+  })
+})
+
+describe('attachTextSelectionDetection', () => {
+  it('reports a text selection to the top frame', () => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selected text'
+    document.body.append(paragraph)
+
+    dispatch('selectstart', paragraph)
+
+    const range = selectContents(paragraph)
+
+    dispatch('mouseup', paragraph)
+
+    expect(select).toHaveBeenCalledWith(range, paragraph)
+  })
+
+  it('stops reporting once disposed', () => {
+    const paragraph = document.createElement('p')
+    paragraph.textContent = 'selected text'
+    document.body.append(paragraph)
+
+    disposeTextSelection()
+
+    dispatch('selectstart', paragraph)
+
+    selectContents(paragraph)
+
+    dispatch('mouseup', paragraph)
+
+    expect(select).not.toHaveBeenCalled()
   })
 })

--- a/src/recorder/browser/view/inspection.ts
+++ b/src/recorder/browser/view/inspection.ts
@@ -91,25 +91,32 @@ export function readSelection(
  * element reference passes across the boundary).
  */
 export function attachInspectionDetection() {
-  document.addEventListener('mouseover', (event) => {
-    const bridge = getBridge()
+  const abortController = new AbortController()
+  const { signal } = abortController
 
-    if (bridge === undefined) {
-      return
-    }
+  document.addEventListener(
+    'mouseover',
+    (event) => {
+      const bridge = getBridge()
 
-    const [target] = event.composedPath()
+      if (bridge === undefined) {
+        return
+      }
 
-    if (!isElement(target)) {
-      return
-    }
+      const [target] = event.composedPath()
 
-    // The inspector running inside the iframe reports the actual element under
-    // the cursor, so don't highlight the iframe element itself; clear the hover
-    // instead so a prior highlight can't linger over it (this also avoids an
-    // expensive selector computation on the often deeply nested iframe element).
-    bridge.hover(isHTMLIFrameElement(target) ? null : target)
-  })
+      if (!isElement(target)) {
+        return
+      }
+
+      // The inspector running inside the iframe reports the actual element under
+      // the cursor, so don't highlight the iframe element itself; clear the hover
+      // instead so a prior highlight can't linger over it (this also avoids an
+      // expensive selector computation on the often deeply nested iframe element).
+      bridge.hover(isHTMLIFrameElement(target) ? null : target)
+    },
+    { signal }
+  )
 
   document.addEventListener(
     'click',
@@ -138,8 +145,10 @@ export function attachInspectionDetection() {
 
       bridge.pick(target, event.clientX, event.clientY)
     },
-    { capture: true }
+    { capture: true, signal }
   )
+
+  return () => abortController.abort()
 }
 
 /**
@@ -148,31 +157,44 @@ export function attachInspectionDetection() {
  * is read here and forwarded to the top frame.
  */
 export function attachTextSelectionDetection() {
+  const abortController = new AbortController()
+  const { signal } = abortController
+
   let isSelecting = false
 
-  document.addEventListener('selectstart', () => {
-    if (getTextSelectionBridge() !== undefined) {
-      isSelecting = true
-    }
-  })
+  document.addEventListener(
+    'selectstart',
+    () => {
+      if (getTextSelectionBridge() !== undefined) {
+        isSelecting = true
+      }
+    },
+    { signal }
+  )
 
-  document.addEventListener('mouseup', () => {
-    if (!isSelecting) {
-      return
-    }
+  document.addEventListener(
+    'mouseup',
+    () => {
+      if (!isSelecting) {
+        return
+      }
 
-    isSelecting = false
+      isSelecting = false
 
-    const bridge = getTextSelectionBridge()
+      const bridge = getTextSelectionBridge()
 
-    if (bridge === undefined) {
-      return
-    }
+      if (bridge === undefined) {
+        return
+      }
 
-    const selection = readSelection(document)
+      const selection = readSelection(document)
 
-    if (selection !== null) {
-      bridge.select(selection.range, selection.commonAncestor)
-    }
-  })
+      if (selection !== null) {
+        bridge.select(selection.range, selection.commonAncestor)
+      }
+    },
+    { signal }
+  )
+
+  return () => abortController.abort()
 }

--- a/src/recorder/browser/view/monitor.test.ts
+++ b/src/recorder/browser/view/monitor.test.ts
@@ -1,0 +1,79 @@
+// The monitor only arms while the page is still on the initial empty document,
+// so every test in this file runs against a document with that URL.
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "about:blank" }
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { monitorDocumentChange } from './monitor'
+
+function replaceDocument() {
+  vi.stubGlobal('document', document.implementation.createHTMLDocument())
+}
+
+describe('monitorDocumentChange', () => {
+  beforeEach(() => {
+    // If the environment options above ever stop being applied, the monitor
+    // early-returns and every test below passes without polling anything.
+    expect(document.location.href).toBe('about:blank')
+
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reports a document instance that is replaced while polling', () => {
+    const onChange = vi.fn()
+
+    monitorDocumentChange(onChange)
+
+    vi.advanceTimersByTime(50)
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    replaceDocument()
+
+    vi.advanceTimersByTime(1)
+
+    expect(onChange).toHaveBeenCalledOnce()
+  })
+
+  it('stops polling once disposed', () => {
+    const onChange = vi.fn()
+
+    const stopMonitoring = monitorDocumentChange(onChange)
+
+    vi.advanceTimersByTime(50)
+
+    stopMonitoring()
+
+    replaceDocument()
+
+    vi.advanceTimersByTime(50)
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    // Once the poll stops rescheduling itself only the auto-stop timeout is
+    // left, and that one drains when its window has passed.
+    vi.advanceTimersByTime(5000)
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('returns a dispose when there is nothing to monitor', () => {
+    const onChange = vi.fn()
+
+    vi.stubGlobal('document', { location: { href: 'https://example.com/' } })
+
+    const stopMonitoring = monitorDocumentChange(onChange)
+
+    stopMonitoring()
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/recorder/browser/view/monitor.ts
+++ b/src/recorder/browser/view/monitor.ts
@@ -1,0 +1,54 @@
+// When using CDP, some pages will open with an empty document with readyState "completed"
+// the first time that a page is loaded. This means our UI is injected into the empty document,
+// then the document is replaced with the actual content, making our UI disappear.
+//
+// It's not entirely clear why this happens and there doesn't seem to be any events firing that
+// we can rely on. So instead, we use use a brute-force polling mechanism to monitor if the document
+// reference changes during the opening stages of the page. It's not pretty but it works.
+//
+// This covers only the initial empty-document swap (a navigation commit that
+// replaces the Document object). The other way a page loses our UI is
+// document.open(), which reuses the same Document object and so is invisible
+// to this poll; that case is handled from the main process, which re-injects
+// the whole script on CDP's Page.documentOpened event (see the documentOpened
+// handler in src/recorder/launchers/cdp/page.ts).
+//
+// The caller must stop the monitor when the view that started it is disposed.
+// A poll left running on a copy of the script whose document was handed over
+// still holds that dead copy's onChange, and would start a view that nothing
+// can dispose again.
+export function monitorDocumentChange(onChange: () => void) {
+  const abortController = new AbortController()
+
+  function stopMonitoring() {
+    abortController.abort()
+  }
+
+  // During this short period of time the document will have the URL "about:blank", so if it's
+  // different then we can skip this check entirely.
+  if (document.location.href !== 'about:blank') {
+    return stopMonitoring
+  }
+
+  const currentDocument = document
+
+  setTimeout(function checkDocumentInstance() {
+    if (abortController.signal.aborted) {
+      return
+    }
+
+    if (document === currentDocument) {
+      setTimeout(checkDocumentInstance, 1)
+
+      return
+    }
+
+    onChange()
+  }, 1)
+
+  // We only need to monitor the first few seconds or so. If nothing has changed
+  // by then, there's no point in wasting CPU cycles.
+  setTimeout(stopMonitoring, 5000)
+
+  return stopMonitoring
+}

--- a/src/recorder/browser/view/mount.test.ts
+++ b/src/recorder/browser/view/mount.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { keepMountAtEndOfBody } from './mount'
+import { createMount, isDocumentMounted, keepMountAtEndOfBody } from './mount'
 
 let dispose: (() => void) | null = null
 
@@ -73,5 +73,21 @@ describe('keepMountAtEndOfBody', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(document.body.contains(mount)).toBe(false)
+  })
+})
+
+describe('createMount', () => {
+  it('removes the mount from the document when disposed', () => {
+    const { mount, dispose } = createMount()
+
+    // view/index.tsx attaches the shadow root that holds the UI, and a shadow
+    // root cannot be detached again. A disposed mount left in the document
+    // would keep passing for a live UI and block the next injection.
+    mount.attachShadow({ mode: 'open' })
+
+    dispose()
+
+    expect(isDocumentMounted()).toBe(false)
+    expect(mount.isConnected).toBe(false)
   })
 })

--- a/src/recorder/browser/view/mount.test.ts
+++ b/src/recorder/browser/view/mount.test.ts
@@ -51,4 +51,27 @@ describe('keepMountAtEndOfBody', () => {
 
     await expectLastBodyChild(mount)
   })
+
+  // document.open() replaces the body element but does not disconnect
+  // observers, so a mutation queued just before the rewrite would otherwise
+  // re-append the dead mount into the new document, where its marker would
+  // block the re-injected script from mounting a working UI.
+  it('does not resurrect the mount into a replaced body', async () => {
+    const mount = setup()
+    const oldBody = document.body
+
+    // Queue a mutation record on the observed body, then swap the body
+    // element before the observer's microtask runs, like document.open()
+    // rewriting the document in the same task.
+    oldBody.appendChild(document.createElement('footer'))
+
+    const newBody = document.createElement('body')
+
+    document.documentElement.replaceChild(newBody, oldBody)
+
+    // Let the observer's queued microtask run before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(document.body.contains(mount)).toBe(false)
+  })
 })

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -1,13 +1,31 @@
 /**
+ * Marks the mount element so that other copies of this script can tell that
+ * the document already hosts the recorder UI. The same document can be
+ * initialized from more than one copy of the script (e.g. one injected into
+ * the initial empty document and one injected when the real document commits
+ * into the same context), and their mounts would fight over the end of the
+ * body through keepMountAtEndOfBody, locking the renderer in an infinite
+ * MutationObserver loop.
+ */
+export const MOUNT_MARKER_ATTRIBUTE = 'data-ksix-studio-mount'
+
+export function isDocumentMounted() {
+  return document.querySelector(`[${MOUNT_MARKER_ATTRIBUTE}]`) !== null
+}
+
+/**
  * Creates the element that hosts the recorder UI inside the recorded page and
- * defends it against the page's own DOM manipulation.
+ * defends it against the page's own DOM manipulation. Returns the mount and a
+ * dispose function that stops the defending observers.
  */
 export function createMount() {
   const mount = document.createElement('div')
 
+  mount.setAttribute(MOUNT_MARKER_ATTRIBUTE, 'true')
+
   document.body.appendChild(mount)
 
-  keepMountAtEndOfBody(mount)
+  const stopKeepingAtEndOfBody = keepMountAtEndOfBody(mount)
 
   // Some UI frameworks use the `inert` attribute to disable interaction with
   // elements outside of a modal. We remove this attribute so that the recording
@@ -23,7 +41,13 @@ export function createMount() {
     attributeFilter: ['inert'],
   })
 
-  return mount
+  return {
+    mount,
+    dispose: () => {
+      stopKeepingAtEndOfBody()
+      attributeObserver.disconnect()
+    },
+  }
 }
 
 /**

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -1,13 +1,15 @@
 /**
- * Marks the mount element so that other copies of this script can tell that
- * the document already hosts the recorder UI. The same document can be
- * initialized from more than one copy of the script (e.g. one injected into
- * the initial empty document and one injected when the real document commits
- * into the same context), and their mounts would fight over the end of the
- * body through keepMountAtEndOfBody, locking the renderer in an infinite
- * MutationObserver loop.
+ * Marks the mount element so that any other initializer can tell that the
+ * document already hosts the recorder UI. The same document can be
+ * initialized more than once: by another copy of this script (one injected
+ * into the initial empty document and one injected when the real document
+ * commits into the same context), or by the same copy re-entering through
+ * monitorDocumentChange in view/index.tsx. Two mounts would fight over the
+ * end of the body through keepMountAtEndOfBody, locking the renderer in an
+ * infinite MutationObserver loop. The marker lives in the DOM because the
+ * DOM is the only state separate script copies share.
  */
-export const MOUNT_MARKER_ATTRIBUTE = 'data-ksix-studio-mount'
+const MOUNT_MARKER_ATTRIBUTE = 'data-ksix-studio-mount'
 
 export function isDocumentMounted() {
   return document.querySelector(`[${MOUNT_MARKER_ATTRIBUTE}]`) !== null

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -40,7 +40,8 @@ function findMounts() {
 /**
  * Creates the element that hosts the recorder UI inside the recorded page and
  * defends it against the page's own DOM manipulation. Returns the mount and a
- * dispose function that stops the defending observers.
+ * dispose function that stops the defending observers and takes the mount back
+ * out of the document.
  */
 export function createMount() {
   const mount = document.createElement('div')
@@ -70,6 +71,13 @@ export function createMount() {
     dispose: () => {
       stopKeepingAtEndOfBody()
       attributeObserver.disconnect()
+
+      // The shadow root cannot be detached, so a disposed mount left in the
+      // document would still pass isDocumentMounted and block the next copy of
+      // the script from mounting a working UI. Its position observer is gone
+      // too, so the page could also drift it away from the end of the body and
+      // skew generated selectors.
+      mount.remove()
     },
   }
 }

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -11,8 +11,30 @@
  */
 const MOUNT_MARKER_ATTRIBUTE = 'data-ksix-studio-mount'
 
+/**
+ * Whether the document hosts a LIVE recorder UI. The marker attribute alone
+ * is not proof: a page that serializes its own body and rewrites itself
+ * (e.g. document.write(document.body.innerHTML)) reproduces the marker as a
+ * dead copy, since shadow roots do not serialize. A mount without a shadow
+ * root has no UI behind it and must not block a fresh injection.
+ */
 export function isDocumentMounted() {
-  return document.querySelector(`[${MOUNT_MARKER_ATTRIBUTE}]`) !== null
+  return findMounts().some((element) => element.shadowRoot !== null)
+}
+
+/**
+ * Removes marker-bearing elements that have no UI behind them, so they can't
+ * skew generated nth-child selectors. See isDocumentMounted for how dead
+ * copies come to exist.
+ */
+export function removeStaleMounts() {
+  findMounts()
+    .filter((element) => element.shadowRoot === null)
+    .forEach((element) => element.remove())
+}
+
+function findMounts() {
+  return [...document.querySelectorAll(`[${MOUNT_MARKER_ATTRIBUTE}]`)]
 }
 
 /**
@@ -79,7 +101,19 @@ export function createMount() {
  * so the recording controls stay available.
  */
 export function keepMountAtEndOfBody(mount: Element) {
+  const body = document.body
+
   function ensureAtEndOfBody() {
+    // The body this observer was attached to is gone (e.g. document.open()
+    // rewrote the document, which does not disconnect observers). The mount
+    // died with it and must not be resurrected into the new document, where
+    // its marker would block a fresh injection from mounting a working UI.
+    if (document.body !== body) {
+      positionObserver.disconnect()
+
+      return
+    }
+
     if (document.body.lastElementChild !== mount) {
       document.body.appendChild(mount)
     }
@@ -87,7 +121,7 @@ export function keepMountAtEndOfBody(mount: Element) {
 
   const positionObserver = new MutationObserver(ensureAtEndOfBody)
 
-  positionObserver.observe(document.body, {
+  positionObserver.observe(body, {
     childList: true,
   })
 

--- a/src/recorder/browser/view/mount.ts
+++ b/src/recorder/browser/view/mount.ts
@@ -1,22 +1,8 @@
-/**
- * Marks the mount element so that any other initializer can tell that the
- * document already hosts the recorder UI. The same document can be
- * initialized more than once: by another copy of this script (one injected
- * into the initial empty document and one injected when the real document
- * commits into the same context), or by the same copy re-entering through
- * monitorDocumentChange in view/index.tsx. Two mounts would fight over the
- * end of the body through keepMountAtEndOfBody, locking the renderer in an
- * infinite MutationObserver loop. The marker lives in the DOM because the
- * DOM is the only state separate script copies share.
- */
 const MOUNT_MARKER_ATTRIBUTE = 'data-ksix-studio-mount'
 
 /**
- * Whether the document hosts a LIVE recorder UI. The marker attribute alone
- * is not proof: a page that serializes its own body and rewrites itself
- * (e.g. document.write(document.body.innerHTML)) reproduces the marker as a
- * dead copy, since shadow roots do not serialize. A mount without a shadow
- * root has no UI behind it and must not block a fresh injection.
+ * Whether the document hosts a LIVE recorder UI. A mount is live if
+ * it has the marker attribute and a shadow root.
  */
 export function isDocumentMounted() {
   return findMounts().some((element) => element.shadowRoot !== null)
@@ -24,8 +10,7 @@ export function isDocumentMounted() {
 
 /**
  * Removes marker-bearing elements that have no UI behind them, so they can't
- * skew generated nth-child selectors. See isDocumentMounted for how dead
- * copies come to exist.
+ * skew generated nth-child selectors.
  */
 export function removeStaleMounts() {
   findMounts()
@@ -71,12 +56,6 @@ export function createMount() {
     dispose: () => {
       stopKeepingAtEndOfBody()
       attributeObserver.disconnect()
-
-      // The shadow root cannot be detached, so a disposed mount left in the
-      // document would still pass isDocumentMounted and block the next copy of
-      // the script from mounting a working UI. Its position observer is gone
-      // too, so the page could also drift it away from the end of the body and
-      // skew generated selectors.
       mount.remove()
     },
   }

--- a/src/recorder/browser/window.ts
+++ b/src/recorder/browser/window.ts
@@ -2,6 +2,11 @@ import { BrowserExtensionClient } from './messaging'
 
 let wasFocused = false
 
+/**
+ * Reports to the client when the tab gains focus. Returns a dispose function:
+ * document.open() erases the focus listener but not the interval, so a
+ * re-injected copy disposes the previous tracker and starts its own.
+ */
 export function trackTabFocus(client: BrowserExtensionClient) {
   const checkFocus = () => {
     const tab = window.__K6_STUDIO_TAB_ID__
@@ -22,14 +27,18 @@ export function trackTabFocus(client: BrowserExtensionClient) {
     wasFocused = isFocused
   }
 
-  window.addEventListener(
-    'focus',
-    () => {
-      checkFocus()
-    },
-    true
-  )
+  const handleFocus = () => {
+    checkFocus()
+  }
 
-  setInterval(checkFocus, 200)
+  window.addEventListener('focus', handleFocus, true)
+
+  const interval = setInterval(checkFocus, 200)
+
   checkFocus()
+
+  return function dispose() {
+    window.removeEventListener('focus', handleFocus, true)
+    clearInterval(interval)
+  }
 }

--- a/src/recorder/browser/window.ts
+++ b/src/recorder/browser/window.ts
@@ -2,11 +2,6 @@ import { BrowserExtensionClient } from './messaging'
 
 let wasFocused = false
 
-/**
- * Reports to the client when the tab gains focus. Returns a dispose function:
- * document.open() erases the focus listener but not the interval, so a
- * re-injected copy disposes the previous tracker and starts its own.
- */
 export function trackTabFocus(client: BrowserExtensionClient) {
   const checkFocus = () => {
     const tab = window.__K6_STUDIO_TAB_ID__

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -18,6 +18,12 @@ class FakeTransport implements Transport {
   // Url the main frame has committed, reported by Page.getFrameTree
   frameUrl = ''
 
+  // Context Page.createIsolatedWorld resolves to
+  isolatedWorldContextId = 42
+
+  // Methods that respond with an error, e.g. because the frame is gone
+  rejectedMethods = new Set<string>()
+
   #listeners = new Map<string, Set<Listener>>()
 
   // Mimics a popup opened with noopener/noreferrer: while such a page is
@@ -33,11 +39,11 @@ class FakeTransport implements Transport {
   call<Return>(command: ChromeCommand): Promise<Return> {
     this.calls.push(command)
 
-    const result = (
-      command.method === 'Page.getFrameTree'
-        ? { frameTree: { frame: { id: 'tab-1', url: this.frameUrl } } }
-        : {}
-    ) as Return
+    if (this.rejectedMethods.has(command.method)) {
+      return Promise.reject(new Error(`${command.method} failed`))
+    }
+
+    const result = this.#resultFor(command) as Return
 
     if (!this.#holdResponsesUntilResume) {
       return Promise.resolve(result)
@@ -77,6 +83,19 @@ class FakeTransport implements Transport {
   }
 
   dispose() {}
+
+  #resultFor(command: ChromeCommand) {
+    switch (command.method) {
+      case 'Page.getFrameTree':
+        return { frameTree: { frame: { id: 'tab-1', url: this.frameUrl } } }
+
+      case 'Page.createIsolatedWorld':
+        return { executionContextId: this.isolatedWorldContextId }
+
+      default:
+        return {}
+    }
+  }
 }
 
 function setup(holdResponsesUntilResume = false) {
@@ -112,28 +131,21 @@ function evaluateCalls(transport: FakeTransport) {
   return transport.calls.filter((call) => call.method === 'Runtime.evaluate')
 }
 
-function createExecutionContext(
-  transport: FakeTransport,
-  {
-    id,
-    frameId,
-    isDefault = true,
-    sessionId,
-  }: { id: number; frameId: string; isDefault?: boolean; sessionId?: string }
-) {
-  transport.emit(
-    'Runtime.executionContextCreated',
-    { context: { id, auxData: { isDefault, frameId } } },
-    sessionId
+function isolatedWorldCalls(transport: FakeTransport) {
+  return transport.calls.filter(
+    (call) => call.method === 'Page.createIsolatedWorld'
   )
 }
 
-function openDocument(
+// Re-injecting the script is asynchronous, so let it settle before asserting.
+async function openDocument(
   transport: FakeTransport,
   frameId: string,
   sessionId?: string
 ) {
   transport.emit('Page.documentOpened', { frame: { id: frameId } }, sessionId)
+
+  await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
 describe('Page.attach', () => {
@@ -173,8 +185,18 @@ describe('Page.attach', () => {
 
       expect(calls).toHaveLength(2)
       calls.forEach((call) => {
-        expect(call.params).toMatchObject({ runImmediately })
+        expect(call.params).toMatchObject({
+          runImmediately,
+          worldName: 'k6-studio-recorder',
+        })
       })
+
+      // Both scripts share one isolated world, and the recording script reads
+      // the tab id when it starts up, so the tab id has to be registered first.
+      expect(calls[0]?.params).toMatchObject({
+        source: 'window.__K6_STUDIO_TAB_ID__ = "tab-1";',
+      })
+      expect(calls[1]?.params).toMatchObject({ source: 'script-content' })
     }
   )
 
@@ -264,96 +286,70 @@ describe('Page.attach', () => {
 // injected recording script's UI and event listeners, and Chromium does not
 // re-run scripts registered with Page.addScriptToEvaluateOnNewDocument for the
 // replaced document. The recorder has to evaluate the script again in the
-// frame's execution context, which survives the replacement.
+// isolated world it injects into, which Page.createIsolatedWorld returns when
+// it survived the replacement and creates otherwise.
 describe('document.open', () => {
-  it('re-evaluates the recording script when a document is replaced', async () => {
+  it('re-injects the recording script when a document is replaced', async () => {
     const { transport, page } = setup()
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
-    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
-    openDocument(transport, 'tab-1')
+    await openDocument(transport, 'tab-1')
 
-    const calls = evaluateCalls(transport)
+    const worlds = isolatedWorldCalls(transport)
 
-    expect(calls).toHaveLength(1)
-    expect(calls[0]?.params).toMatchObject({
-      expression: 'script-content',
-      contextId: 7,
-    })
-  })
-
-  it('re-evaluates in the context of the frame that opened the document', async () => {
-    const { transport, page } = setup()
-
-    await page.attach({ isInitialTab: true, hasOpener: false })
-
-    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
-    createExecutionContext(transport, { id: 9, frameId: 'frame-2' })
-    openDocument(transport, 'frame-2')
-
-    const calls = evaluateCalls(transport)
-
-    expect(calls).toHaveLength(1)
-    expect(calls[0]?.params).toMatchObject({ contextId: 9 })
-  })
-
-  it('ignores frames without a known context', async () => {
-    const { transport, page } = setup()
-
-    await page.attach({ isInitialTab: true, hasOpener: false })
-
-    openDocument(transport, 'frame-2')
-
-    expect(evaluateCalls(transport)).toEqual([])
-  })
-
-  it('ignores contexts that are not the default context of the frame', async () => {
-    const { transport, page } = setup()
-
-    await page.attach({ isInitialTab: true, hasOpener: false })
-
-    createExecutionContext(transport, {
-      id: 7,
+    expect(worlds).toHaveLength(1)
+    expect(worlds[0]?.params).toMatchObject({
       frameId: 'tab-1',
-      isDefault: false,
+      worldName: 'k6-studio-recorder',
     })
-    openDocument(transport, 'tab-1')
 
-    expect(evaluateCalls(transport)).toEqual([])
+    // The script reads the tab id when it starts up, so the global has to be
+    // set before it runs again.
+    const calls = evaluateCalls(transport)
+
+    expect(calls).toHaveLength(2)
+    expect(calls[0]?.params).toMatchObject({
+      expression: 'window.__K6_STUDIO_TAB_ID__ = "tab-1";',
+      contextId: 42,
+    })
+    expect(calls[1]?.params).toMatchObject({
+      expression: 'script-content',
+      contextId: 42,
+    })
   })
 
-  it('does not evaluate in a destroyed context', async () => {
+  it('re-injects into the frame that opened the document', async () => {
     const { transport, page } = setup()
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
-    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
-    transport.emit('Runtime.executionContextDestroyed', {
-      executionContextId: 7,
-    })
-    openDocument(transport, 'tab-1')
+    await openDocument(transport, 'frame-2')
 
-    expect(evaluateCalls(transport)).toEqual([])
+    const worlds = isolatedWorldCalls(transport)
+
+    expect(worlds).toHaveLength(1)
+    expect(worlds[0]?.params).toMatchObject({ frameId: 'frame-2' })
+    expect(evaluateCalls(transport)).toHaveLength(2)
   })
 
-  it('does not evaluate after all contexts are cleared', async () => {
+  it('does not re-inject when the isolated world cannot be created', async () => {
     const { transport, page } = setup()
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
-    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
-    transport.emit('Runtime.executionContextsCleared', {})
-    openDocument(transport, 'tab-1')
+    transport.rejectedMethods.add('Page.createIsolatedWorld')
+
+    await openDocument(transport, 'tab-1')
 
     expect(evaluateCalls(transport)).toEqual([])
   })
 
   // The generated CDP client registers its listeners on the shared transport
   // without applying its per-session filter, so a Page receives every tab's
-  // Runtime and Page events. The context tracking has to filter by session
-  // itself, or one tab's document.open would trigger an evaluate from every
-  // Page in the recording.
+  // Page events. The handler has to filter by session itself, or one tab's
+  // document.open would trigger a re-injection from every Page in the
+  // recording.
   it('ignores events addressed to other sessions', async () => {
     const transport = new FakeTransport(false)
     const client = new ChromeDevToolsClient(transport).withSession('session-1')
@@ -361,33 +357,22 @@ describe('document.open', () => {
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
-    createExecutionContext(transport, {
-      id: 7,
-      frameId: 'tab-1',
-      sessionId: 'session-2',
-    })
-    openDocument(transport, 'tab-1', 'session-2')
+    await openDocument(transport, 'tab-1', 'session-2')
 
+    expect(isolatedWorldCalls(transport)).toEqual([])
     expect(evaluateCalls(transport)).toEqual([])
   })
 
-  it('re-evaluates for events addressed to its own session', async () => {
+  it('re-injects for events addressed to its own session', async () => {
     const transport = new FakeTransport(false)
     const client = new ChromeDevToolsClient(transport).withSession('session-1')
     const page = new Page('tab-1', client, new Script('script-content'))
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
-    createExecutionContext(transport, {
-      id: 7,
-      frameId: 'tab-1',
-      sessionId: 'session-1',
-    })
-    openDocument(transport, 'tab-1', 'session-1')
+    await openDocument(transport, 'tab-1', 'session-1')
 
-    const calls = evaluateCalls(transport)
-
-    expect(calls).toHaveLength(1)
-    expect(calls[0]?.params).toMatchObject({ contextId: 7 })
+    expect(isolatedWorldCalls(transport)).toHaveLength(1)
+    expect(evaluateCalls(transport)).toHaveLength(2)
   })
 })

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -70,9 +70,9 @@ class FakeTransport implements Transport {
     this.#listeners.get(event)?.delete(listener)
   }
 
-  emit(event: string, data: unknown) {
+  emit(event: string, data: unknown, sessionId?: string) {
     this.#listeners.get(event)?.forEach((listener) => {
-      listener({ method: event, sessionId: undefined, data } as never)
+      listener({ method: event, sessionId, data } as never)
     })
   }
 
@@ -106,6 +106,34 @@ function scriptCalls(transport: FakeTransport) {
   return transport.calls.filter(
     (call) => call.method === 'Page.addScriptToEvaluateOnNewDocument'
   )
+}
+
+function evaluateCalls(transport: FakeTransport) {
+  return transport.calls.filter((call) => call.method === 'Runtime.evaluate')
+}
+
+function createExecutionContext(
+  transport: FakeTransport,
+  {
+    id,
+    frameId,
+    isDefault = true,
+    sessionId,
+  }: { id: number; frameId: string; isDefault?: boolean; sessionId?: string }
+) {
+  transport.emit(
+    'Runtime.executionContextCreated',
+    { context: { id, auxData: { isDefault, frameId } } },
+    sessionId
+  )
+}
+
+function openDocument(
+  transport: FakeTransport,
+  frameId: string,
+  sessionId?: string
+) {
+  transport.emit('Page.documentOpened', { frame: { id: frameId } }, sessionId)
 }
 
 describe('Page.attach', () => {
@@ -229,5 +257,137 @@ describe('Page.attach', () => {
 
     expect(recorded).toHaveLength(2)
     expect(recorded[1]).toMatchObject({ url: 'https://example.test/next' })
+  })
+})
+
+// A page can replace its document with `document.open()`. That destroys the
+// injected recording script's UI and event listeners, and Chromium does not
+// re-run scripts registered with Page.addScriptToEvaluateOnNewDocument for the
+// replaced document. The recorder has to evaluate the script again in the
+// frame's execution context, which survives the replacement.
+describe('document.open', () => {
+  it('re-evaluates the recording script when a document is replaced', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
+    openDocument(transport, 'tab-1')
+
+    const calls = evaluateCalls(transport)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.params).toMatchObject({
+      expression: 'script-content',
+      contextId: 7,
+    })
+  })
+
+  it('re-evaluates in the context of the frame that opened the document', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
+    createExecutionContext(transport, { id: 9, frameId: 'frame-2' })
+    openDocument(transport, 'frame-2')
+
+    const calls = evaluateCalls(transport)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.params).toMatchObject({ contextId: 9 })
+  })
+
+  it('ignores frames without a known context', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    openDocument(transport, 'frame-2')
+
+    expect(evaluateCalls(transport)).toEqual([])
+  })
+
+  it('ignores contexts that are not the default context of the frame', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, {
+      id: 7,
+      frameId: 'tab-1',
+      isDefault: false,
+    })
+    openDocument(transport, 'tab-1')
+
+    expect(evaluateCalls(transport)).toEqual([])
+  })
+
+  it('does not evaluate in a destroyed context', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
+    transport.emit('Runtime.executionContextDestroyed', {
+      executionContextId: 7,
+    })
+    openDocument(transport, 'tab-1')
+
+    expect(evaluateCalls(transport)).toEqual([])
+  })
+
+  it('does not evaluate after all contexts are cleared', async () => {
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, { id: 7, frameId: 'tab-1' })
+    transport.emit('Runtime.executionContextsCleared', {})
+    openDocument(transport, 'tab-1')
+
+    expect(evaluateCalls(transport)).toEqual([])
+  })
+
+  // The generated CDP client registers its listeners on the shared transport
+  // without applying its per-session filter, so a Page receives every tab's
+  // Runtime and Page events. The context tracking has to filter by session
+  // itself, or one tab's document.open would trigger an evaluate from every
+  // Page in the recording.
+  it('ignores events addressed to other sessions', async () => {
+    const transport = new FakeTransport(false)
+    const client = new ChromeDevToolsClient(transport).withSession('session-1')
+    const page = new Page('tab-1', client, new Script('script-content'))
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, {
+      id: 7,
+      frameId: 'tab-1',
+      sessionId: 'session-2',
+    })
+    openDocument(transport, 'tab-1', 'session-2')
+
+    expect(evaluateCalls(transport)).toEqual([])
+  })
+
+  it('re-evaluates for events addressed to its own session', async () => {
+    const transport = new FakeTransport(false)
+    const client = new ChromeDevToolsClient(transport).withSession('session-1')
+    const page = new Page('tab-1', client, new Script('script-content'))
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    createExecutionContext(transport, {
+      id: 7,
+      frameId: 'tab-1',
+      sessionId: 'session-1',
+    })
+    openDocument(transport, 'tab-1', 'session-1')
+
+    const calls = evaluateCalls(transport)
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]?.params).toMatchObject({ contextId: 7 })
   })
 })

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -121,20 +121,8 @@ function navigateFrame(transport: FakeTransport, url: string) {
   })
 }
 
-function scriptCalls(transport: FakeTransport) {
-  return transport.calls.filter(
-    (call) => call.method === 'Page.addScriptToEvaluateOnNewDocument'
-  )
-}
-
-function evaluateCalls(transport: FakeTransport) {
-  return transport.calls.filter((call) => call.method === 'Runtime.evaluate')
-}
-
-function isolatedWorldCalls(transport: FakeTransport) {
-  return transport.calls.filter(
-    (call) => call.method === 'Page.createIsolatedWorld'
-  )
+function callsTo(transport: FakeTransport, method: string) {
+  return transport.calls.filter((call) => call.method === method)
 }
 
 // Re-injecting the script is asynchronous, so let it settle before asserting.
@@ -181,7 +169,7 @@ describe('Page.attach', () => {
 
       await page.attach({ isInitialTab: true, hasOpener })
 
-      const calls = scriptCalls(transport)
+      const calls = callsTo(transport, 'Page.addScriptToEvaluateOnNewDocument')
 
       expect(calls).toHaveLength(2)
       calls.forEach((call) => {
@@ -296,7 +284,7 @@ describe('document.open', () => {
 
     await openDocument(transport, 'tab-1')
 
-    const worlds = isolatedWorldCalls(transport)
+    const worlds = callsTo(transport, 'Page.createIsolatedWorld')
 
     expect(worlds).toHaveLength(1)
     expect(worlds[0]?.params).toMatchObject({
@@ -306,7 +294,7 @@ describe('document.open', () => {
 
     // The script reads the tab id when it starts up, so the global has to be
     // set before it runs again.
-    const calls = evaluateCalls(transport)
+    const calls = callsTo(transport, 'Runtime.evaluate')
 
     expect(calls).toHaveLength(2)
     expect(calls[0]?.params).toMatchObject({
@@ -326,11 +314,11 @@ describe('document.open', () => {
 
     await openDocument(transport, 'frame-2')
 
-    const worlds = isolatedWorldCalls(transport)
+    const worlds = callsTo(transport, 'Page.createIsolatedWorld')
 
     expect(worlds).toHaveLength(1)
     expect(worlds[0]?.params).toMatchObject({ frameId: 'frame-2' })
-    expect(evaluateCalls(transport)).toHaveLength(2)
+    expect(callsTo(transport, 'Runtime.evaluate')).toHaveLength(2)
   })
 
   it('does not re-inject when the isolated world cannot be created', async () => {
@@ -342,7 +330,7 @@ describe('document.open', () => {
 
     await openDocument(transport, 'tab-1')
 
-    expect(evaluateCalls(transport)).toEqual([])
+    expect(callsTo(transport, 'Runtime.evaluate')).toEqual([])
   })
 
   // The generated CDP client registers its listeners on the shared transport
@@ -359,8 +347,8 @@ describe('document.open', () => {
 
     await openDocument(transport, 'tab-1', 'session-2')
 
-    expect(isolatedWorldCalls(transport)).toEqual([])
-    expect(evaluateCalls(transport)).toEqual([])
+    expect(callsTo(transport, 'Page.createIsolatedWorld')).toEqual([])
+    expect(callsTo(transport, 'Runtime.evaluate')).toEqual([])
   })
 
   it('re-injects for events addressed to its own session', async () => {
@@ -372,7 +360,7 @@ describe('document.open', () => {
 
     await openDocument(transport, 'tab-1', 'session-1')
 
-    expect(isolatedWorldCalls(transport)).toHaveLength(1)
-    expect(evaluateCalls(transport)).toHaveLength(2)
+    expect(callsTo(transport, 'Page.createIsolatedWorld')).toHaveLength(1)
+    expect(callsTo(transport, 'Runtime.evaluate')).toHaveLength(2)
   })
 })

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import logger from 'electron-log/main'
+import { describe, expect, it, vi } from 'vitest'
 
 import { BrowserEvent } from '@/schemas/recording'
 import {
@@ -23,6 +24,10 @@ class FakeTransport implements Transport {
 
   // Methods that respond with an error, e.g. because the frame is gone
   rejectedMethods = new Set<string>()
+
+  // When set, Runtime.evaluate reports that the evaluated expression threw.
+  // The CDP call itself still succeeds.
+  evaluationThrows = false
 
   #listeners = new Map<string, Set<Listener>>()
 
@@ -91,6 +96,20 @@ class FakeTransport implements Transport {
 
       case 'Page.createIsolatedWorld':
         return { executionContextId: this.isolatedWorldContextId }
+
+      case 'Runtime.evaluate':
+        return this.evaluationThrows
+          ? {
+              result: { type: 'undefined' },
+              exceptionDetails: {
+                exceptionId: 1,
+                text: 'Uncaught',
+                lineNumber: 0,
+                columnNumber: 0,
+                exception: { type: 'object', description: 'Error: boom' },
+              },
+            }
+          : { result: { type: 'undefined' } }
 
       default:
         return {}
@@ -325,6 +344,7 @@ describe('document.open', () => {
   })
 
   it('does not re-inject when the isolated world cannot be created', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
     const { transport, page } = setup()
 
     await page.attach({ isInitialTab: true, hasOpener: false })
@@ -334,13 +354,39 @@ describe('document.open', () => {
     await openDocument(transport, 'tab-1')
 
     expect(callsTo(transport, 'Runtime.evaluate')).toEqual([])
+
+    // The failure is logged; waiting for it also keeps the rejection chain
+    // from settling during a later test.
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce())
+
+    warn.mockRestore()
   })
 
-  // The generated CDP client registers its listeners on the shared transport
-  // without applying its per-session filter, so a Page receives every tab's
-  // Page events. The handler has to filter by session itself, or one tab's
-  // document.open would trigger a re-injection from every Page in the
-  // recording.
+  // Runtime.evaluate reports a throwing expression via exceptionDetails on an
+  // otherwise successful response. Treating that as success would leave the
+  // recorder dead for the document without any trace in the logs.
+  it('logs a warning when the re-injected script throws', async () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+    const { transport, page } = setup()
+
+    await page.attach({ isInitialTab: true, hasOpener: false })
+
+    transport.evaluationThrows = true
+
+    await openDocument(transport, 'tab-1')
+
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      'Failed to re-inject recording script after document.open:',
+      expect.any(Error)
+    )
+
+    const error: unknown = warn.mock.calls[0]?.[1]
+
+    expect(String(error)).toContain('boom')
+
+    warn.mockRestore()
+  })
+
   it('ignores events addressed to other sessions', async () => {
     const { transport, page } = setup({ sessionId: 'session-1' })
 

--- a/src/recorder/launchers/cdp/page.test.ts
+++ b/src/recorder/launchers/cdp/page.test.ts
@@ -98,9 +98,12 @@ class FakeTransport implements Transport {
   }
 }
 
-function setup(holdResponsesUntilResume = false) {
+function setup({
+  holdResponsesUntilResume = false,
+  sessionId,
+}: { holdResponsesUntilResume?: boolean; sessionId?: string } = {}) {
   const transport = new FakeTransport(holdResponsesUntilResume)
-  const client = new ChromeDevToolsClient(transport)
+  const client = new ChromeDevToolsClient(transport, sessionId)
   const page = new Page('tab-1', client, new Script('script-content'))
 
   const recorded: BrowserEvent[] = []
@@ -141,7 +144,7 @@ describe('Page.attach', () => {
     'registers scripts before resuming a paused popup that holds command responses until resume',
     { timeout: 1000 },
     async () => {
-      const { transport, page } = setup(true)
+      const { transport, page } = setup({ holdResponsesUntilResume: true })
 
       await page.attach({ isInitialTab: false, hasOpener: true })
 
@@ -339,9 +342,7 @@ describe('document.open', () => {
   // document.open would trigger a re-injection from every Page in the
   // recording.
   it('ignores events addressed to other sessions', async () => {
-    const transport = new FakeTransport(false)
-    const client = new ChromeDevToolsClient(transport).withSession('session-1')
-    const page = new Page('tab-1', client, new Script('script-content'))
+    const { transport, page } = setup({ sessionId: 'session-1' })
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 
@@ -352,9 +353,7 @@ describe('document.open', () => {
   })
 
   it('re-injects for events addressed to its own session', async () => {
-    const transport = new FakeTransport(false)
-    const client = new ChromeDevToolsClient(transport).withSession('session-1')
-    const page = new Page('tab-1', client, new Script('script-content'))
+    const { transport, page } = setup({ sessionId: 'session-1' })
 
     await page.attach({ isInitialTab: true, hasOpener: false })
 

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -1,11 +1,21 @@
 import logger from 'electron-log/main'
+import { z } from 'zod/v4'
 
 import { NavigateToPageEvent, ReloadPageEvent } from '@/schemas/recording'
-import { ChromeDevToolsClient, Page as CdpPage } from '@/utils/cdp/client'
+import {
+  ChromeDevToolsClient,
+  Page as CdpPage,
+  Runtime as CdpRuntime,
+} from '@/utils/cdp/client'
 import { EventEmitter } from '@/utils/events'
 import { uuid } from '@/utils/uuid'
 
 import { Script } from './script'
+
+const ExecutionContextAuxDataSchema = z.object({
+  isDefault: z.boolean(),
+  frameId: z.string(),
+})
 
 function toNavigationSource(
   event: CdpPage.FrameStartedNavigatingEvent
@@ -48,6 +58,12 @@ export class Page extends EventEmitter<PageEventMap> {
 
   #requestedNavigation: CdpPage.FrameRequestedNavigationEvent | null = null
   #startedNavigation: CdpPage.FrameStartedNavigatingEvent | null = null
+
+  // The default execution context of each frame in the tab. See the
+  // documentOpened handler for why they are tracked.
+  readonly #contexts = new Map<string, CdpRuntime.ExecutionContextId>()
+
+  readonly #disposers: Array<() => void> = []
 
   // Whether any navigation has been recorded for this tab. See
   // #recordMissedEntryNavigation.
@@ -143,6 +159,86 @@ export class Page extends EventEmitter<PageEventMap> {
 
       this.#reset()
     })
+
+    // The context and document.open handlers below cannot filter by frame id
+    // like the navigation handlers above: they must handle every frame in the
+    // tab (e.g. a frameset child the parent document.write()s into). They
+    // filter by session instead, because the generated CDP client registers
+    // its listeners on the shared transport without applying its per-session
+    // filter, delivering every tab's events to every Page.
+    const isOwnSession = (sessionId: string | undefined) =>
+      sessionId === this.#client.sessionId
+
+    this.#disposers.push(
+      this.#client.runtime.on(
+        'executionContextCreated',
+        ({ sessionId, data }) => {
+          if (!isOwnSession(sessionId)) {
+            return
+          }
+
+          const auxData = ExecutionContextAuxDataSchema.safeParse(
+            data.context.auxData
+          )
+
+          if (!auxData.success || !auxData.data.isDefault) {
+            return
+          }
+
+          this.#contexts.set(auxData.data.frameId, data.context.id)
+        }
+      ),
+
+      this.#client.runtime.on(
+        'executionContextDestroyed',
+        ({ sessionId, data }) => {
+          if (!isOwnSession(sessionId)) {
+            return
+          }
+
+          for (const [frameId, contextId] of this.#contexts) {
+            if (contextId === data.executionContextId) {
+              this.#contexts.delete(frameId)
+            }
+          }
+        }
+      ),
+
+      this.#client.runtime.on('executionContextsCleared', ({ sessionId }) => {
+        if (!isOwnSession(sessionId)) {
+          return
+        }
+
+        this.#contexts.clear()
+      }),
+
+      // A document replaced via document.open() loses the recording script's
+      // UI and event listeners, and Chromium does not run scripts registered
+      // with Page.addScriptToEvaluateOnNewDocument again for it. The frame's
+      // execution context survives the replacement, so the script is
+      // evaluated there again. Complements the in-page recovery mechanisms
+      // (monitorDocumentChange and keepMountAtEndOfBody in
+      // src/recorder/browser/view), which cannot survive document.open
+      // because their observers die with the old document.
+      this.#client.page.on('documentOpened', ({ sessionId, data }) => {
+        if (!isOwnSession(sessionId)) {
+          return
+        }
+
+        const contextId = this.#contexts.get(data.frame.id)
+
+        if (contextId === undefined) {
+          return
+        }
+
+        this.#script.evaluate(this.#client, contextId).catch((error) => {
+          logger.warn(
+            'Failed to re-inject recording script after document.open:',
+            error
+          )
+        })
+      })
+    )
 
     this.#script.on('reload', () => {
       this.#client.page.reload({}).catch((error) => {
@@ -276,6 +372,8 @@ export class Page extends EventEmitter<PageEventMap> {
   }
 
   dispose() {
+    this.#disposers.forEach((dispose) => dispose())
+
     this.#script.remove(this.#client).catch(() => {
       // Let's just assume we got here because the session was already
       // closed or the script was already removed.

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -1,21 +1,17 @@
 import logger from 'electron-log/main'
-import { z } from 'zod/v4'
 
 import { NavigateToPageEvent, ReloadPageEvent } from '@/schemas/recording'
-import {
-  ChromeDevToolsClient,
-  Page as CdpPage,
-  Runtime as CdpRuntime,
-} from '@/utils/cdp/client'
+import { ChromeDevToolsClient, Page as CdpPage } from '@/utils/cdp/client'
 import { EventEmitter } from '@/utils/events'
 import { uuid } from '@/utils/uuid'
 
-import { Script } from './script'
+import { RECORDER_WORLD_NAME, Script } from './script'
 
-const ExecutionContextAuxDataSchema = z.object({
-  isDefault: z.boolean(),
-  frameId: z.string(),
-})
+// The recording script reads the tab id from this global when it starts up, so
+// every world it runs in has to have it set.
+function tabIdSource(tabId: string) {
+  return `window.__K6_STUDIO_TAB_ID__ = "${tabId}";`
+}
 
 function toNavigationSource(
   event: CdpPage.FrameStartedNavigatingEvent
@@ -58,10 +54,6 @@ export class Page extends EventEmitter<PageEventMap> {
 
   #requestedNavigation: CdpPage.FrameRequestedNavigationEvent | null = null
   #startedNavigation: CdpPage.FrameStartedNavigatingEvent | null = null
-
-  // The default execution context of each frame in the tab. See the
-  // documentOpened handler for why they are tracked.
-  readonly #contexts = new Map<string, CdpRuntime.ExecutionContextId>()
 
   readonly #disposers: Array<() => void> = []
 
@@ -160,78 +152,30 @@ export class Page extends EventEmitter<PageEventMap> {
       this.#reset()
     })
 
-    // The context and document.open handlers below cannot filter by frame id
-    // like the navigation handlers above: they must handle every frame in the
-    // tab (e.g. a frameset child the parent document.write()s into). They
-    // filter by session instead, because the generated CDP client registers
-    // its listeners on the shared transport without applying its per-session
-    // filter, delivering every tab's events to every Page.
+    // The document.open handler below cannot filter by frame id like the
+    // navigation handlers above: it must handle every frame in the tab (e.g. a
+    // frameset child the parent document.write()s into). It filters by session
+    // instead, because the generated CDP client registers its listeners on the
+    // shared transport without applying its per-session filter, delivering
+    // every tab's events to every Page.
     const isOwnSession = (sessionId: string | undefined) =>
       sessionId === this.#client.sessionId
 
     this.#disposers.push(
-      this.#client.runtime.on(
-        'executionContextCreated',
-        ({ sessionId, data }) => {
-          if (!isOwnSession(sessionId)) {
-            return
-          }
-
-          const auxData = ExecutionContextAuxDataSchema.safeParse(
-            data.context.auxData
-          )
-
-          if (!auxData.success || !auxData.data.isDefault) {
-            return
-          }
-
-          this.#contexts.set(auxData.data.frameId, data.context.id)
-        }
-      ),
-
-      this.#client.runtime.on(
-        'executionContextDestroyed',
-        ({ sessionId, data }) => {
-          if (!isOwnSession(sessionId)) {
-            return
-          }
-
-          for (const [frameId, contextId] of this.#contexts) {
-            if (contextId === data.executionContextId) {
-              this.#contexts.delete(frameId)
-            }
-          }
-        }
-      ),
-
-      this.#client.runtime.on('executionContextsCleared', ({ sessionId }) => {
-        if (!isOwnSession(sessionId)) {
-          return
-        }
-
-        this.#contexts.clear()
-      }),
-
       // A document replaced via document.open() loses the recording script's
       // UI and event listeners, and Chromium does not run scripts registered
-      // with Page.addScriptToEvaluateOnNewDocument again for it. The frame's
-      // execution context survives the replacement, so the script is
-      // evaluated there again. Complements the in-page recovery mechanisms
-      // (monitorDocumentChange and keepMountAtEndOfBody in
-      // src/recorder/browser/view), which cannot survive document.open
-      // because their observers die with the old document.
+      // with Page.addScriptToEvaluateOnNewDocument again for it, so the script
+      // is evaluated again in the frame's isolated world. Complements the
+      // in-page recovery mechanisms (monitorDocumentChange and
+      // keepMountAtEndOfBody in src/recorder/browser/view), which cannot
+      // survive document.open because their observers die with the old
+      // document.
       this.#client.page.on('documentOpened', ({ sessionId, data }) => {
         if (!isOwnSession(sessionId)) {
           return
         }
 
-        const contextId = this.#contexts.get(data.frame.id)
-
-        if (contextId === undefined) {
-          return
-        }
-
-        this.#script.evaluate(this.#client, contextId).catch((error) => {
+        this.#reinjectScript(data.frame.id).catch((error) => {
           logger.warn(
             'Failed to re-inject recording script after document.open:',
             error
@@ -291,7 +235,8 @@ export class Page extends EventEmitter<PageEventMap> {
       this.#client.page.setBypassCSP(true),
 
       this.#client.page.addScriptToEvaluateOnNewDocument({
-        source: `window.__K6_STUDIO_TAB_ID__ = "${this.#id}";`,
+        source: tabIdSource(this.#id),
+        worldName: RECORDER_WORLD_NAME,
         runImmediately,
       }),
       this.#script.inject(this.#client, runImmediately),
@@ -336,6 +281,25 @@ export class Page extends EventEmitter<PageEventMap> {
         tab: this.#id,
       },
     })
+  }
+
+  /**
+   * Runs the recording script in the frame's isolated world again. The world
+   * outlives the document it was created for, and `Page.createIsolatedWorld`
+   * returns it when it is still around and creates it otherwise.
+   */
+  async #reinjectScript(frameId: string) {
+    const { executionContextId } = await this.#client.page.createIsolatedWorld({
+      frameId,
+      worldName: RECORDER_WORLD_NAME,
+    })
+
+    await this.#client.runtime.evaluate({
+      expression: tabIdSource(this.#id),
+      contextId: executionContextId,
+    })
+
+    await this.#script.evaluate(this.#client, executionContextId)
   }
 
   navigateTo(url: string) {

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -55,7 +55,10 @@ export class Page extends EventEmitter<PageEventMap> {
   #requestedNavigation: CdpPage.FrameRequestedNavigationEvent | null = null
   #startedNavigation: CdpPage.FrameStartedNavigatingEvent | null = null
 
-  readonly #disposers: Array<() => void> = []
+  // The navigation handlers in the constructor are never unregistered (a Page
+  // outliving its CDP session only leaks no-op listeners), but documentOpened
+  // triggers multi-megabyte evaluates, so it must stop with the Page.
+  #disposeDocumentOpened = () => {}
 
   // Whether any navigation has been recorded for this tab. See
   // #recordMissedEntryNavigation.
@@ -152,26 +155,28 @@ export class Page extends EventEmitter<PageEventMap> {
       this.#reset()
     })
 
-    // The document.open handler below cannot filter by frame id like the
-    // navigation handlers above: it must handle every frame in the tab (e.g. a
-    // frameset child the parent document.write()s into). It filters by session
-    // instead, because the generated CDP client registers its listeners on the
-    // shared transport without applying its per-session filter, delivering
-    // every tab's events to every Page.
-    const isOwnSession = (sessionId: string | undefined) =>
-      sessionId === this.#client.sessionId
-
-    this.#disposers.push(
-      // A document replaced via document.open() loses the recording script's
-      // UI and event listeners, and Chromium does not run scripts registered
-      // with Page.addScriptToEvaluateOnNewDocument again for it, so the script
-      // is evaluated again in the frame's isolated world. Complements the
-      // in-page recovery mechanisms (monitorDocumentChange and
-      // keepMountAtEndOfBody in src/recorder/browser/view), which cannot
-      // survive document.open because their observers die with the old
-      // document.
-      this.#client.page.on('documentOpened', ({ sessionId, data }) => {
-        if (!isOwnSession(sessionId)) {
+    // A document replaced via document.open() loses the recording script's
+    // UI and event listeners, and Chromium does not run scripts registered
+    // with Page.addScriptToEvaluateOnNewDocument again for it, so the script
+    // is evaluated again in the frame's isolated world. Complements the
+    // in-page recovery mechanisms (monitorDocumentChange and
+    // keepMountAtEndOfBody in src/recorder/browser/view), which cannot
+    // survive document.open because their observers die with the old
+    // document.
+    //
+    // Unlike the navigation handlers above, this handler cannot filter by
+    // frame id: it must handle every frame in the tab (e.g. a frameset child
+    // the parent document.write()s into). It filters by session because the
+    // generated CDP client delivers every tab's events to every Page.
+    // TODO: That is a bug in generateCdpClient.ts — `on` builds a session
+    // filter but registers the raw listener (`off` needs the symmetric fix).
+    // The frame id checks in the handlers above only double as session
+    // filters by accident, because a page target's frame id equals its
+    // target id.
+    this.#disposeDocumentOpened = this.#client.page.on(
+      'documentOpened',
+      ({ sessionId, data }) => {
+        if (sessionId !== this.#client.sessionId) {
           return
         }
 
@@ -181,7 +186,7 @@ export class Page extends EventEmitter<PageEventMap> {
             error
           )
         })
-      })
+      }
     )
 
     this.#script.on('reload', () => {
@@ -336,7 +341,7 @@ export class Page extends EventEmitter<PageEventMap> {
   }
 
   dispose() {
-    this.#disposers.forEach((dispose) => dispose())
+    this.#disposeDocumentOpened()
 
     this.#script.remove(this.#client).catch(() => {
       // Let's just assume we got here because the session was already

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -168,8 +168,11 @@ export class Page extends EventEmitter<PageEventMap> {
     // frame id: it must handle every frame in the tab (e.g. a frameset child
     // the parent document.write()s into). It filters by session because the
     // generated CDP client delivers every tab's events to every Page.
-    // TODO: That is a bug in generateCdpClient.ts — `on` builds a session
-    // filter but registers the raw listener (`off` needs the symmetric fix).
+    // TODO: That is a bug in generateCdpClient.ts: `on` builds a session
+    // filter but registers the raw listener. The generator is fixed to
+    // register filteredListener, but client.ts could not be regenerated
+    // (gen:cdp currently fails with TS5011), so this guard stays until a
+    // regenerated client ships.
     // The frame id checks in the handlers above only double as session
     // filters by accident, because a page target's frame id equals its
     // target id.
@@ -299,10 +302,16 @@ export class Page extends EventEmitter<PageEventMap> {
       worldName: RECORDER_WORLD_NAME,
     })
 
-    await this.#client.runtime.evaluate({
+    const { exceptionDetails } = await this.#client.runtime.evaluate({
       expression: tabIdSource(this.#id),
       contextId: executionContextId,
     })
+
+    if (exceptionDetails !== undefined) {
+      throw new Error(
+        `Failed to set tab id: ${exceptionDetails.exception?.description ?? exceptionDetails.text}`
+      )
+    }
 
     await this.#script.evaluate(this.#client, executionContextId)
   }

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -197,15 +197,6 @@ export class Page extends EventEmitter<PageEventMap> {
     isInitialTab: boolean
     hasOpener: boolean
   }) {
-    // A target paused waiting for the debugger (e.g. a popup opened with
-    // noopener/noreferrer, which gets a new browsing context group) doesn't
-    // process session commands until Runtime.runIfWaitingForDebugger is sent,
-    // so awaiting any response before requesting resume would deadlock and
-    // leave the tab paused with a spinner forever. All commands are therefore
-    // dispatched up front and only then awaited. The transport sends messages
-    // in call order, so the scripts are still registered before the page
-    // resumes.
-    //
     // Scripts run immediately only in tabs the page did not open itself. A
     // popup the page opened (window.open, target=_blank) attaches before its
     // document exists, and executing the recording script in its empty
@@ -217,6 +208,19 @@ export class Page extends EventEmitter<PageEventMap> {
     // so the scripts must also run in whatever document already exists.
     const runImmediately = !hasOpener
 
+    // We tell the browser to pause and wait for a debugger whenever a new target
+    // is created so that we can attach to it and inject our scripts before the page
+    // runs any of its own scripts. While the target is waiting for a debugger,
+    // all commands are queued up and are only executed after `runIfWaitingForDebugger`
+    // is sent.
+    //
+    // If we were to await any of the calls below individually then we'd never reach
+    // the call to `runIfWaitingForDebugger` because we're stuck in the queue waiting
+    // for `runIfWaitingForDebugger` to be called.
+    //
+    // Calling them this way queues the commands up in the correct order without blocking
+    // the call to `runIfWaitingForDebugger` and by awaiting `Promise.all` we can still
+    // wait for all commands to be completed before continuing with out logic.
     await Promise.all([
       this.#client.page.enable(),
 

--- a/src/recorder/launchers/cdp/page.ts
+++ b/src/recorder/launchers/cdp/page.ts
@@ -166,23 +166,14 @@ export class Page extends EventEmitter<PageEventMap> {
     //
     // Unlike the navigation handlers above, this handler cannot filter by
     // frame id: it must handle every frame in the tab (e.g. a frameset child
-    // the parent document.write()s into). It filters by session because the
-    // generated CDP client delivers every tab's events to every Page.
-    // TODO: That is a bug in generateCdpClient.ts: `on` builds a session
-    // filter but registers the raw listener. The generator is fixed to
-    // register filteredListener, but client.ts could not be regenerated
-    // (gen:cdp currently fails with TS5011), so this guard stays until a
-    // regenerated client ships.
+    // the parent document.write()s into). The session is filtered by the
+    // client, which only forwards the events of the session it is bound to.
     // The frame id checks in the handlers above only double as session
     // filters by accident, because a page target's frame id equals its
     // target id.
     this.#disposeDocumentOpened = this.#client.page.on(
       'documentOpened',
-      ({ sessionId, data }) => {
-        if (sessionId !== this.#client.sessionId) {
-          return
-        }
-
+      ({ data }) => {
         this.#reinjectScript(data.frame.id).catch((error) => {
           logger.warn(
             'Failed to re-inject recording script after document.open:',

--- a/src/recorder/launchers/cdp/script.ts
+++ b/src/recorder/launchers/cdp/script.ts
@@ -1,6 +1,12 @@
 import { ChromeDevToolsClient, Runtime } from '@/utils/cdp/client'
 import { EventEmitter } from '@/utils/events'
 
+// The recording script runs in an isolated world so that it neither collides
+// with the page's own globals nor is broken by pages that mangle built-ins.
+// Anything that has to reach it (the tab id global, re-injection after
+// document.open) must target the same world.
+export const RECORDER_WORLD_NAME = 'k6-studio-recorder'
+
 interface ScriptEventMap {
   reload: EmptyObject
 }
@@ -25,6 +31,7 @@ export class Script extends EventEmitter<ScriptEventMap> {
   async inject(client: ChromeDevToolsClient, runImmediately: boolean) {
     const { identifier } = await client.page.addScriptToEvaluateOnNewDocument({
       source: this.#content,
+      worldName: RECORDER_WORLD_NAME,
       runImmediately,
     })
 

--- a/src/recorder/launchers/cdp/script.ts
+++ b/src/recorder/launchers/cdp/script.ts
@@ -48,10 +48,19 @@ export class Script extends EventEmitter<ScriptEventMap> {
     client: ChromeDevToolsClient,
     contextId: Runtime.ExecutionContextId
   ) {
-    await client.runtime.evaluate({
+    const { exceptionDetails } = await client.runtime.evaluate({
       expression: this.#content,
       contextId,
     })
+
+    // Runtime.evaluate reports a throwing expression on an otherwise
+    // successful response, which would silently pass for a working
+    // re-injection.
+    if (exceptionDetails !== undefined) {
+      throw new Error(
+        `Script threw during evaluation: ${exceptionDetails.exception?.description ?? exceptionDetails.text}`
+      )
+    }
   }
 
   async remove(client: ChromeDevToolsClient) {

--- a/src/recorder/launchers/cdp/script.ts
+++ b/src/recorder/launchers/cdp/script.ts
@@ -1,4 +1,4 @@
-import { ChromeDevToolsClient } from '@/utils/cdp/client'
+import { ChromeDevToolsClient, Runtime } from '@/utils/cdp/client'
 import { EventEmitter } from '@/utils/events'
 
 interface ScriptEventMap {
@@ -29,6 +29,22 @@ export class Script extends EventEmitter<ScriptEventMap> {
     })
 
     this.#sessions.push({ client, scriptId: identifier })
+  }
+
+  /**
+   * Evaluates the script in an existing execution context. Used for documents
+   * that replaced an already-injected document (e.g. via `document.open()`),
+   * where scripts registered with `Page.addScriptToEvaluateOnNewDocument` are
+   * not run again.
+   */
+  async evaluate(
+    client: ChromeDevToolsClient,
+    contextId: Runtime.ExecutionContextId
+  ) {
+    await client.runtime.evaluate({
+      expression: this.#content,
+      contextId,
+    })
   }
 
   async remove(client: ChromeDevToolsClient) {

--- a/src/recorder/launchers/cdp/script.ts
+++ b/src/recorder/launchers/cdp/script.ts
@@ -38,12 +38,6 @@ export class Script extends EventEmitter<ScriptEventMap> {
     this.#sessions.push({ client, scriptId: identifier })
   }
 
-  /**
-   * Evaluates the script in an existing execution context. Used for documents
-   * that replaced an already-injected document (e.g. via `document.open()`),
-   * where scripts registered with `Page.addScriptToEvaluateOnNewDocument` are
-   * not run again.
-   */
   async evaluate(
     client: ChromeDevToolsClient,
     contextId: Runtime.ExecutionContextId

--- a/src/recorder/server.test.ts
+++ b/src/recorder/server.test.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/main'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { BrowserExtensionMessageSchema } from '@/recorder/browser/messaging/types'
+import { createInputChangeEvent } from '@/test/factories/browserEvents'
 
 import { createInvalidMessageReporter } from './server'
 
@@ -21,7 +22,7 @@ function createValidationError() {
   const result = BrowserExtensionMessageSchema.safeParse({
     type: 'record-events',
     events: JSON.stringify([
-      { type: 'input-change', sensitive: true, value: RECORDED_PASSWORD },
+      createInputChangeEvent({ sensitive: true, value: RECORDED_PASSWORD }),
     ]),
   })
 

--- a/src/recorder/server.test.ts
+++ b/src/recorder/server.test.ts
@@ -1,0 +1,79 @@
+import * as Sentry from '@sentry/electron/main'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { BrowserExtensionMessageSchema } from '@/recorder/browser/messaging/types'
+
+import { createInvalidMessageReporter } from './server'
+
+vi.mock('@sentry/electron/main', () => ({
+  captureMessage: vi.fn(),
+}))
+
+const captureMessage = vi.mocked(Sentry.captureMessage)
+
+const RECORDED_PASSWORD = 'correct-horse-battery-staple'
+
+/**
+ * Produces a real validation error for the message a polluted page sends:
+ * `events` double-encoded as a string, carrying recorded user input.
+ */
+function createValidationError() {
+  const result = BrowserExtensionMessageSchema.safeParse({
+    type: 'record-events',
+    events: JSON.stringify([
+      { type: 'input-change', sensitive: true, value: RECORDED_PASSWORD },
+    ]),
+  })
+
+  if (result.success) {
+    throw new Error('expected the message to fail validation')
+  }
+
+  return result.error
+}
+
+describe('createInvalidMessageReporter', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports the validation issues to Sentry', () => {
+    const error = createValidationError()
+
+    createInvalidMessageReporter()(error)
+
+    expect(captureMessage).toHaveBeenCalledWith(
+      'Browser extension client received an invalid message',
+      {
+        level: 'warning',
+        tags: { component: 'browser-extension-messaging' },
+        extra: {
+          issues: [
+            {
+              path: 'events',
+              code: 'invalid_type',
+              message: error.issues[0]?.message,
+            },
+          ],
+        },
+      }
+    )
+  })
+
+  it('never sends recorded data to Sentry', () => {
+    createInvalidMessageReporter()(createValidationError())
+
+    expect(JSON.stringify(captureMessage.mock.calls)).not.toContain(
+      RECORDED_PASSWORD
+    )
+  })
+
+  it('reports only the first invalid message', () => {
+    const report = createInvalidMessageReporter()
+
+    report(createValidationError())
+    report(createValidationError())
+
+    expect(captureMessage).toHaveBeenCalledOnce()
+  })
+})

--- a/src/recorder/server.ts
+++ b/src/recorder/server.ts
@@ -1,3 +1,6 @@
+import { captureMessage } from '@sentry/electron/main'
+import type { z } from 'zod/v4'
+
 import { BrowserExtensionClient } from '@/recorder/browser/messaging'
 import { WebSocketServerTransport } from '@/recorder/browser/messaging/transports/webSocketServer'
 import {
@@ -19,6 +22,39 @@ type BrowserExtensionServerEvents = {
   focus: { tab: string }
 }
 
+/**
+ * Reports messages the browser rejected as invalid. A page that breaks the
+ * transport breaks every message it sends, e.g. a script polluting
+ * Array.prototype with toJSON double-encodes the events we receive, so we only
+ * report the first failure instead of flooding Sentry for the whole session.
+ */
+export function createInvalidMessageReporter() {
+  let reported = false
+
+  return (error: z.ZodError) => {
+    if (reported) {
+      return
+    }
+
+    reported = true
+
+    captureMessage('Browser extension client received an invalid message', {
+      level: 'warning',
+      tags: { component: 'browser-extension-messaging' },
+      extra: {
+        // Only zod's issue metadata is safe to send. The message that failed
+        // validation holds recorded user input, including passwords typed into
+        // the page, so never attach the message or any part of it here.
+        issues: error.issues.map((issue) => ({
+          path: issue.path.map(String).join('.'),
+          code: issue.code,
+          message: issue.message,
+        })),
+      },
+    })
+  }
+}
+
 export class BrowserServer extends EventEmitter<BrowserExtensionServerEvents> {
   #client: BrowserExtensionClient
 
@@ -28,7 +64,9 @@ export class BrowserServer extends EventEmitter<BrowserExtensionServerEvents> {
     const transport = await WebSocketServerTransport.create('127.0.0.1', 7554)
 
     return new BrowserServer(
-      new BrowserExtensionClient('studio-server', transport)
+      new BrowserExtensionClient('studio-server', transport, {
+        onInvalidMessage: createInvalidMessageReporter(),
+      })
     )
   }
 

--- a/src/utils/cdp/client.ts
+++ b/src/utils/cdp/client.ts
@@ -7855,7 +7855,7 @@ export namespace Schema {
 class AccessibilityClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -7942,39 +7942,44 @@ class AccessibilityClient {
     listener: (event: ChromeEvent<Accessibility.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Accessibility.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Accessibility.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Accessibility.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Accessibility.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class AnimationClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8067,39 +8072,44 @@ class AnimationClient {
     listener: (event: ChromeEvent<Animation.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Animation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Animation.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Animation.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Animation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class AuditsClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8152,33 +8162,44 @@ class AuditsClient {
     listener: (event: ChromeEvent<Audits.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Audits.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Audits.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Audits.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Audits.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Audits.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Audits.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class AutofillClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8221,39 +8242,44 @@ class AutofillClient {
     listener: (event: ChromeEvent<Autofill.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Autofill.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Autofill.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Autofill.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Autofill.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class BackgroundServiceClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8296,39 +8322,44 @@ class BackgroundServiceClient {
     listener: (event: ChromeEvent<BackgroundService.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'BackgroundService.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof BackgroundService.EventMap>(
     name: K,
     listener: (event: ChromeEvent<BackgroundService.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'BackgroundService.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class BluetoothEmulationClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8475,39 +8506,44 @@ class BluetoothEmulationClient {
     listener: (event: ChromeEvent<BluetoothEmulation.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'BluetoothEmulation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof BluetoothEmulation.EventMap>(
     name: K,
     listener: (event: ChromeEvent<BluetoothEmulation.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'BluetoothEmulation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class BrowserClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -8688,36 +8724,44 @@ class BrowserClient {
     listener: (event: ChromeEvent<Browser.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Browser.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Browser.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Browser.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Browser.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Browser.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class CSSClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9062,33 +9106,44 @@ class CSSClient {
     listener: (event: ChromeEvent<CSS.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'CSS.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('CSS.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof CSS.EventMap>(
     name: K,
     listener: (event: ChromeEvent<CSS.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('CSS.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'CSS.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class CacheStorageClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9144,7 +9199,7 @@ class CacheStorageClient {
 class CastClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9203,33 +9258,44 @@ class CastClient {
     listener: (event: ChromeEvent<Cast.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Cast.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Cast.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Cast.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Cast.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Cast.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Cast.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class DOMClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9700,33 +9766,44 @@ class DOMClient {
     listener: (event: ChromeEvent<DOM.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'DOM.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('DOM.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof DOM.EventMap>(
     name: K,
     listener: (event: ChromeEvent<DOM.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('DOM.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'DOM.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class DOMDebuggerClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9826,7 +9903,7 @@ class DOMDebuggerClient {
 class DOMSnapshotClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9872,7 +9949,7 @@ class DOMSnapshotClient {
 class DOMStorageClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -9935,39 +10012,44 @@ class DOMStorageClient {
     listener: (event: ChromeEvent<DOMStorage.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'DOMStorage.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof DOMStorage.EventMap>(
     name: K,
     listener: (event: ChromeEvent<DOMStorage.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'DOMStorage.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class DeviceAccessClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10010,39 +10092,44 @@ class DeviceAccessClient {
     listener: (event: ChromeEvent<DeviceAccess.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'DeviceAccess.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof DeviceAccess.EventMap>(
     name: K,
     listener: (event: ChromeEvent<DeviceAccess.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'DeviceAccess.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class DeviceOrientationClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10070,7 +10157,7 @@ class DeviceOrientationClient {
 class EmulationClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10486,39 +10573,44 @@ class EmulationClient {
     listener: (event: ChromeEvent<Emulation.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Emulation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Emulation.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Emulation.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Emulation.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class EventBreakpointsClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10552,7 +10644,7 @@ class EventBreakpointsClient {
 class ExtensionsClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10612,7 +10704,7 @@ class ExtensionsClient {
 class FedCmClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10679,33 +10771,44 @@ class FedCmClient {
     listener: (event: ChromeEvent<FedCm.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'FedCm.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('FedCm.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof FedCm.EventMap>(
     name: K,
     listener: (event: ChromeEvent<FedCm.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('FedCm.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'FedCm.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class FetchClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10792,33 +10895,44 @@ class FetchClient {
     listener: (event: ChromeEvent<Fetch.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Fetch.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Fetch.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Fetch.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Fetch.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Fetch.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Fetch.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class FileSystemClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10838,7 +10952,7 @@ class FileSystemClient {
 class HeadlessExperimentalClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10874,7 +10988,7 @@ class HeadlessExperimentalClient {
 class IOClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -10908,7 +11022,7 @@ class IOClient {
 class IndexedDBClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11000,7 +11114,7 @@ class IndexedDBClient {
 class InputClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11121,33 +11235,44 @@ class InputClient {
     listener: (event: ChromeEvent<Input.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Input.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Input.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Input.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Input.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Input.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Input.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class InspectorClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11174,39 +11299,44 @@ class InspectorClient {
     listener: (event: ChromeEvent<Inspector.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Inspector.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Inspector.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Inspector.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Inspector.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class LayerTreeClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11301,39 +11431,44 @@ class LayerTreeClient {
     listener: (event: ChromeEvent<LayerTree.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'LayerTree.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof LayerTree.EventMap>(
     name: K,
     listener: (event: ChromeEvent<LayerTree.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'LayerTree.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class LogClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11384,33 +11519,44 @@ class LogClient {
     listener: (event: ChromeEvent<Log.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Log.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Log.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Log.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Log.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Log.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Log.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class MediaClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11437,33 +11583,44 @@ class MediaClient {
     listener: (event: ChromeEvent<Media.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Media.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Media.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Media.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Media.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Media.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Media.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class MemoryClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11561,7 +11718,7 @@ class MemoryClient {
 class NetworkClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -11920,36 +12077,44 @@ class NetworkClient {
     listener: (event: ChromeEvent<Network.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Network.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Network.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Network.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Network.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Network.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class OverlayClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -12216,36 +12381,44 @@ class OverlayClient {
     listener: (event: ChromeEvent<Overlay.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Overlay.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Overlay.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Overlay.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Overlay.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Overlay.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class PWAClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -12313,7 +12486,7 @@ class PWAClient {
 class PageClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -12855,33 +13028,44 @@ class PageClient {
     listener: (event: ChromeEvent<Page.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Page.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Page.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Page.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Page.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Page.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Page.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class PerformanceClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -12924,39 +13108,44 @@ class PerformanceClient {
     listener: (event: ChromeEvent<Performance.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Performance.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Performance.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Performance.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Performance.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class PerformanceTimelineClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -12975,39 +13164,44 @@ class PerformanceTimelineClient {
     listener: (event: ChromeEvent<PerformanceTimeline.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'PerformanceTimeline.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof PerformanceTimeline.EventMap>(
     name: K,
     listener: (event: ChromeEvent<PerformanceTimeline.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'PerformanceTimeline.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class PreloadClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13034,36 +13228,44 @@ class PreloadClient {
     listener: (event: ChromeEvent<Preload.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Preload.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Preload.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Preload.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Preload.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Preload.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class SecurityClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13116,39 +13318,44 @@ class SecurityClient {
     listener: (event: ChromeEvent<Security.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Security.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Security.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Security.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Security.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class ServiceWorkerClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13259,39 +13466,44 @@ class ServiceWorkerClient {
     listener: (event: ChromeEvent<ServiceWorker.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'ServiceWorker.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof ServiceWorker.EventMap>(
     name: K,
     listener: (event: ChromeEvent<ServiceWorker.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'ServiceWorker.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class StorageClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13634,36 +13846,44 @@ class StorageClient {
     listener: (event: ChromeEvent<Storage.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Storage.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Storage.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Storage.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Storage.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Storage.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class SystemInfoClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13699,7 +13919,7 @@ class SystemInfoClient {
 class TargetClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13878,33 +14098,44 @@ class TargetClient {
     listener: (event: ChromeEvent<Target.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Target.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Target.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Target.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Target.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
-    return this.transport.off('Target.' + name, listener as ChromeEventListener)
+    listenersByName.delete(name)
+    return this.transport.off(
+      'Target.' + name,
+      filteredListener as ChromeEventListener
+    )
   }
 }
 class TetheringClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -13931,39 +14162,44 @@ class TetheringClient {
     listener: (event: ChromeEvent<Tethering.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Tethering.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Tethering.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Tethering.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Tethering.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class TracingClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14024,36 +14260,44 @@ class TracingClient {
     listener: (event: ChromeEvent<Tracing.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Tracing.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Tracing.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Tracing.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Tracing.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Tracing.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class WebAudioClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14090,39 +14334,44 @@ class WebAudioClient {
     listener: (event: ChromeEvent<WebAudio.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'WebAudio.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof WebAudio.EventMap>(
     name: K,
     listener: (event: ChromeEvent<WebAudio.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'WebAudio.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class WebAuthnClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14251,39 +14500,44 @@ class WebAuthnClient {
     listener: (event: ChromeEvent<WebAuthn.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'WebAuthn.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof WebAuthn.EventMap>(
     name: K,
     listener: (event: ChromeEvent<WebAuthn.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'WebAuthn.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class ConsoleClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14318,36 +14572,44 @@ class ConsoleClient {
     listener: (event: ChromeEvent<Console.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Console.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Console.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Console.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Console.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Console.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class DebuggerClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14654,39 +14916,44 @@ class DebuggerClient {
     listener: (event: ChromeEvent<Debugger.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Debugger.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Debugger.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Debugger.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Debugger.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class HeapProfilerClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14801,39 +15068,44 @@ class HeapProfilerClient {
     listener: (event: ChromeEvent<HeapProfiler.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'HeapProfiler.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof HeapProfiler.EventMap>(
     name: K,
     listener: (event: ChromeEvent<HeapProfiler.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'HeapProfiler.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class ProfilerClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -14918,39 +15190,44 @@ class ProfilerClient {
     listener: (event: ChromeEvent<Profiler.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
-      filteredListener as ChromeEventListener
-    )
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
     return this.transport.on(
       'Profiler.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
   off<K extends keyof Profiler.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Profiler.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Profiler.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class RuntimeClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId
@@ -15159,36 +15436,44 @@ class RuntimeClient {
     listener: (event: ChromeEvent<Runtime.EventMap[K]>) => void
   ): () => void {
     const filteredListener: typeof listener = (event) => {
-      if (event.sessionId !== this.sessionId) {
+      if (this.sessionId !== undefined && event.sessionId !== this.sessionId) {
         return
       }
       listener(event)
     }
-    this.listeners.set(
-      listener as ChromeEventListener,
+    const listenersByName =
+      this.listeners.get(listener as ChromeEventListener) ??
+      new Map<string, ChromeEventListener>()
+    listenersByName.set(name, filteredListener as ChromeEventListener)
+    this.listeners.set(listener as ChromeEventListener, listenersByName)
+    return this.transport.on(
+      'Runtime.' + name,
       filteredListener as ChromeEventListener
     )
-    return this.transport.on('Runtime.' + name, listener as ChromeEventListener)
   }
   off<K extends keyof Runtime.EventMap>(
     name: K,
     listener: (event: ChromeEvent<Runtime.EventMap[K]>) => void
   ): void {
-    const filteredListener = this.listeners.get(listener as ChromeEventListener)
+    const listenersByName = this.listeners.get(listener as ChromeEventListener)
+    if (listenersByName === undefined) {
+      return
+    }
+    const filteredListener = listenersByName.get(name)
     if (filteredListener === undefined) {
       return
     }
-    this.listeners.delete(listener as ChromeEventListener)
+    listenersByName.delete(name)
     return this.transport.off(
       'Runtime.' + name,
-      listener as ChromeEventListener
+      filteredListener as ChromeEventListener
     )
   }
 }
 class SchemaClient {
   transport: Transport
   sessionId: Target.SessionID | undefined
-  listeners: WeakMap<ChromeEventListener, ChromeEventListener>
+  listeners: WeakMap<ChromeEventListener, Map<string, ChromeEventListener>>
   constructor(transport: Transport, sessionId?: Target.SessionID) {
     this.transport = transport
     this.sessionId = sessionId

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,11 @@
     ]
   },
   "ts-node": {
-    "require": ["tsconfig-paths/register"]
+    "require": ["tsconfig-paths/register"],
+    "compilerOptions": {
+      "rootDir": ".",
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext"
+    }
   }
 }

--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, type ConfigEnv, type UserConfig } from 'vite'
 // https://vitejs.dev/config
 export default defineConfig((env) => {
   const forgeEnv = env as ConfigEnv<'renderer'>
-  const { root, mode } = forgeEnv
+  const { root, mode, command } = forgeEnv
   const nodeEnv = process.env.NODE_ENV || 'production'
 
   return {
@@ -25,7 +25,12 @@ export default defineConfig((env) => {
     build: {
       target: 'esnext',
       outDir: `resources/browser`,
-      sourcemap: 'inline',
+      // Inline only in dev: the bundle is evaluated from a string, so a
+      // separate .js.map with a relative sourceMappingURL could never resolve
+      // (worse, the fetch would go through the recording proxy). In packaged
+      // builds nothing consumes the map, and it made up ~79% of the bundle
+      // that gets shipped over CDP on every injection.
+      sourcemap: command === 'serve' ? 'inline' : false,
       lib: {
         entry: 'src/recorder/browser/index.ts',
         formats: ['iife'],

--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -25,11 +25,6 @@ export default defineConfig((env) => {
     build: {
       target: 'esnext',
       outDir: `resources/browser`,
-      // Inline only in dev: the bundle is evaluated from a string, so a
-      // separate .js.map with a relative sourceMappingURL could never resolve
-      // (worse, the fetch would go through the recording proxy). In packaged
-      // builds nothing consumes the map, and it made up ~79% of the bundle
-      // that gets shipped over CDP on every injection.
       sourcemap: command === 'serve' ? 'inline' : false,
       lib: {
         entry: 'src/recorder/browser/index.ts',


### PR DESCRIPTION
## Description

Recording a site built with Prototype.js 1.6 produces no toolbar and no recorded browser actions, and session replay of the same site is blank. The recording script used to run in the page's main world, so the page's overrides of `toJSON`, `Function.prototype.bind` and `Array.from` corrupted both the recorder's event envelopes (silently rejected by the app) and the toolbar rendering, and pages that rewrite themselves with `document.open()` additionally wiped the injected script mid-recording.

- The recording script now runs in a CDP isolated world (the content-script model), so page-level JavaScript can no longer break it.
- `Page.documentOpened` triggers re-injection, so the toolbar and event capture survive `document.open()` rewrites. The runtime is reused across re-injections instead of leaking a connection each time.
- Each in-browser UI feature is wrapped in an error boundary, and a double-injection guard prevents two UI instances from fighting over the DOM (previously an infinite mutation loop that froze the recorded page).
- Invalid browser extension messages are reported to Sentry (validation issues only, never the payload), so this failure class is visible instead of silent.
- Session replay has to stay in the main world (k6 injects init scripts there), so it sidesteps the pollution instead: the event serializer ignores page-added `toJSON` methods, and `Array.from` is pinned to the native so rrweb's stylesheet inlining keeps working. Fixes blank and unstyled replays.

## How to Test

Save as `index.html`, serve with `python3 -m http.server 8000`:

```html
<!doctype html>
<html>
  <head>
    <script src="https://ajax.googleapis.com/ajax/libs/prototype/1.6.0.3/prototype.js"></script>
    <style>body { background: #e8f5e9; font-size: 18px }</style>
  </head>
  <body>
    <input id="user" placeholder="user" />
    <button onclick="document.open(); document.write('<input id=next><button>done</button>'); document.close()">
      rewrite
    </button>
  </body>
</html>
```

1. Record `http://localhost:8000`: the toolbar shows, typing and clicks are recorded. Before: no toolbar, no browser events, `Received invalid message` warnings in the app log.
2. Click `rewrite`: the toolbar survives the rewrite and actions on the new content keep recording. Before: toolbar and capture gone until the next navigation.
3. Generate a browser test from the recording and validate it: the session replay preview is populated and styled. Before: blank preview while the test itself passes.

## Checklist

- [ ] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Related: https://github.com/grafana/k6-studio/pull/1348 (restores the toolbar after app rehydration; does not cover main-world pollution or `document.open()`)
