### PR TITLE
fix: clarify HTTP search scope tooltip

### DIFF
--- a/src/components/WebLogView/Filter.test.tsx
+++ b/src/components/WebLogView/Filter.test.tsx
@@ -1,0 +1,44 @@
+import { Theme } from '@radix-ui/themes'
+import { render, screen } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Filter } from './Filter'
+
+function renderFilter(filterAllData: boolean, setFilterAllData = vi.fn()) {
+  render(
+    <Theme>
+      <Filter
+        filter=""
+        setFilter={vi.fn()}
+        filterAllData={filterAllData}
+        setFilterAllData={setFilterAllData}
+      />
+    </Theme>
+  )
+}
+
+describe('Filter', () => {
+  it('describes enabling full request-data search', () => {
+    renderFilter(false)
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Include headers, cookies, payload, and response data in search',
+      })
+    ).toBeTruthy()
+  })
+
+  it('describes returning to request-summary search', async () => {
+    const setFilterAllData = vi.fn()
+    renderFilter(true, setFilterAllData)
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Search URL, method, and status code only',
+      })
+    )
+
+    expect(setFilterAllData).toHaveBeenCalledWith(false)
+  })
+})

--- a/src/components/WebLogView/Filter.tsx
+++ b/src/components/WebLogView/Filter.tsx
@@ -19,6 +19,9 @@ export function Filter({
   setFilterAllData: (filterAllData: boolean) => void
 }) {
   const inputRef = useRef<SearchFieldHandle>(null)
+  const filterScopeAction = filterAllData
+    ? 'Search URL, method, and status code only'
+    : 'Include headers, cookies, payload, and response data in search'
 
   useKeyPressEvent('Escape', () => {
     inputRef.current?.clear()
@@ -47,8 +50,9 @@ export function Filter({
       onChange={setFilter}
     >
       <TextField.Slot px="1">
-        <Tooltip content="Search all request data, including headers, cookies, payload, and response data">
+        <Tooltip content={filterScopeAction}>
           <IconButton
+            aria-label={filterScopeAction}
             variant={filterAllData ? 'solid' : 'ghost'}
             size="1"
             onClick={() => setFilterAllData(!filterAllData)}


### PR DESCRIPTION
## What this changes

- make the HTTP search tooltip describe the active search scope
- keep tooltip and accessible-label text in sync as the search mode changes
- add regression coverage for both supported scopes

## Testing

- focused Vitest suite (2 tests)
- `npm run typecheck`
- `npm run format:check`
- `npm run lint`
- `git diff --check`

All project commands were run in Docker.

Fixes #476