### PR TITLE
fix(assistant): Offer a way out when a hibernating stack needs a captcha

### DIFF
--- a/src/components/Assistant/AssistantAuthGate.test.tsx
+++ b/src/components/Assistant/AssistantAuthGate.test.tsx
@@ -37,6 +37,8 @@ vi.mock('@/hooks/useStackHealth', () => ({
 const trackEvent = vi.fn()
 const openExternalLink = vi.fn().mockResolvedValue(undefined)
 
+const stackUrl = 'https://mystack.grafana.net'
+
 beforeEach(() => {
   vi.clearAllMocks()
 
@@ -98,7 +100,7 @@ describe('AssistantAuthGate (hibernating stack)', () => {
   it('asks the user to open their instance when it waits for a captcha', () => {
     useStackHealthMock.mockReturnValue({
       isStackReady: false,
-      captchaUrl: 'https://mystack.grafana.net',
+      captchaUrl: stackUrl,
     })
 
     renderGate()

--- a/src/components/Assistant/AssistantAuthGate.test.tsx
+++ b/src/components/Assistant/AssistantAuthGate.test.tsx
@@ -3,10 +3,23 @@ import { render, screen } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { AssistantAuthStatus } from '@/handlers/ai/a2a/assistantAuth'
+import type { useStackHealth } from '@/hooks/useStackHealth'
+
 import { AssistantAuthGate } from './AssistantAuthGate'
 
+type AuthStatusQuery = {
+  data: AssistantAuthStatus | undefined
+  isLoading: boolean
+}
+
+const { useAssistantAuthStatusMock, useStackHealthMock } = vi.hoisted(() => ({
+  useAssistantAuthStatusMock: vi.fn<() => AuthStatusQuery>(),
+  useStackHealthMock: vi.fn<() => ReturnType<typeof useStackHealth>>(),
+}))
+
 vi.mock('@/hooks/useAssistantAuth', () => ({
-  useAssistantAuthStatus: () => ({ data: undefined, isLoading: false }),
+  useAssistantAuthStatus: () => useAssistantAuthStatusMock(),
   useAssistantSignIn: () => ({
     isPending: false,
     mutate: vi.fn(),
@@ -18,7 +31,7 @@ vi.mock('@/hooks/useAssistantAuth', () => ({
 }))
 
 vi.mock('@/hooks/useStackHealth', () => ({
-  useStackHealth: () => ({ isStackReady: true }),
+  useStackHealth: () => useStackHealthMock(),
 }))
 
 const trackEvent = vi.fn()
@@ -26,6 +39,12 @@ const openExternalLink = vi.fn().mockResolvedValue(undefined)
 
 beforeEach(() => {
   vi.clearAllMocks()
+
+  useAssistantAuthStatusMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+  })
+  useStackHealthMock.mockReturnValue({ isStackReady: true, captchaUrl: null })
 
   vi.stubGlobal('studio', {
     app: { trackEvent },
@@ -65,5 +84,50 @@ describe('AssistantAuthGate (signed out)', () => {
     expect(trackEvent).toHaveBeenCalledWith({
       event: 'test_setup_wizard_sign_up_clicked',
     })
+  })
+})
+
+describe('AssistantAuthGate (hibernating stack)', () => {
+  beforeEach(() => {
+    useAssistantAuthStatusMock.mockReturnValue({
+      data: { authenticated: true, stackId: '1', stackName: 'my-stack' },
+      isLoading: false,
+    })
+  })
+
+  it('asks the user to open their instance when it waits for a captcha', () => {
+    useStackHealthMock.mockReturnValue({
+      isStackReady: false,
+      captchaUrl: 'https://mystack.grafana.net',
+    })
+
+    renderGate()
+
+    expect(
+      screen.getByRole('button', { name: 'Open my instance' })
+    ).toBeDefined()
+    expect(screen.queryByText('Your Grafana instance is loading...')).toBeNull()
+  })
+
+  it('keeps showing the spinner while the instance boots on its own', () => {
+    useStackHealthMock.mockReturnValue({
+      isStackReady: false,
+      captchaUrl: null,
+    })
+
+    renderGate()
+
+    expect(
+      screen.getByText('Your Grafana instance is loading...')
+    ).toBeDefined()
+    expect(
+      screen.queryByRole('button', { name: 'Open my instance' })
+    ).toBeNull()
+  })
+
+  it('renders its children once the stack is ready', () => {
+    renderGate()
+
+    expect(screen.getByTestId('wizard-content')).toBeDefined()
   })
 })

--- a/src/components/Assistant/AssistantAuthGate.tsx
+++ b/src/components/Assistant/AssistantAuthGate.tsx
@@ -14,6 +14,8 @@ import {
 import { useStackHealth } from '@/hooks/useStackHealth'
 import { UsageEventName } from '@/services/usageTracking/types'
 
+import { StackWakePrompt } from './StackWakePrompt'
+
 interface AssistantAuthGateProps {
   /** Rendered once the user is signed in, connected, and the stack is ready. */
   children: ReactNode
@@ -140,7 +142,16 @@ export function AssistantAuthGate({ children }: AssistantAuthGateProps) {
 }
 
 function StackHealthGate({ children }: AssistantAuthGateProps) {
-  const { isStackReady } = useStackHealth(true)
+  const { isStackReady, captchaUrl } = useStackHealth(true)
+
+  if (captchaUrl) {
+    return (
+      <GateLayout>
+        <GrafanaLogo />
+        <StackWakePrompt url={captchaUrl} />
+      </GateLayout>
+    )
+  }
 
   if (!isStackReady) {
     return (

--- a/src/components/Assistant/StackWakePrompt.test.tsx
+++ b/src/components/Assistant/StackWakePrompt.test.tsx
@@ -1,0 +1,34 @@
+import { Theme } from '@radix-ui/themes'
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { StackWakePrompt } from './StackWakePrompt'
+
+const openExternalLink = vi.fn().mockResolvedValue(undefined)
+
+const stackUrl = 'https://mystack.grafana.net'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  vi.stubGlobal('studio', {
+    browser: { openExternalLink },
+  })
+})
+
+describe('StackWakePrompt', () => {
+  it('opens the instance in the default browser', async () => {
+    render(
+      <Theme>
+        <StackWakePrompt url={stackUrl} />
+      </Theme>
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Open my instance' })
+    )
+
+    expect(openExternalLink).toHaveBeenCalledWith(stackUrl)
+  })
+})

--- a/src/components/Assistant/StackWakePrompt.tsx
+++ b/src/components/Assistant/StackWakePrompt.tsx
@@ -1,0 +1,27 @@
+import { Button, Flex, Text } from '@radix-ui/themes'
+import { ExternalLinkIcon } from 'lucide-react'
+
+interface StackWakePromptProps {
+  url: string
+}
+
+/**
+ * Grafana Cloud guards hibernating instances with a captcha, so k6 Studio can't
+ * wake them on its own. Send the user to their instance to click it instead.
+ */
+export function StackWakePrompt({ url }: StackWakePromptProps) {
+  const handleOpen = () => window.studio.browser.openExternalLink(url)
+
+  return (
+    <Flex direction="column" align="center" gap="3">
+      <Text size="2" color="gray">
+        Your Grafana instance is hibernating. Open it in your browser to confirm
+        you&apos;re not a robot, then come back here.
+      </Text>
+      <Button size="3" onClick={handleOpen}>
+        <ExternalLinkIcon />
+        Open my instance
+      </Button>
+    </Flex>
+  )
+}

--- a/src/components/Assistant/StackWakePrompt.tsx
+++ b/src/components/Assistant/StackWakePrompt.tsx
@@ -5,10 +5,7 @@ interface StackWakePromptProps {
   url: string
 }
 
-/**
- * Grafana Cloud guards hibernating instances with a captcha, so k6 Studio can't
- * wake them on its own. Send the user to their instance to click it instead.
- */
+/** Only a browser can solve the captcha guarding a hibernating instance. */
 export function StackWakePrompt({ url }: StackWakePromptProps) {
   const handleOpen = () => window.studio.browser.openExternalLink(url)
 

--- a/src/handlers/ai/a2a/assistantAuth.ts
+++ b/src/handlers/ai/a2a/assistantAuth.ts
@@ -22,6 +22,7 @@ import {
   checkStackHealth,
   wakeStack,
   type StackHealthStatus,
+  type StackWakeResult,
 } from './stackHealth'
 import {
   clearAssistantTokens,
@@ -223,9 +224,12 @@ export function initialize() {
     }
   })
 
-  ipcMain.handle(AssistantAuthHandler.WakeStack, async (): Promise<void> => {
-    return wakeStack(await getCurrentStackUrl())
-  })
+  ipcMain.handle(
+    AssistantAuthHandler.WakeStack,
+    async (): Promise<StackWakeResult> => {
+      return wakeStack(await getCurrentStackUrl())
+    }
+  )
 
   ipcMain.handle(
     AssistantAuthHandler.CheckStackHealth,

--- a/src/handlers/ai/a2a/preload.ts
+++ b/src/handlers/ai/a2a/preload.ts
@@ -4,7 +4,7 @@ import { createListener } from '../../utils'
 import { AssistantAuthHandler } from '../types'
 
 import type { AssistantAuthResult, AssistantAuthStatus } from './assistantAuth'
-import type { StackHealthStatus } from './stackHealth'
+import type { StackHealthStatus, StackWakeResult } from './stackHealth'
 
 export function onAssistantVerificationCode(callback: (code: string) => void) {
   return createListener(AssistantAuthHandler.VerificationCode, callback)
@@ -31,7 +31,9 @@ export function assistantSignOut() {
 }
 
 export function assistantWakeStack() {
-  return ipcRenderer.invoke(AssistantAuthHandler.WakeStack) as Promise<void>
+  return ipcRenderer.invoke(
+    AssistantAuthHandler.WakeStack
+  ) as Promise<StackWakeResult>
 }
 
 export function assistantCheckStackHealth() {

--- a/src/handlers/ai/a2a/stackHealth.test.ts
+++ b/src/handlers/ai/a2a/stackHealth.test.ts
@@ -10,7 +10,7 @@ import {
 const mockFetch = vi.fn()
 const stackUrl = 'https://mystack.grafana.net'
 
-/** Body Grafana Cloud returns while a hibernating instance waits for the captcha. */
+/** What the gateway sends while a hibernating instance waits for the captcha. */
 const HIBERNATING_BODY = JSON.stringify({
   code: 'Loading',
   message: 'Click on the checkbox to continue loading your instance',

--- a/src/handlers/ai/a2a/stackHealth.test.ts
+++ b/src/handlers/ai/a2a/stackHealth.test.ts
@@ -10,7 +10,7 @@ import {
 const mockFetch = vi.fn()
 const stackUrl = 'https://mystack.grafana.net'
 
-/** What the gateway sends while a hibernating instance waits for the captcha. */
+/** The gateway sends this while an instance waits for the captcha. */
 const HIBERNATING_BODY = JSON.stringify({
   code: 'Loading',
   message: 'Click on the checkbox to continue loading your instance',

--- a/src/handlers/ai/a2a/stackHealth.test.ts
+++ b/src/handlers/ai/a2a/stackHealth.test.ts
@@ -4,10 +4,17 @@ import {
   checkStackHealth,
   wakeStack,
   type StackHealthStatus,
+  type StackWakeResult,
 } from './stackHealth'
 
 const mockFetch = vi.fn()
 const stackUrl = 'https://mystack.grafana.net'
+
+/** Body Grafana Cloud returns while a hibernating instance waits for the captcha. */
+const HIBERNATING_BODY = JSON.stringify({
+  code: 'Loading',
+  message: 'Click on the checkbox to continue loading your instance',
+})
 
 beforeEach(() => {
   mockFetch.mockClear()
@@ -36,10 +43,67 @@ describe('wakeStack', () => {
     )
   })
 
-  it('does not throw when the request fails', async () => {
+  it('returns "awake" when the stack serves the login page', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('<html>login</html>'),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'awake',
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "captcha-required" when the instance is hibernating', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(HIBERNATING_BODY),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'captcha-required',
+      url: stackUrl,
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "loading" for other gateway errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            code: 'NotFound',
+            message:
+              "We do not recognize the instance URL you're trying to reach.",
+          })
+        ),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'loading',
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "loading" when the error body is not JSON', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 502,
+      text: () => Promise.resolve('<html>Bad gateway</html>'),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'loading',
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "loading" when the request fails', async () => {
     mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'))
 
-    await expect(wakeStack(stackUrl)).resolves.toBeUndefined()
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'loading',
+    } satisfies StackWakeResult)
   })
 })
 
@@ -64,6 +128,17 @@ describe('checkStackHealth', () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 503,
+    })
+
+    const result = await checkStackHealth(stackUrl)
+
+    expect(result).toBe<StackHealthStatus>('loading')
+  })
+
+  it('returns "loading" when a hibernating instance 404s the health endpoint', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
     })
 
     const result = await checkStackHealth(stackUrl)

--- a/src/handlers/ai/a2a/stackHealth.test.ts
+++ b/src/handlers/ai/a2a/stackHealth.test.ts
@@ -67,16 +67,45 @@ describe('wakeStack', () => {
     } satisfies StackWakeResult)
   })
 
-  it('returns "loading" for other gateway errors', async () => {
+  it('returns "loading" when the instance is booting without a captcha', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
-      status: 404,
+      status: 503,
       text: () =>
         Promise.resolve(
           JSON.stringify({
-            code: 'NotFound',
-            message:
-              "We do not recognize the instance URL you're trying to reach.",
+            code: 'Loading',
+            message: 'Your instance is loading, and will be ready shortly.',
+          })
+        ),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'loading',
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "loading" for a maintenance response without a code', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve(JSON.stringify({ message: 'Maintenance' })),
+    })
+
+    await expect(wakeStack(stackUrl)).resolves.toEqual({
+      status: 'loading',
+    } satisfies StackWakeResult)
+  })
+
+  it('returns "loading" for other gateway states', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: () =>
+        Promise.resolve(
+          JSON.stringify({
+            code: 'Migrating',
+            message: 'Your instance is being migrated.',
           })
         ),
     })

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -34,8 +34,8 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000
  * The /api/health endpoint does not wake hibernating stacks on its own.
  * See: https://github.com/grafana/terraform-provider-grafana/blob/6d9acfb3939ef17e5cff4f144ff91ecec88c2d97/internal/resources/cloud/resource_cloud_stack.go#L704-L705
  *
- * Keep this one-shot. The gateway rate limits wake attempts per client IP and
- * forces its captcha once tripped. Poll checkStackHealth instead, it's exempt.
+ * Send this once. The gateway limits wake requests per client IP and shows its
+ * captcha when that limit is reached. Poll checkStackHealth, which is not limited.
  */
 export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   try {

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -22,9 +22,17 @@ const HealthResponseSchema = z.object({
  */
 const GatewayErrorSchema = z.object({
   code: z.string(),
+  message: z.string(),
 })
 
 const HIBERNATING_CODE = 'Loading'
+
+/**
+ * An instance that is booting on its own answers with the same status and code
+ * as one waiting for the captcha, so the message is the only thing telling them
+ * apart. Anything we don't recognise keeps the loading spinner.
+ */
+const CAPTCHA_MESSAGE = 'Click on the checkbox'
 
 const HEALTH_CHECK_TIMEOUT_MS = 5000
 
@@ -32,6 +40,10 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000
  * Sends a request to the login page to wake a hibernating Grafana Cloud stack.
  * The /api/health endpoint does not wake hibernating stacks on its own.
  * See: https://github.com/grafana/terraform-provider-grafana/blob/6d9acfb3939ef17e5cff4f144ff91ecec88c2d97/internal/resources/cloud/resource_cloud_stack.go#L704-L705
+ *
+ * Keep this a one-shot request. The gateway rate limits wake attempts per client
+ * IP and forces its captcha once tripped, so polling here would create the very
+ * captcha we're detecting. Poll checkStackHealth instead, which is exempt.
  */
 export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   try {
@@ -48,7 +60,7 @@ export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
       return { status: 'awake' }
     }
 
-    if (isHibernating(body)) {
+    if (needsCaptcha(body)) {
       return { status: 'captcha-required', url: stackUrl }
     }
 
@@ -59,11 +71,11 @@ export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   }
 }
 
-function isHibernating(body: string): boolean {
+function needsCaptcha(body: string): boolean {
   try {
-    const { code } = GatewayErrorSchema.parse(JSON.parse(body))
+    const { code, message } = GatewayErrorSchema.parse(JSON.parse(body))
 
-    return code === HIBERNATING_CODE
+    return code === HIBERNATING_CODE && message.includes(CAPTCHA_MESSAGE)
   } catch {
     return false
   }

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -15,8 +15,9 @@ const HealthResponseSchema = z.object({
 })
 
 /**
- * Grafana Cloud's gateway rejects requests to a hibernating instance with this
- * payload. A browser gets the same status as an HTML page holding a reCAPTCHA
+ * Shape of every error the Grafana Cloud gateway returns for an instance it
+ * won't serve yet. A hibernating one waiting for its captcha is the case we act
+ * on: a browser gets the same response as an HTML page holding a reCAPTCHA
  * checkbox, and the instance only boots once someone clicks it, so we point the
  * user at their instance instead of polling forever.
  */
@@ -30,7 +31,7 @@ const HIBERNATING_CODE = 'Loading'
 /**
  * An instance that is booting on its own answers with the same status and code
  * as one waiting for the captcha, so the message is the only thing telling them
- * apart. Anything we don't recognise keeps the loading spinner.
+ * apart. Anything we don't recognize keeps the loading spinner.
  */
 const CAPTCHA_MESSAGE = 'Click on the checkbox'
 

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -16,7 +16,7 @@ const HealthResponseSchema = z.object({
   database: z.string(),
 })
 
-/** Error the Grafana Cloud gateway returns for an instance it won't serve yet. */
+/** The Grafana Cloud gateway sends this error when the instance is not available. */
 const GatewayErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
@@ -40,7 +40,7 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000
 export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   try {
     const response = await fetch(`${stackUrl}/login?disableAutoLogin=true`, {
-      // Get the gateway's JSON error, not its captcha page
+      // Ask for JSON so the gateway does not send its captcha page
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
     })

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -1,6 +1,8 @@
 import log from 'electron-log/main'
 import { z } from 'zod'
 
+import { parseJsonAsSchema } from '@/utils/json'
+
 import { LOG_PREFIX } from './constants'
 
 export type StackHealthStatus = 'ready' | 'loading'
@@ -73,13 +75,13 @@ export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
 }
 
 function needsCaptcha(body: string): boolean {
-  try {
-    const { code, message } = GatewayErrorSchema.parse(JSON.parse(body))
+  const parsed = parseJsonAsSchema(body, GatewayErrorSchema)
 
-    return code === HIBERNATING_CODE && message.includes(CAPTCHA_MESSAGE)
-  } catch {
-    return false
-  }
+  return (
+    parsed.success &&
+    parsed.data.code === HIBERNATING_CODE &&
+    parsed.data.message.includes(CAPTCHA_MESSAGE)
+  )
 }
 
 export async function checkStackHealth(

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -5,9 +5,26 @@ import { LOG_PREFIX } from './constants'
 
 export type StackHealthStatus = 'ready' | 'loading'
 
+export type StackWakeResult =
+  | { status: 'awake' }
+  | { status: 'loading' }
+  | { status: 'captcha-required'; url: string }
+
 const HealthResponseSchema = z.object({
   database: z.string(),
 })
+
+/**
+ * Grafana Cloud's gateway rejects requests to a hibernating instance with this
+ * payload. A browser gets the same status as an HTML page holding a reCAPTCHA
+ * checkbox, and the instance only boots once someone clicks it, so we point the
+ * user at their instance instead of polling forever.
+ */
+const GatewayErrorSchema = z.object({
+  code: z.string(),
+})
+
+const HIBERNATING_CODE = 'Loading'
 
 const HEALTH_CHECK_TIMEOUT_MS = 5000
 
@@ -16,16 +33,39 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000
  * The /api/health endpoint does not wake hibernating stacks on its own.
  * See: https://github.com/grafana/terraform-provider-grafana/blob/6d9acfb3939ef17e5cff4f144ff91ecec88c2d97/internal/resources/cloud/resource_cloud_stack.go#L704-L705
  */
-export async function wakeStack(stackUrl: string): Promise<void> {
+export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   try {
     const response = await fetch(`${stackUrl}/login?disableAutoLogin=true`, {
+      // Ask for the gateway's JSON error instead of its captcha page
+      headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
     })
 
     // Consume body to release the connection
-    await response.text()
+    const body = await response.text()
+
+    if (response.ok) {
+      return { status: 'awake' }
+    }
+
+    if (isHibernating(body)) {
+      return { status: 'captcha-required', url: stackUrl }
+    }
+
+    return { status: 'loading' }
   } catch (error) {
     log.debug(LOG_PREFIX, 'Wake request failed:', error)
+    return { status: 'loading' }
+  }
+}
+
+function isHibernating(body: string): boolean {
+  try {
+    const { code } = GatewayErrorSchema.parse(JSON.parse(body))
+
+    return code === HIBERNATING_CODE
+  } catch {
+    return false
   }
 }
 

--- a/src/handlers/ai/a2a/stackHealth.ts
+++ b/src/handlers/ai/a2a/stackHealth.ts
@@ -16,13 +16,7 @@ const HealthResponseSchema = z.object({
   database: z.string(),
 })
 
-/**
- * Shape of every error the Grafana Cloud gateway returns for an instance it
- * won't serve yet. A hibernating one waiting for its captcha is the case we act
- * on: a browser gets the same response as an HTML page holding a reCAPTCHA
- * checkbox, and the instance only boots once someone clicks it, so we point the
- * user at their instance instead of polling forever.
- */
+/** Error the Grafana Cloud gateway returns for an instance it won't serve yet. */
 const GatewayErrorSchema = z.object({
   code: z.string(),
   message: z.string(),
@@ -30,11 +24,7 @@ const GatewayErrorSchema = z.object({
 
 const HIBERNATING_CODE = 'Loading'
 
-/**
- * An instance that is booting on its own answers with the same status and code
- * as one waiting for the captcha, so the message is the only thing telling them
- * apart. Anything we don't recognize keeps the loading spinner.
- */
+/** An instance booting on its own sends the same code, so match the message. */
 const CAPTCHA_MESSAGE = 'Click on the checkbox'
 
 const HEALTH_CHECK_TIMEOUT_MS = 5000
@@ -44,14 +34,13 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000
  * The /api/health endpoint does not wake hibernating stacks on its own.
  * See: https://github.com/grafana/terraform-provider-grafana/blob/6d9acfb3939ef17e5cff4f144ff91ecec88c2d97/internal/resources/cloud/resource_cloud_stack.go#L704-L705
  *
- * Keep this a one-shot request. The gateway rate limits wake attempts per client
- * IP and forces its captcha once tripped, so polling here would create the very
- * captcha we're detecting. Poll checkStackHealth instead, which is exempt.
+ * Keep this one-shot. The gateway rate limits wake attempts per client IP and
+ * forces its captcha once tripped. Poll checkStackHealth instead, it's exempt.
  */
 export async function wakeStack(stackUrl: string): Promise<StackWakeResult> {
   try {
     const response = await fetch(`${stackUrl}/login?disableAutoLogin=true`, {
-      // Ask for the gateway's JSON error instead of its captcha page
+      // Get the gateway's JSON error, not its captcha page
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
     })

--- a/src/hooks/useStackHealth.test.tsx
+++ b/src/hooks/useStackHealth.test.tsx
@@ -95,6 +95,24 @@ describe('useStackHealth', () => {
     })
   })
 
+  it('wakes the stack again when reopened after it hibernated', async () => {
+    checkStackHealthMock.mockResolvedValue('loading')
+    const wrapper = createWrapper()
+
+    const { unmount } = renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(wakeStackMock).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(wakeStackMock).toHaveBeenCalledTimes(2)
+    })
+  })
+
   it('does not call wake when disabled', () => {
     renderHook(() => useStackHealth(false), {
       wrapper: createWrapper(),

--- a/src/hooks/useStackHealth.test.tsx
+++ b/src/hooks/useStackHealth.test.tsx
@@ -3,12 +3,17 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { type PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { StackHealthStatus } from '@/handlers/ai/a2a/stackHealth'
+import type {
+  StackHealthStatus,
+  StackWakeResult,
+} from '@/handlers/ai/a2a/stackHealth'
 
 import { useStackHealth } from './useStackHealth'
 
 const checkStackHealthMock = vi.fn<() => Promise<StackHealthStatus>>()
-const wakeStackMock = vi.fn<() => Promise<void>>()
+const wakeStackMock = vi.fn<() => Promise<StackWakeResult>>()
+
+const stackUrl = 'https://mystack.grafana.net'
 
 function createWrapper() {
   const client = new QueryClient({
@@ -22,6 +27,7 @@ function createWrapper() {
 describe('useStackHealth', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    wakeStackMock.mockResolvedValue({ status: 'awake' })
     vi.stubGlobal('studio', {
       ai: {
         assistantCheckStackHealth: checkStackHealthMock,
@@ -95,5 +101,54 @@ describe('useStackHealth', () => {
     })
 
     expect(wakeStackMock).not.toHaveBeenCalled()
+  })
+
+  it('exposes the stack url when the instance waits for a captcha', async () => {
+    checkStackHealthMock.mockResolvedValue('loading')
+    wakeStackMock.mockResolvedValue({
+      status: 'captcha-required',
+      url: stackUrl,
+    })
+
+    const { result } = renderHook(() => useStackHealth(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.captchaUrl).toBe(stackUrl)
+    })
+  })
+
+  it('does not expose a captcha url once the stack is ready', async () => {
+    checkStackHealthMock.mockResolvedValue('ready')
+    wakeStackMock.mockResolvedValue({
+      status: 'captcha-required',
+      url: stackUrl,
+    })
+
+    const { result } = renderHook(() => useStackHealth(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isStackReady).toBe(true)
+    })
+
+    expect(result.current.captchaUrl).toBeNull()
+  })
+
+  it('does not expose a captcha url while the stack is only booting', async () => {
+    checkStackHealthMock.mockResolvedValue('loading')
+    wakeStackMock.mockResolvedValue({ status: 'loading' })
+
+    const { result } = renderHook(() => useStackHealth(true), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isStackReady).toBe(false)
+    })
+
+    expect(result.current.captchaUrl).toBeNull()
   })
 })

--- a/src/hooks/useStackHealth.test.tsx
+++ b/src/hooks/useStackHealth.test.tsx
@@ -15,6 +15,14 @@ const wakeStackMock = vi.fn<() => Promise<StackWakeResult>>()
 
 const stackUrl = 'https://mystack.grafana.net'
 
+const authStatusMock = vi.fn(() => ({
+  data: { authenticated: true, stackId: '1', stackName: 'my-stack' },
+}))
+
+vi.mock('@/hooks/useAssistantAuth', () => ({
+  useAssistantAuthStatus: () => authStatusMock(),
+}))
+
 function createWrapper() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -192,5 +200,62 @@ describe('useStackHealth', () => {
     })
 
     expect(result.current.captchaUrl).toBeNull()
+  })
+
+  it('holds the throttle across an unmount longer than the cache default', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    checkStackHealthMock.mockResolvedValue('loading')
+    const wrapper = createWrapper()
+
+    const { unmount } = renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(wakeStackMock).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    // Past react-query's 5 minute gcTime, but well inside the wake throttle.
+    // advanceTimersByTime also runs the pending cache-eviction timer.
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000)
+    renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(checkStackHealthMock).toHaveBeenCalled()
+    })
+
+    expect(wakeStackMock).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
+  })
+
+  it('wakes the newly selected stack instead of reusing the old answer', async () => {
+    checkStackHealthMock.mockResolvedValue('loading')
+    wakeStackMock.mockResolvedValue({
+      status: 'captcha-required',
+      url: stackUrl,
+    })
+    const wrapper = createWrapper()
+
+    const { unmount, result } = renderHook(() => useStackHealth(true), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(result.current.captchaUrl).toBe(stackUrl)
+    })
+
+    unmount()
+    authStatusMock.mockReturnValue({
+      data: { authenticated: true, stackId: '2', stackName: 'other-stack' },
+    })
+    wakeStackMock.mockResolvedValue({ status: 'awake' })
+
+    const second = renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(wakeStackMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(second.result.current.captchaUrl).toBeNull()
   })
 })

--- a/src/hooks/useStackHealth.test.tsx
+++ b/src/hooks/useStackHealth.test.tsx
@@ -95,7 +95,7 @@ describe('useStackHealth', () => {
     })
   })
 
-  it('wakes the stack again when reopened after it hibernated', async () => {
+  it('does not wake the stack again when reopened right away', async () => {
     checkStackHealthMock.mockResolvedValue('loading')
     const wrapper = createWrapper()
 
@@ -106,11 +106,35 @@ describe('useStackHealth', () => {
     })
 
     unmount()
+    const { result } = renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.isStackReady).toBe(false)
+    })
+
+    expect(wakeStackMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('wakes the stack again when reopened after the throttle window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    checkStackHealthMock.mockResolvedValue('loading')
+    const wrapper = createWrapper()
+
+    const { unmount } = renderHook(() => useStackHealth(true), { wrapper })
+
+    await waitFor(() => {
+      expect(wakeStackMock).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    vi.setSystemTime(Date.now() + 16 * 60 * 1000)
     renderHook(() => useStackHealth(true), { wrapper })
 
     await waitFor(() => {
       expect(wakeStackMock).toHaveBeenCalledTimes(2)
     })
+
+    vi.useRealTimers()
   })
 
   it('does not call wake when disabled', () => {

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -4,13 +4,21 @@ const QUERY_KEY = ['assistant-stack-health'] as const
 const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
 const POLL_INTERVAL_MS = 3000
 
+/**
+ * Grafana Cloud rate limits wake attempts per client IP, and forces its captcha
+ * on an instance that would otherwise have woken on its own once tripped. Reuse
+ * the last answer for roughly that window so reopening the gate a few times
+ * doesn't create the captcha we're trying to report.
+ */
+const WAKE_THROTTLE_MS = 15 * 60 * 1000
+
 export function useStackHealth(enabled: boolean) {
-  // Wakes the stack once per mount, and reports whether Grafana Cloud is
-  // waiting for someone to solve its captcha before the instance boots.
   const wake = useQuery({
     queryKey: WAKE_QUERY_KEY,
     queryFn: () => window.studio.ai.assistantWakeStack(),
     networkMode: 'always',
+    staleTime: WAKE_THROTTLE_MS,
+    refetchOnReconnect: false,
     enabled,
   })
 

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -5,11 +5,12 @@ const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
 const POLL_INTERVAL_MS = 3000
 
 export function useStackHealth(enabled: boolean) {
+  // Wakes the stack once per mount, and reports whether Grafana Cloud is
+  // waiting for someone to solve its captcha before the instance boots.
   const wake = useQuery({
     queryKey: WAKE_QUERY_KEY,
     queryFn: () => window.studio.ai.assistantWakeStack(),
     networkMode: 'always',
-    staleTime: Infinity,
     enabled,
   })
 

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -1,17 +1,19 @@
 import { useQuery } from '@tanstack/react-query'
-import { useEffect } from 'react'
 
 const QUERY_KEY = ['assistant-stack-health'] as const
+const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
 const POLL_INTERVAL_MS = 3000
 
 export function useStackHealth(enabled: boolean) {
-  useEffect(() => {
-    if (enabled) {
-      void window.studio.ai.assistantWakeStack()
-    }
-  }, [enabled])
+  const wake = useQuery({
+    queryKey: WAKE_QUERY_KEY,
+    queryFn: () => window.studio.ai.assistantWakeStack(),
+    networkMode: 'always',
+    staleTime: Infinity,
+    enabled,
+  })
 
-  const query = useQuery({
+  const health = useQuery({
     queryKey: QUERY_KEY,
     queryFn: () => window.studio.ai.assistantCheckStackHealth(),
     networkMode: 'always',
@@ -20,7 +22,11 @@ export function useStackHealth(enabled: boolean) {
     enabled,
   })
 
-  return {
-    isStackReady: !enabled || query.data === 'ready',
-  }
+  const isStackReady = !enabled || health.data === 'ready'
+  const captchaUrl =
+    !isStackReady && wake.data?.status === 'captcha-required'
+      ? wake.data.url
+      : null
+
+  return { isStackReady, captchaUrl }
 }

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -5,10 +5,8 @@ const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
 const POLL_INTERVAL_MS = 3000
 
 /**
- * Grafana Cloud rate limits wake attempts per client IP, and forces its captcha
- * on an instance that would otherwise have woken on its own once tripped. Reuse
- * the last answer for roughly that window so reopening the gate a few times
- * doesn't create the captcha we're trying to report.
+ * Grafana Cloud rate limits wake attempts per client IP and forces its captcha
+ * once tripped, so reopening the gate reuses the last answer for that window.
  */
 const WAKE_THROTTLE_MS = 15 * 60 * 1000
 

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
-const QUERY_KEY = ['assistant-stack-health'] as const
-const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
+import { useAssistantAuthStatus } from '@/hooks/useAssistantAuth'
+
 const POLL_INTERVAL_MS = 3000
 
 /**
@@ -11,22 +11,30 @@ const POLL_INTERVAL_MS = 3000
 const WAKE_THROTTLE_MS = 15 * 60 * 1000
 
 export function useStackHealth(enabled: boolean) {
+  const { data: authStatus } = useAssistantAuthStatus()
+  // Both answers describe one instance, so a stack switch must not reuse them.
+  const stackId = authStatus?.stackId
+  const isEnabled = enabled && !!stackId
+
   const wake = useQuery({
-    queryKey: WAKE_QUERY_KEY,
+    queryKey: ['assistant-stack-wake', stackId],
     queryFn: () => window.studio.ai.assistantWakeStack(),
     networkMode: 'always',
     staleTime: WAKE_THROTTLE_MS,
+    // Keeping the entry at least as long as the throttle, or it is evicted
+    // after the default five minutes and the next open wakes the stack again.
+    gcTime: WAKE_THROTTLE_MS,
     refetchOnReconnect: false,
-    enabled,
+    enabled: isEnabled,
   })
 
   const health = useQuery({
-    queryKey: QUERY_KEY,
+    queryKey: ['assistant-stack-health', stackId],
     queryFn: () => window.studio.ai.assistantCheckStackHealth(),
     networkMode: 'always',
     refetchInterval: (result) =>
       result.state.data === 'ready' ? false : POLL_INTERVAL_MS,
-    enabled,
+    enabled: isEnabled,
   })
 
   const isStackReady = !enabled || health.data === 'ready'

--- a/src/hooks/useStackHealth.ts
+++ b/src/hooks/useStackHealth.ts
@@ -5,8 +5,8 @@ const WAKE_QUERY_KEY = ['assistant-stack-wake'] as const
 const POLL_INTERVAL_MS = 3000
 
 /**
- * Grafana Cloud rate limits wake attempts per client IP and forces its captcha
- * once tripped, so reopening the gate reuses the last answer for that window.
+ * Grafana Cloud limits wake requests per client IP and shows its captcha when
+ * that limit is reached, so reopening the gate uses the last answer for this long.
  */
 const WAKE_THROTTLE_MS = 15 * 60 * 1000
 

--- a/src/views/Generator/AutoCorrelation/IntroductionMessage.tsx
+++ b/src/views/Generator/AutoCorrelation/IntroductionMessage.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from 'react'
 
 import grotIllustration from '@/assets/grot-magic.svg'
+import { StackWakePrompt } from '@/components/Assistant/StackWakePrompt'
 import { GrafanaIcon } from '@/components/icons/GrafanaIcon'
 import { GrafanaCloudSignIn } from '@/components/Profile/GrafanaCloudSignIn'
 import {
@@ -121,7 +122,7 @@ function AssistantAuthStatus({
   onStart,
   connectError,
 }: AssistantAuthStatusProps) {
-  const { isStackReady } = useStackHealth(isAuthenticated)
+  const { isStackReady, captchaUrl } = useStackHealth(isAuthenticated)
 
   if (isLoading) {
     return (
@@ -162,6 +163,10 @@ function AssistantAuthStatus({
         )}
       </>
     )
+  }
+
+  if (captchaUrl) {
+    return <StackWakePrompt url={captchaUrl} />
   }
 
   if (!isStackReady) {


### PR DESCRIPTION
## Description

A hibernating Grafana Cloud stack showed "Your Grafana instance is loading..." forever. Grafana Cloud puts a reCAPTCHA in front of a hibernating instance and only boots it once someone clicks the checkbox, and the readiness poll could not tell: `/api/health` is excluded from that gate, so a hibernating stack answers `404 {"code":"NotFound"}` there, indistinguishable from a broken one.

The wake request already hits a gated path, so it now classifies the gateway's reply and the assistant gate offers "Open my instance" when a human is needed. It stays one request per gate open, because the gateway rate limits wake attempts per client IP and forces its captcha once tripped.

## How to Test

I don't have a reliable way to trigger captcha, I've tested it with my own stack that was locked behind captcha and verified it "waiting for you instance" clears up after you solve captcha in browser. 


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)
