### PR TITLE
fix: surface settings fallback warnings

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,5 +1,10 @@
 import { Box, IconButton } from '@radix-ui/themes'
-import { CircleCheckIcon, CircleXIcon, XIcon } from 'lucide-react'
+import {
+  CircleCheckIcon,
+  CircleXIcon,
+  TriangleAlertIcon,
+  XIcon,
+} from 'lucide-react'
 
 import { useToastStore } from '@/store/ui/useToast'
 import { Toast as ToastProps } from '@/types/toast'
@@ -68,6 +73,8 @@ function StatusIcon({ status }: { status: ToastProps['status'] }) {
       return <CircleCheckIcon color="var(--green-11)" />
     case 'error':
       return <CircleXIcon color="var(--red-11)" />
+    case 'warning':
+      return <TriangleAlertIcon color="var(--amber-11)" />
     case 'default':
       return null
     default:

--- a/src/components/Toast/Toasts.test.tsx
+++ b/src/components/Toast/Toasts.test.tsx
@@ -8,9 +8,11 @@ import { Toasts } from './Toasts'
 
 describe('Toasts', () => {
   let emitToast: (toast: AddToastPayload) => void
+  const getFallbackWarning = vi.fn<() => Promise<string | null>>()
 
   beforeEach(() => {
     vi.useFakeTimers()
+    getFallbackWarning.mockResolvedValue(null)
     vi.stubGlobal('studio', {
       ui: {
         onToast: (callback: (toast: AddToastPayload) => void) => {
@@ -18,6 +20,7 @@ describe('Toasts', () => {
           return vi.fn()
         },
       },
+      settings: { getFallbackWarning },
     })
   })
 
@@ -65,5 +68,24 @@ describe('Toasts', () => {
     fireEvent.click(screen.getByRole('button', { hidden: true }))
 
     expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows a warning when startup fell back to default settings', async () => {
+    getFallbackWarning.mockResolvedValue(
+      'The settings file could not be parsed.'
+    )
+
+    render(<Toasts />)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('Settings reset to defaults')).toBeDefined()
+    expect(
+      screen.getByText(
+        'The settings file could not be parsed. Review your settings before continuing.'
+      )
+    ).toBeDefined()
   })
 })

--- a/src/components/Toast/Toasts.tsx
+++ b/src/components/Toast/Toasts.tsx
@@ -17,6 +17,18 @@ export function Toasts() {
     })
   }, [addToast])
 
