### PR TITLE
ci: Bump create-github-app-token to v0.3.1

### DIFF
--- a/.github/workflows/create-patch-branch.yml
+++ b/.github/workflows/create-patch-branch.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: k6-release-app
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: k6-release-app
 


### PR DESCRIPTION
## Description

The Release Please workflow has been failing at startup since August 19 because the grafana Actions policy now denies the pinned `create-github-app-token` SHA:

```
The action grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b
is not allowed in grafana/k6-studio because all actions must not match any of the patterns: [...]
```

The deny list enumerates older SHAs of that action, so v0.2.3 is blocked and v0.3.1 is allowed. Failures show up as `startup_failure` with no jobs and no logs, which is why nothing pointed at the pin. `create-patch-branch.yml` carries the same pin and would fail the same way when dispatched.

## How to Test

Merging this is the test. The next push to `main` should produce a Release Please run that reaches the `release-please` job instead of failing at startup.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- Failing run: <https://github.com/grafana/k6-studio/actions/runs/32851957234>