+  useEffect(() => {
+    void window.studio.settings.getFallbackWarning().then((warning) => {
+      if (warning) {
+        addToast({
+          title: 'Settings reset to defaults',
+          description: `${warning} Review your settings before continuing.`,
+          status: 'warning',
+        })
+      }
+    })
+  }, [addToast])
+
   return (
     <RadixToast.Provider key={providerResetKey} swipeDirection="right">
       {toasts.map((toast) => (

--- a/src/handlers/settings/index.ts
+++ b/src/handlers/settings/index.ts
@@ -20,6 +20,12 @@ export function initialize() {
     return await getSettings()
   })
 
+  ipcMain.handle(SettingsHandler.GetFallbackWarning, () => {
+    const warning = k6StudioState.settingsFallbackWarning
+    k6StudioState.settingsFallbackWarning = null
+    return warning
+  })
+
   ipcMain.handle(SettingsHandler.Save, async (event, data: AppSettings) => {
     console.info(`${SettingsHandler.Save} event received`)
 

--- a/src/handlers/settings/preload.ts
+++ b/src/handlers/settings/preload.ts
@@ -8,6 +8,12 @@ export function getSettings() {
   return ipcRenderer.invoke(SettingsHandler.Get) as Promise<AppSettings>
 }
 
+export function getFallbackWarning() {
+  return ipcRenderer.invoke(SettingsHandler.GetFallbackWarning) as Promise<
+    string | null
+  >
+}
+
 export function saveSettings(settings: AppSettings) {
   return ipcRenderer.invoke(
     SettingsHandler.Save,

--- a/src/handlers/settings/types.ts
+++ b/src/handlers/settings/types.ts
@@ -1,5 +1,6 @@
 export enum SettingsHandler {
   Get = 'settings:get',
+  GetFallbackWarning = 'settings:get-fallback-warning',
   Save = 'settings:save',
   SelectBrowserExecutable = 'settings:select-browser-executable',
   SelectUpstreamCertificate = 'settings:select-upstream-certificate',

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import {
   launchProxyAndAttachEmitter,
   stopProxyProcess,
 } from './main/proxy'
-import { getSettings, initSettings } from './main/settings'
+import { initSettings } from './main/settings'
 import { closeWatcher, configureWatcher } from './main/watcher'
 import { showWindow, trackWindowState } from './main/window'
 import { configureSystemProxy } from './services/http'
@@ -176,8 +176,9 @@ const createWindow = async () => {
 
 app.whenReady().then(
   async () => {
-    await initSettings()
-    k6StudioState.appSettings = await getSettings()
+    const { settings, fallbackWarning } = await initSettings()
+    k6StudioState.appSettings = settings
+    k6StudioState.settingsFallbackWarning = fallbackWarning ?? null
     nativeTheme.themeSource = k6StudioState.appSettings.appearance.theme
 
     await setupProjectStructure()

--- a/src/main/k6StudioState.ts
+++ b/src/main/k6StudioState.ts
@@ -14,6 +14,7 @@ export type k6StudioState = {
   proxyStatus: ProxyStatus
   proxyEmitter: eventEmitter
   appSettings: AppSettings
+  settingsFallbackWarning: string | null
   currentProxyProcess: ProxyProcess | null
   wasProxyStoppedByClient: boolean
   proxyRetryCount: number
@@ -32,6 +33,7 @@ export function initialize() {
       ready: [void]
     }>(),
     appSettings: defaultSettings,
+    settingsFallbackWarning: null,
     currentProxyProcess: null,
     wasProxyStoppedByClient: false,
     proxyRetryCount: 0,

--- a/src/main/settings.test.ts
+++ b/src/main/settings.test.ts
@@ -75,10 +75,25 @@ describe('initSettings disk migration', () => {
   it('writes defaults when the file is missing', async () => {
     const { initSettings, defaultSettings } = await import('./settings')
 
-    await initSettings()
+    const result = await initSettings()
 
     expect(existsSync(filePath)).toBe(true)
     expect(readSettingsFile(filePath)).toEqual(defaultSettings)
+    expect(result).toEqual({ settings: defaultSettings })
+  })
+
+  it('returns fresh defaults for each fallback initialization', async () => {
+    const { initSettings, defaultSettings } = await import('./settings')
+
+    const first = await initSettings()
+    first.settings.proxy.port = 1234
+    rmSync(filePath)
+
+    const second = await initSettings()
+
+    expect(second.settings.proxy.port).toBe(defaultSettings.proxy.port)
+    expect(first.settings).not.toBe(second.settings)
+    expect(first.settings.proxy).not.toBe(second.settings.proxy)
   })
 
   it('migrates a v4 file on disk and strips the encrypted api key', async () => {
@@ -117,5 +132,34 @@ describe('initSettings disk migration', () => {
     await initSettings()
 
     expect(readFileSync(filePath, 'utf-8')).toBe(originalRaw)
+  })
+
+  it('reports when malformed JSON is replaced with defaults', async () => {
+    writeFileSync(filePath, '{invalid json')
+
+    const { initSettings, defaultSettings } = await import('./settings')
+    const result = await initSettings()
+
+    expect(result).toEqual({
+      settings: defaultSettings,
+      fallbackWarning: 'The settings file could not be parsed.',
+    })
+    expect(readSettingsFile(filePath)).toEqual(defaultSettings)
+  })
+
+  it('reports when invalid settings are replaced with defaults', async () => {
+    writeFileSync(
+      filePath,
+      JSON.stringify({ ...baseSharedSettings, version: '5.0', proxy: null })
+    )
+
+    const { initSettings, defaultSettings } = await import('./settings')
+    const result = await initSettings()
+
+    expect(result).toEqual({
+      settings: defaultSettings,
+      fallbackWarning: 'The settings file contained invalid values.',
+    })
+    expect(readSettingsFile(filePath)).toEqual(defaultSettings)
   })
 })

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -14,19 +14,23 @@ import { getExecutableNameFromPlist } from '../utils/plist'
 
 import { stopProxyProcess, launchProxyAndAttachEmitter } from './proxy'
 
-export const defaultSettings: AppSettings = {
-  version: '5.0',
-  proxy: {
-    mode: 'regular',
-    port: 6000,
-    automaticallyFindPort: true,
-    sslInsecure: false,
-  },
-  recorder: { detectBrowserPath: true },
-  windowState: { width: 1200, height: 800, x: 0, y: 0, isMaximized: true },
-  telemetry: { usageReport: true, errorReport: true },
-  appearance: { theme: 'system' },
+export function createDefaultSettings(): AppSettings {
+  return {
+    version: '5.0',
+    proxy: {
+      mode: 'regular',
+      port: 6000,
+      automaticallyFindPort: true,
+      sslInsecure: false,
+    },
+    recorder: { detectBrowserPath: true },
+    windowState: { width: 1200, height: 800, x: 0, y: 0, isMaximized: true },
+    telemetry: { usageReport: true, errorReport: true },
+    appearance: { theme: 'system' },
+  }
 }
+
+export const defaultSettings = createDefaultSettings()
 
 const fileName =
   process.env.NODE_ENV === 'development'
@@ -34,21 +38,33 @@ const fileName =
     : 'k6-studio.json'
 const filePath = path.join(app.getPath('userData'), fileName)
 
+export interface SettingsInitializationResult {
+  settings: AppSettings
+  fallbackWarning?: string
+}
+
 /**
  * If an older-version settings file exists on disk, migrate it and
  * rewrite it so deprecated fields (e.g. the OpenAI api key from v4)
  * don't sit on the user's machine after they upgrade.
  */
-export async function initSettings() {
+export async function initSettings(): Promise<SettingsInitializationResult> {
   if (!(await exists(filePath))) {
-    return writeFile(filePath, JSON.stringify(defaultSettings))
+    const settings = createDefaultSettings()
+    await writeFile(filePath, JSON.stringify(settings))
+    return { settings }
   }
 
   const raw = await readFile(filePath, 'utf-8')
   const rawParsed = safeJsonParse<{ version?: unknown }>(raw)
 
   if (!rawParsed) {
-    return writeFile(filePath, JSON.stringify(defaultSettings))
+    const settings = createDefaultSettings()
+    await writeFile(filePath, JSON.stringify(settings))
+    return {
+      settings,
+      fallbackWarning: 'The settings file could not be parsed.',
+    }
   }
 
   const result = AppSettingsSchema.safeParse({
@@ -61,12 +77,19 @@ export async function initSettings() {
       'Failed to migrate settings file, resetting to defaults',
       result.error
     )
-    return writeFile(filePath, JSON.stringify(defaultSettings))
+    const settings = createDefaultSettings()
+    await writeFile(filePath, JSON.stringify(settings))
+    return {
+      settings,
+      fallbackWarning: 'The settings file contained invalid values.',
+    }
   }
 
   if (rawParsed.version !== result.data.version) {
     await writeFile(filePath, JSON.stringify(result.data))
   }
+
+  return { settings: result.data }
 }
 
 /**
@@ -87,7 +110,7 @@ export async function getSettings() {
     log.error('Failed to parse settings file', error)
     // if the file is invalid during runtime,
     // return a valid settings object so the app can keep running
-    return defaultSettings
+    return createDefaultSettings()
   }
 }
 

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -1,7 +1,7 @@
 export interface Toast {
   id: string
   open: boolean
-  status: 'default' | 'success' | 'error'
+  status: 'default' | 'success' | 'warning' | 'error'
   title: string
   description?: string
   action?: React.ReactNode


### PR DESCRIPTION
## What this changes

- report when persisted settings cannot be loaded and defaults are used
- surface the fallback as a one-shot warning toast in the renderer
- keep the existing startup behavior and add coverage for both successful and failed settings loads

## Testing

- focused Vitest suite (8 tests)
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `git diff --check`

All project commands were run in Docker.

Fixes #567